### PR TITLE
Evict stale/offline peers from SOCKS5 balancer to stop reconnect loops

### DIFF
--- a/cmd/node/bootstrap/socks5/balancer.go
+++ b/cmd/node/bootstrap/socks5/balancer.go
@@ -136,11 +136,13 @@ func (b *socksBalancer) detectSuitablePeers(ctx context.Context) {
 		}
 		if p2pNet.Connectedness(peer) == network.NotConnected {
 			if err := b.streamer.SimpleConnect(p2pStore.PeerInfo(peer)); err != nil {
+				b.removePeer(peer)
 				continue
 			}
 		}
 		protocols, _ := p2pStore.GetProtocols(peer)
 		if len(protocols) == 0 || !slices.Contains(protocols, DefaultStreamProtocol) {
+			b.removePeer(peer)
 			continue
 		}
 
@@ -184,6 +186,16 @@ func (b *socksBalancer) detectSuitablePeers(ctx context.Context) {
 		b.peersWithLatency[peer.String()] = key
 
 		b.mx.Unlock()
+	}
+}
+
+func (b *socksBalancer) removePeer(peer warpnet.WarpPeerID) {
+	b.mx.Lock()
+	defer b.mx.Unlock()
+
+	if prevKey, ok := b.peersWithLatency[peer.String()]; ok {
+		b.exitList.Remove(prevKey)
+		delete(b.peersWithLatency, peer.String())
 	}
 }
 


### PR DESCRIPTION
### Motivation
- The SOCKS5 balancer could keep stale or offline peers in its latency-indexed `exitList`, causing the server to route to unavailable peers and trigger frequent reconnects (observed as "blinking" connections).

### Description
- Remove peers from the `exitList` when `SimpleConnect` fails or when a peer no longer advertises the `DefaultStreamProtocol` by calling a new helper `removePeer` in `cmd/node/bootstrap/socks5/balancer.go`.
- Add `removePeer(peer warpnet.WarpPeerID)` to centralize safe removal under the balancer lock and to clear `peersWithLatency` consistently.
- No changes to public APIs; change is internal to the balancer's peer detection logic in `detectSuitablePeers`.

### Testing
- Ran `go test ./cmd/node/bootstrap/socks5` and it completed (package has no test files). 
- Ran `go test ./cmd/node/bootstrap/node` and it completed (package has no test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65efb6bd4832cbe36a98dce6edfde)