### PR TITLE
Mark TLS camouflage handshake failures as temporary to keep swarm listener alive

### DIFF
--- a/security/tls-camouflage.go
+++ b/security/tls-camouflage.go
@@ -67,6 +67,17 @@ var (
 	errALPNMismatch    = errors.New("dpi: ALPN protocol not in allowed set")
 )
 
+// temporaryHandshakeError marks handshake failures as temporary so listener
+// accept loops treat probe failures as transient and keep running.
+type temporaryHandshakeError struct {
+	err error
+}
+
+func (e *temporaryHandshakeError) Error() string   { return e.err.Error() }
+func (e *temporaryHandshakeError) Unwrap() error   { return e.err }
+func (e *temporaryHandshakeError) Temporary() bool { return true }
+func (e *temporaryHandshakeError) Timeout() bool   { return false }
+
 // CamouflageConfig holds the TLS camouflage settings shared by all
 // connections created by a single SpoofTransport instance.
 type CamouflageConfig struct {
@@ -156,7 +167,9 @@ func NewCamouflageConn(conn manet.Conn, isClient bool, cfg *CamouflageConfig) (*
 		tlsConn, err = serverTLSHandshake(conn, cfg)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errHandshakeFailed, err.Error())
+		return nil, &temporaryHandshakeError{
+			err: fmt.Errorf("%w: %s", errHandshakeFailed, err.Error()),
+		}
 	}
 
 	// Clear the handshake deadline so subsequent I/O is not constrained.

--- a/security/tls-camouflage_test.go
+++ b/security/tls-camouflage_test.go
@@ -27,6 +27,7 @@ package security
 import (
 	"bytes"
 	"crypto/x509"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -373,6 +374,24 @@ func TestCamouflageConn_EmptyWrite(t *testing.T) {
 	assert.Equal(t, 0, n)
 
 	_ = clientConn.Close()
+}
+
+func TestCamouflageConn_HandshakeErrorIsTemporary(t *testing.T) {
+	clientRaw, serverRaw := newPipePair()
+	_ = clientRaw.Close() // force server handshake to fail immediately
+
+	cfg := testCamoConfig("example.com")
+	cfg.handshakeTimeout = 50 * time.Millisecond
+
+	_, err := NewCamouflageConn(serverRaw, false, cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errHandshakeFailed)
+
+	var netErr interface {
+		Temporary() bool
+	}
+	require.True(t, errors.As(err, &netErr))
+	assert.True(t, netErr.Temporary())
 }
 
 type recordingConn struct {


### PR DESCRIPTION
### Motivation
- libp2p accept loops treated TLS-camouflage handshake failures as permanent errors, causing the swarm listener to be closed on DPI/probe failures. 
- The intent is to make probe/handshake failures transient so the listener remains active while rejecting the single connection.

### Description
- Add `temporaryHandshakeError` type that implements `Temporary()` and `Timeout()` and wraps the original error via `Unwrap()` so sentinel matching still works. 
- Return `*temporaryHandshakeError` from `NewCamouflageConn` when client/server TLS handshake fails while preserving the `errHandshakeFailed` sentinel. 
- Add unit test `TestCamouflageConn_HandshakeErrorIsTemporary` which asserts the handshake error is `errHandshakeFailed` and implements `Temporary()`.

### Testing
- Ran `go test ./security -run 'TestCamouflageConn_HandshakeErrorIsTemporary|TestCamouflageConn_HandshakeAndDataRoundTrip'` and the tests passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64dc8c50c832ca5c583c95b3d7b42)