### PR TITLE
Support multiple image uploads in single request

### DIFF
--- a/core/handler/media.go
+++ b/core/handler/media.go
@@ -80,6 +80,7 @@ const (
 	ErrTooLargeImage          warpnet.WarpError = "image is too large"
 	ErrInvalidBase64Signature warpnet.WarpError = "invalid base64 image data"
 	ErrEmptyImageKey          warpnet.WarpError = "empty image key"
+	ErrNoImagesProvided       warpnet.WarpError = "at least one image must be provided"
 	ErrInvalidEXIF            warpnet.WarpError = "invalid exif type: not a segment list"
 )
 
@@ -109,6 +110,17 @@ func StreamUploadImageHandler(
 		}
 
 		images := [4]string{ev.Image1, ev.Image2, ev.Image3, ev.Image4}
+
+		hasImages := false
+		for _, img := range images {
+			if img != "" {
+				hasImages = true
+				break
+			}
+		}
+		if !hasImages {
+			return nil, ErrNoImagesProvided
+		}
 
 		nodeInfo := info.NodeInfo()
 		ownerUser, err := userRepo.Get(nodeInfo.OwnerId)

--- a/core/handler/media.go
+++ b/core/handler/media.go
@@ -108,35 +108,7 @@ func StreamUploadImageHandler(
 			return nil, err
 		}
 
-		parts := strings.SplitN(ev.File, ",", 2) //nolint:mnd
-		if len(parts) != 2 {                     //nolint:mnd
-			return nil, ErrInvalidBase64Signature
-		}
-
-		imgBytes, err := base64.StdEncoding.DecodeString(parts[1])
-		if err != nil {
-			return nil, fmt.Errorf("upload: base64 decoding: %w", err)
-		}
-
-		if size := binary.Size(imgBytes); size > units.MiB*50 {
-			return nil, ErrTooLargeImage
-		}
-
-		img, _, err := image.Decode(bytes.NewReader(imgBytes))
-		if errors.Is(err, image.ErrFormat) {
-			return nil, warpnet.WarpError(
-				"invalid image format: PNG, JPG, JPEG, GIF are only allowed", // TODO add more types
-			)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("upload: image decoding: %w", err)
-		}
-
-		var imageBuf bytes.Buffer
-		err = jpeg.Encode(&imageBuf, img, &jpeg.Options{Quality: 100}) //nolint:mnd
-		if err != nil {
-			return nil, fmt.Errorf("upload: JPEG encoding: %w", err)
-		}
+		images := [4]string{ev.Image1, ev.Image2, ev.Image3, ev.Image4}
 
 		nodeInfo := info.NodeInfo()
 		ownerUser, err := userRepo.Get(nodeInfo.OwnerId)
@@ -160,20 +132,77 @@ func StreamUploadImageHandler(
 			return nil, fmt.Errorf("upload: AES encrypting: %w", err)
 		}
 
-		amendedImg, err := amendExifMetadata(imageBuf.Bytes(), encryptedMeta)
-		if err != nil {
-			return nil, fmt.Errorf("upload: meta data amending: %w", err)
+		var keys [4]string
+		for i, file := range images {
+			if file == "" {
+				continue
+			}
+
+			key, err := processAndStoreImage(file, encryptedMeta, ownerUser.Id, mediaRepo)
+			if err != nil {
+				return nil, fmt.Errorf("upload: image%d: %w", i+1, err)
+			}
+			keys[i] = key
 		}
 
-		encoded := base64.StdEncoding.EncodeToString(amendedImg)
-
-		key, err := mediaRepo.SetImage(ownerUser.Id, database.Base64Image(imagePrefix+encoded))
-		if err != nil {
-			return nil, fmt.Errorf("upload: storing media: %w", err)
-		}
-
-		return event.UploadImageResponse{Key: string(key)}, nil
+		return event.UploadImageResponse{
+			Key1: keys[0],
+			Key2: keys[1],
+			Key3: keys[2],
+			Key4: keys[3],
+		}, nil
 	}
+}
+
+func processAndStoreImage(
+	file string,
+	encryptedMeta []byte,
+	userId string,
+	mediaRepo MediaStorer,
+) (string, error) {
+	parts := strings.SplitN(file, ",", 2) //nolint:mnd
+	if len(parts) != 2 {                  //nolint:mnd
+		return "", ErrInvalidBase64Signature
+	}
+
+	imgBytes, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("base64 decoding: %w", err)
+	}
+
+	if size := binary.Size(imgBytes); size > units.MiB*50 {
+		return "", ErrTooLargeImage
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(imgBytes))
+	if errors.Is(err, image.ErrFormat) {
+		return "", warpnet.WarpError(
+			"invalid image format: PNG, JPG, JPEG, GIF are only allowed", // TODO add more types
+		)
+	}
+	if err != nil {
+		return "", fmt.Errorf("image decoding: %w", err)
+	}
+
+	var imageBuf bytes.Buffer
+	err = jpeg.Encode(&imageBuf, img, &jpeg.Options{Quality: 100}) //nolint:mnd
+	if err != nil {
+		return "", fmt.Errorf("JPEG encoding: %w", err)
+	}
+
+	amendedImg, err := amendExifMetadata(imageBuf.Bytes(), encryptedMeta)
+	if err != nil {
+		return "", fmt.Errorf("meta data amending: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(amendedImg)
+
+	key, err := mediaRepo.SetImage(userId, database.Base64Image(imagePrefix+encoded))
+	if err != nil {
+		return "", fmt.Errorf("storing media: %w", err)
+	}
+
+	return string(key), nil
 }
 
 type MediaStreamer interface {

--- a/core/handler/media_test.go
+++ b/core/handler/media_test.go
@@ -75,6 +75,15 @@ func TestUploadMultipleImages_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUploadImage_NoImages(t *testing.T) {
+	ev := event.UploadImageEvent{}
+	bt, err := json.Marshal(ev)
+	assert.NoError(t, err)
+
+	_, err = StreamUploadImageHandler(n{}, m{}, u{})(bt, s{})
+	assert.ErrorIs(t, err, ErrNoImagesProvided)
+}
+
 const (
 	testMetaTag   = imageDescriptionTag
 	testMetaValue = "test meta value"

--- a/core/handler/media_test.go
+++ b/core/handler/media_test.go
@@ -52,7 +52,21 @@ const testImagePNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYA
 
 func TestUploadImage_Success(t *testing.T) {
 	ev := event.UploadImageEvent{
-		File: testImagePNG,
+		Image1: testImagePNG,
+	}
+	bt, err := json.Marshal(ev)
+	assert.NoError(t, err)
+
+	_, err = StreamUploadImageHandler(n{}, m{}, u{})(bt, s{})
+	assert.NoError(t, err)
+}
+
+func TestUploadMultipleImages_Success(t *testing.T) {
+	ev := event.UploadImageEvent{
+		Image1: testImagePNG,
+		Image2: testImagePNG,
+		Image3: testImagePNG,
+		Image4: testImagePNG,
 	}
 	bt, err := json.Marshal(ev)
 	assert.NoError(t, err)

--- a/event/event.go
+++ b/event/event.go
@@ -357,11 +357,17 @@ type UsersResponse struct {
 
 type UploadImageEvent struct {
 	// Image mime type + "," + base64
-	File string `json:"file"`
+	Image1 string `json:"image1"`
+	Image2 string `json:"image2"`
+	Image3 string `json:"image3"`
+	Image4 string `json:"image4"`
 }
 
 type UploadImageResponse struct {
-	Key string `json:"key"`
+	Key1 string `json:"key1"`
+	Key2 string `json:"key2"`
+	Key3 string `json:"key3"`
+	Key4 string `json:"key4"`
 }
 
 type GetImageEvent struct {


### PR DESCRIPTION
## Summary
Refactored the image upload handler to support uploading up to 4 images in a single request, replacing the previous single-image-per-request model.

## Key Changes
- **Event schema update**: Modified `UploadImageEvent` to accept 4 image fields (`Image1`, `Image2`, `Image3`, `Image4`) instead of a single `File` field
- **Response schema update**: Changed `UploadImageResponse` to return 4 keys (`Key1`, `Key2`, `Key3`, `Key4`) corresponding to the uploaded images
- **Handler refactoring**: Extracted image processing logic into a new `processAndStoreImage()` helper function to reduce code duplication and improve maintainability
- **Loop-based processing**: Updated `StreamUploadImageHandler` to iterate through all 4 image fields and process non-empty ones, collecting their storage keys
- **Test coverage**: Added new test case `TestUploadMultipleImages_Success` to verify uploading all 4 images simultaneously, while maintaining existing single-image test

## Implementation Details
- The `processAndStoreImage()` function encapsulates all image processing steps: base64 decoding, validation, JPEG encoding, EXIF metadata amendment, and storage
- Empty image fields are skipped during processing (checked with `if file == ""`), allowing clients to upload 1-4 images as needed
- Error messages now include the image index for better debugging when multiple uploads fail
- All existing image validation logic (size limits, format checks, encryption) is preserved

https://claude.ai/code/session_015qriPBaGGsLLZmKSNqRws1