### PR TITLE
Add comprehensive test coverage for handler package

### DIFF
--- a/core/handler/chat_test.go
+++ b/core/handler/chat_test.go
@@ -471,7 +471,7 @@ func TestMessageReadDeleteHandlers(t *testing.T) {
 		hEmpty := StreamGetMessagesHandler(stubChatRepo{getChatFn: repo.getChatFn, listMessagesFn: func(chatId string, limit *uint64, cursor *string) ([]domain.ChatMessage, string, error) {
 			return nil, "next", nil
 		}}, auth)
-		resp, err := hEmpty(marshal(t, event.GetAllMessagesEvent{ChatId: chatID}), nil)
+		resp, err := hEmpty(marshal(t, event.GetAllMessagesEvent{ChatId: chatID, OwnerId: owner}), nil)
 		if err != nil || len(resp.(event.ChatMessagesResponse).Messages) != 0 {
 			t.Fatalf("unexpected empty response: %#v err=%v", resp, err)
 		}
@@ -479,7 +479,7 @@ func TestMessageReadDeleteHandlers(t *testing.T) {
 		hFilled := StreamGetMessagesHandler(stubChatRepo{getChatFn: repo.getChatFn, listMessagesFn: func(chatId string, limit *uint64, cursor *string) ([]domain.ChatMessage, string, error) {
 			return []domain.ChatMessage{{Id: msgID, ChatId: chatID}}, "", nil
 		}}, auth)
-		resp, err = hFilled(marshal(t, event.GetAllMessagesEvent{ChatId: chatID}), nil)
+		resp, err = hFilled(marshal(t, event.GetAllMessagesEvent{ChatId: chatID, OwnerId: owner}), nil)
 		if err != nil || len(resp.(event.ChatMessagesResponse).Messages) != 1 {
 			t.Fatalf("unexpected filled response: %#v err=%v", resp, err)
 		}

--- a/core/handler/following.go
+++ b/core/handler/following.go
@@ -208,7 +208,7 @@ func StreamUnfollowHandler(
 		isMeUnfollowed := ownerUserId == ev.FollowingId
 
 		if isMeUnfollowed {
-			err = followRepo.Unfollow(ev.FollowingId, ev.FollowerId)
+			err = followRepo.Unfollow(ev.FollowerId, ev.FollowingId)
 			if err != nil {
 				return nil, err
 			}

--- a/core/handler/following_test.go
+++ b/core/handler/following_test.go
@@ -1,0 +1,678 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+)
+
+type stubFollowRepo struct {
+	followFn        func(from, to string) error
+	unfollowFn      func(from, to string) error
+	getFollowersFn  func(userId string, limit *uint64, cursor *string) ([]string, string, error)
+	getFollowingsFn func(userId string, limit *uint64, cursor *string) ([]string, string, error)
+	isFollowingFn   func(ownerId, otherUserId string) bool
+	isFollowerFn    func(ownerId, otherUserId string) bool
+}
+
+func (s stubFollowRepo) Follow(from, to string) error {
+	if s.followFn != nil {
+		return s.followFn(from, to)
+	}
+	return nil
+}
+func (s stubFollowRepo) Unfollow(from, to string) error {
+	if s.unfollowFn != nil {
+		return s.unfollowFn(from, to)
+	}
+	return nil
+}
+func (s stubFollowRepo) GetFollowers(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.getFollowersFn != nil {
+		return s.getFollowersFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubFollowRepo) GetFollowings(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.getFollowingsFn != nil {
+		return s.getFollowingsFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubFollowRepo) IsFollowing(ownerId, otherUserId string) bool {
+	if s.isFollowingFn != nil {
+		return s.isFollowingFn(ownerId, otherUserId)
+	}
+	return false
+}
+func (s stubFollowRepo) IsFollower(ownerId, otherUserId string) bool {
+	if s.isFollowerFn != nil {
+		return s.isFollowerFn(ownerId, otherUserId)
+	}
+	return false
+}
+
+type stubFollowBroadcaster struct {
+	subscribeFn   func(userId string) error
+	unsubscribeFn func(userId string) error
+}
+
+func (s stubFollowBroadcaster) SubscribeUserUpdate(userId string) error {
+	if s.subscribeFn != nil {
+		return s.subscribeFn(userId)
+	}
+	return nil
+}
+func (s stubFollowBroadcaster) UnsubscribeUserUpdate(userId string) error {
+	if s.unsubscribeFn != nil {
+		return s.unsubscribeFn(userId)
+	}
+	return nil
+}
+
+type stubFollowUserRepo struct {
+	getFn    func(userId string) (domain.User, error)
+	listFn   func(limit *uint64, cursor *string) ([]domain.User, string, error)
+	createFn func(user domain.User) (domain.User, error)
+}
+
+func (s stubFollowUserRepo) Get(userId string) (domain.User, error) {
+	if s.getFn != nil {
+		return s.getFn(userId)
+	}
+	return domain.User{Id: userId, NodeId: "node-2"}, nil
+}
+func (s stubFollowUserRepo) List(limit *uint64, cursor *string) ([]domain.User, string, error) {
+	if s.listFn != nil {
+		return s.listFn(limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubFollowUserRepo) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
+}
+
+type stubFollowStreamer struct {
+	genericStreamFn func(nodeId string, path stream.WarpRoute, data any) ([]byte, error)
+}
+
+func (s stubFollowStreamer) GenericStream(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+	if s.genericStreamFn != nil {
+		return s.genericStreamFn(nodeId, path, data)
+	}
+	return nil, nil
+}
+
+func TestStreamFollowHandler(t *testing.T) {
+	owner := "owner-1"
+	following := "following-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty follower id", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowingId: following}), nil)
+		if err == nil || err.Error() != "empty follower or following id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty following id", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner}), nil)
+		if err == nil || err.Error() != "empty follower or following id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("self follow returns accepted", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("someone follows me", func(t *testing.T) {
+		var capturedFrom, capturedTo string
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{followFn: func(from, to string) error {
+			capturedFrom = from
+			capturedTo = to
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: following, FollowingId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if capturedFrom != following || capturedTo != owner {
+			t.Fatalf("expected Follow(%q, %q), got Follow(%q, %q)", following, owner, capturedFrom, capturedTo)
+		}
+	})
+
+	t.Run("someone follows me - already followed", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{followFn: func(from, to string) error {
+			return database.ErrAlreadyFollowed
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: following, FollowingId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("someone follows me - repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{followFn: func(from, to string) error {
+			return repoErr
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: following, FollowingId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("I follow someone - user not found", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("I follow someone - user repo error", func(t *testing.T) {
+		repoErr := errors.New("user fetch error")
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, repoErr
+		}}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected user repo error: %v", err)
+		}
+	})
+
+	t.Run("I follow someone - node offline", func(t *testing.T) {
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, warpnet.ErrUserIsOffline) {
+			t.Fatalf("expected user offline error: %v", err)
+		}
+	})
+
+	t.Run("I follow someone - stream error", func(t *testing.T) {
+		streamErr := errors.New("stream broken")
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, streamErr
+		}})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("expected stream error: %v", err)
+		}
+	})
+
+	t.Run("I follow someone - already followed locally", func(t *testing.T) {
+		acceptedResp, _ := json.Marshal(event.Accepted)
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{followFn: func(from, to string) error {
+			return database.ErrAlreadyFollowed
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return acceptedResp, nil
+		}})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("I follow someone - success", func(t *testing.T) {
+		subscribed := false
+		acceptedResp, _ := json.Marshal(event.Accepted)
+		h := StreamFollowHandler(stubFollowBroadcaster{subscribeFn: func(userId string) error {
+			subscribed = true
+			return nil
+		}}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return acceptedResp, nil
+		}})
+		resp, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !subscribed {
+			t.Fatal("expected broadcaster subscribe to be called")
+		}
+	})
+
+	t.Run("I follow someone - subscribe error", func(t *testing.T) {
+		subErr := errors.New("subscribe failed")
+		acceptedResp, _ := json.Marshal(event.Accepted)
+		h := StreamFollowHandler(stubFollowBroadcaster{subscribeFn: func(userId string) error {
+			return subErr
+		}}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return acceptedResp, nil
+		}})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, subErr) {
+			t.Fatalf("expected subscribe error: %v", err)
+		}
+	})
+
+	t.Run("I follow someone - remote error response", func(t *testing.T) {
+		errResp, _ := json.Marshal(event.ResponseError{Code: 500, Message: "remote error"})
+		h := StreamFollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return errResp, nil
+		}})
+		_, err := h(marshal(t, event.NewFollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err == nil {
+			t.Fatal("expected error from remote error response")
+		}
+	})
+}
+
+func TestStreamUnfollowHandler(t *testing.T) {
+	owner := "owner-1"
+	following := "following-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty ids", func(t *testing.T) {
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner}), nil)
+		if err == nil || err.Error() != "empty follower or following id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("self unfollow returns accepted", func(t *testing.T) {
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner, FollowingId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("someone unfollows me - correct arg order", func(t *testing.T) {
+		var capturedFrom, capturedTo string
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{unfollowFn: func(from, to string) error {
+			capturedFrom = from
+			capturedTo = to
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: following, FollowingId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		// Verify the correct argument order: follower unfollows me
+		if capturedFrom != following || capturedTo != owner {
+			t.Fatalf("expected Unfollow(%q, %q), got Unfollow(%q, %q)", following, owner, capturedFrom, capturedTo)
+		}
+	})
+
+	t.Run("someone unfollows me - repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{unfollowFn: func(from, to string) error {
+			return repoErr
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: following, FollowingId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("I unfollow someone - user not found", func(t *testing.T) {
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+
+	t.Run("I unfollow someone - node offline", func(t *testing.T) {
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}})
+		_, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, warpnet.ErrUserIsOffline) {
+			t.Fatalf("expected user offline error: %v", err)
+		}
+	})
+
+	t.Run("I unfollow someone - stream error", func(t *testing.T) {
+		streamErr := errors.New("stream broken")
+		h := StreamUnfollowHandler(stubFollowBroadcaster{}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, streamErr
+		}})
+		_, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("expected stream error: %v", err)
+		}
+	})
+
+	t.Run("I unfollow someone - success", func(t *testing.T) {
+		unsubscribed := false
+		acceptedResp, _ := json.Marshal(event.Accepted)
+		h := StreamUnfollowHandler(stubFollowBroadcaster{unsubscribeFn: func(userId string) error {
+			unsubscribed = true
+			return nil
+		}}, stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return acceptedResp, nil
+		}})
+		resp, err := h(marshal(t, event.NewUnfollowEvent{FollowerId: owner, FollowingId: following}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !unsubscribed {
+			t.Fatal("expected broadcaster unsubscribe to be called")
+		}
+	})
+}
+
+func TestStreamIsFollowingHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamIsFollowingHandler(stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamIsFollowingHandler(stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		_, err := h(marshal(t, event.GetIsFollowingEvent{}), nil)
+		if err == nil || err.Error() != "empty following id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("is following true", func(t *testing.T) {
+		h := StreamIsFollowingHandler(stubFollowRepo{isFollowingFn: func(ownerId, otherUserId string) bool {
+			return true
+		}}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h(marshal(t, event.GetIsFollowingEvent{UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !resp.(event.IsFollowingResponse).IsFollowing {
+			t.Fatal("expected is following true")
+		}
+	})
+
+	t.Run("is following false", func(t *testing.T) {
+		h := StreamIsFollowingHandler(stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h(marshal(t, event.GetIsFollowingEvent{UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.IsFollowingResponse).IsFollowing {
+			t.Fatal("expected is following false")
+		}
+	})
+}
+
+func TestStreamIsFollowerHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamIsFollowerHandler(stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamIsFollowerHandler(stubFollowRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		_, err := h(marshal(t, event.GetIsFollowingEvent{}), nil)
+		if err == nil || err.Error() != "empty follower id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("is follower true", func(t *testing.T) {
+		h := StreamIsFollowerHandler(stubFollowRepo{isFollowerFn: func(ownerId, otherUserId string) bool {
+			return true
+		}}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h(marshal(t, event.GetIsFollowingEvent{UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !resp.(event.IsFollowerResponse).IsFollower {
+			t.Fatal("expected is follower true")
+		}
+	})
+}
+
+func TestStreamGetFollowersHandler(t *testing.T) {
+	owner := "owner-1"
+	other := "other-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.GetFollowersEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("own followers", func(t *testing.T) {
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{getFollowersFn: func(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+			return []string{"f1", "f2"}, "end", nil
+		}}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.GetFollowersEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.FollowersResponse)
+		if len(r.Followers) != 2 {
+			t.Fatalf("expected 2 followers, got %d", len(r.Followers))
+		}
+	})
+
+	t.Run("own followers - repo error", func(t *testing.T) {
+		repoErr := errors.New("db failed")
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{getFollowersFn: func(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+			return nil, "", repoErr
+		}}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.GetFollowersEvent{UserId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("other user followers - user not found fallback", func(t *testing.T) {
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubFollowRepo{getFollowersFn: func(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+			return []string{"cached-f1"}, "end", nil
+		}}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.GetFollowersEvent{UserId: other}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.FollowersResponse)
+		if len(r.Followers) != 1 || r.Followers[0] != "cached-f1" {
+			t.Fatalf("expected cached followers fallback: %v", r)
+		}
+	})
+
+	t.Run("other user followers - node offline fallback", func(t *testing.T) {
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}})
+		resp, err := h(marshal(t, event.GetFollowersEvent{UserId: other}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		_ = resp.(event.FollowersResponse)
+	})
+
+	t.Run("other user followers - stream error", func(t *testing.T) {
+		streamErr := errors.New("stream broken")
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, streamErr
+		}})
+		_, err := h(marshal(t, event.GetFollowersEvent{UserId: other}), nil)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("expected stream error: %v", err)
+		}
+	})
+
+	t.Run("other user followers - remote success", func(t *testing.T) {
+		remoteResp, _ := json.Marshal(event.FollowersResponse{
+			Cursor:      "end",
+			FollowingId: other,
+			Followers:   []string{"remote-f1", "remote-f2"},
+		})
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return remoteResp, nil
+		}})
+		resp, err := h(marshal(t, event.GetFollowersEvent{UserId: other}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.FollowersResponse)
+		if len(r.Followers) != 2 {
+			t.Fatalf("expected 2 remote followers, got %d", len(r.Followers))
+		}
+	})
+
+	t.Run("other user followers - remote error response", func(t *testing.T) {
+		errResp, _ := json.Marshal(event.ResponseError{Code: 500, Message: "remote error"})
+		h := StreamGetFollowersHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return errResp, nil
+		}})
+		_, err := h(marshal(t, event.GetFollowersEvent{UserId: other}), nil)
+		if err == nil {
+			t.Fatal("expected error from remote error response")
+		}
+	})
+}
+
+func TestStreamGetFollowingsHandler(t *testing.T) {
+	owner := "owner-1"
+	other := "other-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetFollowingsHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetFollowingsHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{})
+		_, err := h(marshal(t, event.GetFollowingsEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("own followings", func(t *testing.T) {
+		h := StreamGetFollowingsHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{getFollowingsFn: func(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+			return []string{"f1"}, "end", nil
+		}}, stubFollowStreamer{})
+		resp, err := h(marshal(t, event.GetFollowingsEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.FollowingsResponse)
+		if len(r.Followings) != 1 {
+			t.Fatalf("expected 1 following, got %d", len(r.Followings))
+		}
+	})
+
+	t.Run("other user followings - remote success", func(t *testing.T) {
+		remoteResp, _ := json.Marshal(event.FollowingsResponse{
+			Cursor:     "end",
+			FollowerId: other,
+			Followings: []string{"remote-f1"},
+		})
+		h := StreamGetFollowingsHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return remoteResp, nil
+		}})
+		resp, err := h(marshal(t, event.GetFollowingsEvent{UserId: other}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.FollowingsResponse)
+		if len(r.Followings) != 1 {
+			t.Fatalf("expected 1 remote following, got %d", len(r.Followings))
+		}
+	})
+
+	t.Run("other user followings - node offline fallback", func(t *testing.T) {
+		h := StreamGetFollowingsHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubFollowUserRepo{}, stubFollowRepo{}, stubFollowStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}})
+		resp, err := h(marshal(t, event.GetFollowingsEvent{UserId: other}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		_ = resp.(event.FollowingsResponse)
+	})
+}

--- a/core/handler/info_test.go
+++ b/core/handler/info_test.go
@@ -1,0 +1,90 @@
+//nolint:all
+package handler
+
+import (
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type stubNodeInformer struct {
+	info warpnet.NodeInfo
+}
+
+func (s stubNodeInformer) NodeInfo() warpnet.NodeInfo { return s.info }
+
+// stubInfoConn embeds the interface so we only need to implement methods actually called
+type stubInfoConn struct {
+	network.Conn
+	remotePeerID peer.ID
+	remoteAddr   ma.Multiaddr
+}
+
+func (c stubInfoConn) RemotePeer() peer.ID           { return c.remotePeerID }
+func (c stubInfoConn) RemoteMultiaddr() ma.Multiaddr { return c.remoteAddr }
+
+// stubInfoStream embeds the interface so we only need to implement Conn()
+type stubInfoStream struct {
+	network.Stream
+	conn stubInfoConn
+}
+
+func (s stubInfoStream) Conn() network.Conn { return s.conn }
+
+func TestStreamGetInfoHandler(t *testing.T) {
+	expectedInfo := warpnet.NodeInfo{
+		OwnerId: "owner-1",
+	}
+
+	t.Run("returns node info and calls discovery handler", func(t *testing.T) {
+		discoveryCalled := false
+		addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+		peerID, _ := peer.Decode("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+
+		stream := stubInfoStream{conn: stubInfoConn{
+			remotePeerID: peerID,
+			remoteAddr:   addr,
+		}}
+
+		h := StreamGetInfoHandler(stubNodeInformer{info: expectedInfo}, func(info warpnet.WarpAddrInfo) {
+			discoveryCalled = true
+			if info.ID != peerID {
+				t.Fatalf("expected peer ID %s, got %s", peerID, info.ID)
+			}
+		})
+		resp, err := h(nil, stream)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		info := resp.(warpnet.NodeInfo)
+		if info.OwnerId != "owner-1" {
+			t.Fatalf("expected owner-1, got: %s", info.OwnerId)
+		}
+		if !discoveryCalled {
+			t.Fatal("expected discovery handler to be called")
+		}
+	})
+
+	t.Run("nil discovery handler does not panic", func(t *testing.T) {
+		addr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+		peerID, _ := peer.Decode("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+
+		stream := stubInfoStream{conn: stubInfoConn{
+			remotePeerID: peerID,
+			remoteAddr:   addr,
+		}}
+
+		h := StreamGetInfoHandler(stubNodeInformer{info: expectedInfo}, nil)
+		resp, err := h(nil, stream)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		info := resp.(warpnet.NodeInfo)
+		if info.OwnerId != "owner-1" {
+			t.Fatalf("expected owner-1, got: %s", info.OwnerId)
+		}
+	})
+}

--- a/core/handler/moderation_test.go
+++ b/core/handler/moderation_test.go
@@ -1,0 +1,194 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+)
+
+type stubModerationNotifier struct {
+	addFn func(not domain.Notification) error
+}
+
+func (s stubModerationNotifier) Add(not domain.Notification) error {
+	if s.addFn != nil {
+		return s.addFn(not)
+	}
+	return nil
+}
+
+type stubModerationTweetUpdater struct {
+	updateFn func(tweet domain.Tweet) error
+}
+
+func (s stubModerationTweetUpdater) Update(tweet domain.Tweet) error {
+	if s.updateFn != nil {
+		return s.updateFn(tweet)
+	}
+	return nil
+}
+
+type stubModerationTimelineDeleter struct {
+	deleteFn func(userID, tweetID string) error
+}
+
+func (s stubModerationTimelineDeleter) DeleteTweetFromTimeline(userID, tweetID string) error {
+	if s.deleteFn != nil {
+		return s.deleteFn(userID, tweetID)
+	}
+	return nil
+}
+
+
+func TestStreamModerationResultHandler(t *testing.T) {
+	owner := "owner-1"
+	tweetId := "tweet-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamModerationResultHandler(stubModerationNotifier{}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		_, err := h([]byte("{"), s{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("tweet moderation - missing object id", func(t *testing.T) {
+		h := StreamModerationResultHandler(stubModerationNotifier{}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		_, err := h(marshal(t, event.ModerationResultEvent{Type: domain.ModerationTweetType, UserID: owner}), s{})
+		if !errors.Is(err, ErrNoObjectID) {
+			t.Fatalf("expected ErrNoObjectID, got: %v", err)
+		}
+	})
+
+	t.Run("tweet moderation - missing user id", func(t *testing.T) {
+		h := StreamModerationResultHandler(stubModerationNotifier{}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		_, err := h(marshal(t, event.ModerationResultEvent{Type: domain.ModerationTweetType, ObjectID: &tweetId}), s{})
+		if !errors.Is(err, ErrNoUserID) {
+			t.Fatalf("expected ErrNoUserID, got: %v", err)
+		}
+	})
+
+	t.Run("tweet moderation OK - no notification", func(t *testing.T) {
+		notified := false
+		h := StreamModerationResultHandler(stubModerationNotifier{addFn: func(not domain.Notification) error {
+			notified = true
+			return nil
+		}}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:     domain.ModerationTweetType,
+			ObjectID: &tweetId,
+			UserID:   owner,
+			Result:   domain.OK,
+		}), s{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if notified {
+			t.Fatal("should not notify on OK result")
+		}
+	})
+
+	t.Run("tweet moderation FAIL - adds notification for owner", func(t *testing.T) {
+		notified := false
+		reason := "inappropriate content"
+		h := StreamModerationResultHandler(stubModerationNotifier{addFn: func(not domain.Notification) error {
+			notified = true
+			if not.Type != domain.NotificationModerationType {
+				t.Fatalf("expected moderation type, got: %v", not.Type)
+			}
+			return nil
+		}}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:     domain.ModerationTweetType,
+			ObjectID: &tweetId,
+			UserID:   owner,
+			Result:   domain.FAIL,
+			Reason:   &reason,
+		}), s{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !notified {
+			t.Fatal("expected notification to be added")
+		}
+	})
+
+	t.Run("tweet moderation FAIL - not owner, no notification", func(t *testing.T) {
+		notified := false
+		h := StreamModerationResultHandler(stubModerationNotifier{addFn: func(not domain.Notification) error {
+			notified = true
+			return nil
+		}}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:     domain.ModerationTweetType,
+			ObjectID: &tweetId,
+			UserID:   "other-user",
+			Result:   domain.FAIL,
+		}), s{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if notified {
+			t.Fatal("should not notify for other user")
+		}
+	})
+
+	t.Run("unknown moderation type - returns accepted", func(t *testing.T) {
+		h := StreamModerationResultHandler(stubModerationNotifier{}, stubModerationTweetUpdater{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{})
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:   domain.ModerationObjectType(99),
+			UserID: owner,
+		}), s{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted for unknown type, got: %v", resp)
+		}
+	})
+
+	t.Run("tweet moderation - updates tweet and removes from timeline", func(t *testing.T) {
+		tweetUpdated := false
+		timelineDeleted := false
+		h := StreamModerationResultHandler(stubModerationNotifier{}, stubModerationTweetUpdater{updateFn: func(tweet domain.Tweet) error {
+			tweetUpdated = true
+			if tweet.Moderation == nil {
+				t.Fatal("expected moderation info")
+			}
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubModerationTimelineDeleter{deleteFn: func(userID, tweetID string) error {
+			timelineDeleted = true
+			return nil
+		}})
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:     domain.ModerationTweetType,
+			ObjectID: &tweetId,
+			UserID:   owner,
+			Result:   domain.OK,
+		}), s{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !tweetUpdated {
+			t.Fatal("expected tweet to be updated")
+		}
+		if !timelineDeleted {
+			t.Fatal("expected timeline entry to be deleted")
+		}
+	})
+}

--- a/core/handler/pair.go
+++ b/core/handler/pair.go
@@ -48,10 +48,7 @@ func StreamNodesPairingHandler(serverAuthInfo domain.AuthNodeInfo) warpnet.WarpH
 		}
 		isTokenMatch := serverAuthInfo.Identity.Token == clientInfo.Identity.Token
 		if !isTokenMatch {
-			log.Errorf(
-				"pair: token does not match server identity: %s != %s",
-				serverAuthInfo.Identity.Token, clientInfo.Identity.Token,
-			)
+			log.Errorf("pair: token does not match server identity")
 			return nil, warpnet.WarpError("token mismatch")
 		}
 		return event.Accepted, nil

--- a/core/handler/pair.go
+++ b/core/handler/pair.go
@@ -39,9 +39,12 @@ func StreamNodesPairingHandler(serverAuthInfo domain.AuthNodeInfo) warpnet.WarpH
 	return func(buf []byte, s warpnet.WarpStream) (any, error) {
 		// TODO: add devices storage
 		var clientInfo domain.AuthNodeInfo
-		if err := json.Unmarshal(buf, &clientInfo); err != nil || clientInfo.Identity.Token == "" {
+		if err := json.Unmarshal(buf, &clientInfo); err != nil {
 			log.Errorf("pair: unmarshaling from stream: %s %v", buf, err)
 			return nil, err
+		}
+		if clientInfo.Identity.Token == "" {
+			return nil, warpnet.WarpError("empty token")
 		}
 		isTokenMatch := serverAuthInfo.Identity.Token == clientInfo.Identity.Token
 		if !isTokenMatch {

--- a/core/handler/pair_test.go
+++ b/core/handler/pair_test.go
@@ -1,0 +1,66 @@
+//nolint:all
+package handler
+
+import (
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+)
+
+func TestStreamNodesPairingHandler(t *testing.T) {
+	serverToken := "secret-token"
+	serverAuth := domain.AuthNodeInfo{
+		Identity: domain.Identity{Token: serverToken},
+	}
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamNodesPairingHandler(serverAuth)
+		_, err := h([]byte("{invalid"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		h := StreamNodesPairingHandler(serverAuth)
+		// Use raw JSON to avoid peer.ID marshaling issues
+		_, err := h([]byte(`{"identity":{"token":""}}`), nil)
+		if err == nil {
+			t.Fatal("expected error for empty token")
+		}
+		if err.Error() != "empty token" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("token mismatch", func(t *testing.T) {
+		h := StreamNodesPairingHandler(serverAuth)
+		_, err := h([]byte(`{"identity":{"token":"wrong-token"}}`), nil)
+		if err == nil {
+			t.Fatal("expected error for token mismatch")
+		}
+		if err.Error() != "token mismatch" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("success - token match", func(t *testing.T) {
+		h := StreamNodesPairingHandler(serverAuth)
+		_, err := h([]byte(`{"identity":{"token":"secret-token"}}`), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("success - returns accepted", func(t *testing.T) {
+		h := StreamNodesPairingHandler(serverAuth)
+		resp, err := h([]byte(`{"identity":{"token":"secret-token"}}`), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+	})
+}

--- a/core/handler/reply.go
+++ b/core/handler/reply.go
@@ -188,14 +188,15 @@ func StreamGetReplyHandler(
 			return nil, err
 		}
 
-		var reply domain.Tweet
-		if err = json.Unmarshal(getTweetResp, &reply); err != nil {
+		var possibleError event.ResponseError
+		if _ = json.Unmarshal(getTweetResp, &possibleError); possibleError.Message != "" {
+			log.Errorf("unmarshal other get reply error response: %s", possibleError.Message)
 			return repo.GetReply(rootId, id)
 		}
 
-		var possibleError event.ResponseError
-		if _ = json.Unmarshal(getTweetResp, &possibleError); possibleError.Message != "" {
-			log.Errorf("unmarshal other unlike error response: %s", possibleError.Message)
+		var reply domain.Tweet
+		if err = json.Unmarshal(getTweetResp, &reply); err != nil {
+			return repo.GetReply(rootId, id)
 		}
 
 		return reply, nil

--- a/core/handler/stats_test.go
+++ b/core/handler/stats_test.go
@@ -27,7 +27,7 @@ type stubStatsPeerstore struct {
 	peers []peer.ID
 }
 
-func (s stubStatsPeerstore) Peers() peer.IDSlice { return s.peers }
+func (s stubStatsPeerstore) Peers() peer.IDSlice { return peer.IDSlice(s.peers) }
 
 // stubStatsNetwork embeds the full interface, overrides only Peers()
 type stubStatsNetwork struct {

--- a/core/handler/stats_test.go
+++ b/core/handler/stats_test.go
@@ -1,0 +1,110 @@
+//nolint:all
+package handler
+
+import (
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+)
+
+type stubStatsProvider struct {
+	stats map[string]string
+}
+
+func (s stubStatsProvider) Stats() map[string]string {
+	if s.stats != nil {
+		return s.stats
+	}
+	return map[string]string{}
+}
+
+// stubStatsPeerstore embeds the full interface, overrides only Peers()
+type stubStatsPeerstore struct {
+	peerstore.Peerstore
+	peers []peer.ID
+}
+
+func (s stubStatsPeerstore) Peers() peer.IDSlice { return s.peers }
+
+// stubStatsNetwork embeds the full interface, overrides only Peers()
+type stubStatsNetwork struct {
+	network.Network
+	peers []peer.ID
+}
+
+func (s stubStatsNetwork) Peers() []peer.ID { return s.peers }
+
+// stubStatsNode implements StatsNodeInformer
+type stubStatsNode struct {
+	info      warpnet.NodeInfo
+	peerStore stubStatsPeerstore
+	net       stubStatsNetwork
+}
+
+func (s stubStatsNode) NodeInfo() warpnet.NodeInfo         { return s.info }
+func (s stubStatsNode) Peerstore() warpnet.WarpPeerstore   { return s.peerStore }
+func (s stubStatsNode) Network() warpnet.WarpNetwork       { return s.net }
+
+func TestStreamGetStatsHandler(t *testing.T) {
+	t.Run("connected with peers", func(t *testing.T) {
+		pid, _ := peer.Decode("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
+		node := stubStatsNode{
+			info: warpnet.NodeInfo{
+				OwnerId:   "owner-1",
+				Addresses: []string{"/ip4/127.0.0.1/tcp/4001"},
+			},
+			peerStore: stubStatsPeerstore{peers: []peer.ID{pid}},
+			net:       stubStatsNetwork{peers: []peer.ID{pid}},
+		}
+		h := StreamGetStatsHandler(node, stubStatsProvider{stats: map[string]string{"keys": "100"}})
+		resp, err := h(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(warpnet.NodeStats)
+		if stats.UserId != "owner-1" {
+			t.Fatalf("expected user id owner-1, got: %s", stats.UserId)
+		}
+		if stats.NetworkState != "Connected" {
+			t.Fatalf("expected Connected, got: %s", stats.NetworkState)
+		}
+		if stats.PeersOnline != 1 {
+			t.Fatalf("expected 1 peer online, got: %d", stats.PeersOnline)
+		}
+		if stats.PeersStored != 1 {
+			t.Fatalf("expected 1 stored peer, got: %d", stats.PeersStored)
+		}
+		if stats.PublicAddresses != "/ip4/127.0.0.1/tcp/4001" {
+			t.Fatalf("unexpected addresses: %s", stats.PublicAddresses)
+		}
+		if stats.DatabaseStats["keys"] != "100" {
+			t.Fatalf("unexpected db stats: %v", stats.DatabaseStats)
+		}
+	})
+
+	t.Run("disconnected with no peers", func(t *testing.T) {
+		node := stubStatsNode{
+			info:      warpnet.NodeInfo{OwnerId: "owner-1"},
+			peerStore: stubStatsPeerstore{},
+			net:       stubStatsNetwork{},
+		}
+		h := StreamGetStatsHandler(node, stubStatsProvider{})
+		resp, err := h(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(warpnet.NodeStats)
+		if stats.NetworkState != "Disconnected" {
+			t.Fatalf("expected Disconnected, got: %s", stats.NetworkState)
+		}
+		if stats.PeersOnline != 0 {
+			t.Fatalf("expected 0 peers online, got: %d", stats.PeersOnline)
+		}
+		if stats.PublicAddresses != "Waiting..." {
+			t.Fatalf("expected 'Waiting...', got: %s", stats.PublicAddresses)
+		}
+	})
+}

--- a/core/handler/timeline_test.go
+++ b/core/handler/timeline_test.go
@@ -1,0 +1,111 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+)
+
+type stubTimelineFetcher struct {
+	getTimelineFn func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error)
+}
+
+func (s stubTimelineFetcher) GetTimeline(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+	if s.getTimelineFn != nil {
+		return s.getTimelineFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+
+func TestStreamTimelineHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamTimelineHandler(stubTimelineFetcher{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamTimelineHandler(stubTimelineFetcher{})
+		_, err := h(marshal(t, event.GetTimelineEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty timeline returns empty array not nil", func(t *testing.T) {
+		h := StreamTimelineHandler(stubTimelineFetcher{getTimelineFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			return nil, "end", nil
+		}})
+		resp, err := h(marshal(t, event.GetTimelineEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.TweetsResponse)
+		if r.Tweets == nil {
+			t.Fatal("expected non-nil empty tweets slice")
+		}
+		if len(r.Tweets) != 0 {
+			t.Fatalf("expected 0 tweets, got %d", len(r.Tweets))
+		}
+	})
+
+	t.Run("with tweets", func(t *testing.T) {
+		h := StreamTimelineHandler(stubTimelineFetcher{getTimelineFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			return []domain.Tweet{{Id: "t1", Text: "hello"}}, "end", nil
+		}})
+		resp, err := h(marshal(t, event.GetTimelineEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.TweetsResponse)
+		if len(r.Tweets) != 1 {
+			t.Fatalf("expected 1 tweet, got %d", len(r.Tweets))
+		}
+		if r.UserId != owner {
+			t.Fatalf("expected user id %q, got %q", owner, r.UserId)
+		}
+		if r.Cursor != "end" {
+			t.Fatalf("expected cursor 'end', got %q", r.Cursor)
+		}
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamTimelineHandler(stubTimelineFetcher{getTimelineFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			return nil, "", repoErr
+		}})
+		_, err := h(marshal(t, event.GetTimelineEvent{UserId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		var capturedLimit *uint64
+		var capturedCursor *string
+		h := StreamTimelineHandler(stubTimelineFetcher{getTimelineFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			capturedLimit = limit
+			capturedCursor = cursor
+			return []domain.Tweet{}, "next", nil
+		}})
+		limit := uint64(10)
+		cursor := "some-cursor"
+		_, err := h(marshal(t, event.GetTimelineEvent{UserId: owner, Limit: &limit, Cursor: &cursor}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if capturedLimit == nil || *capturedLimit != 10 {
+			t.Fatalf("expected limit 10, got %v", capturedLimit)
+		}
+		if capturedCursor == nil || *capturedCursor != "some-cursor" {
+			t.Fatalf("expected cursor 'some-cursor', got %v", capturedCursor)
+		}
+	})
+}

--- a/core/handler/tweet.go
+++ b/core/handler/tweet.go
@@ -193,14 +193,15 @@ func StreamGetTweetHandler(
 			return nil, err
 		}
 
-		var tweet domain.Tweet
-		if err = json.Unmarshal(getTweetResp, &tweet); err != nil {
+		var possibleError event.ResponseError
+		if _ = json.Unmarshal(getTweetResp, &possibleError); possibleError.Message != "" {
+			log.Errorf("unmarshal other get tweet error response: %s", possibleError.Message)
 			return repo.Get(ev.UserId, ev.TweetId)
 		}
 
-		var possibleError event.ResponseError
-		if _ = json.Unmarshal(getTweetResp, &possibleError); possibleError.Message != "" {
-			log.Errorf("unmarshal other unlike error response: %s", possibleError.Message)
+		var tweet domain.Tweet
+		if err = json.Unmarshal(getTweetResp, &tweet); err != nil {
+			return repo.Get(ev.UserId, ev.TweetId)
 		}
 
 		return tweet, nil

--- a/core/handler/tweet_test.go
+++ b/core/handler/tweet_test.go
@@ -1,0 +1,669 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+)
+
+type stubTweetRepo struct {
+	tweetsCountFn   func(userId string) (uint64, error)
+	getViewsCountFn func(tweetId string) (uint64, error)
+	isBlocklistedFn func(tweetId string) bool
+	blocklistFn     func(tweetId string) error
+	getFn           func(userID, tweetID string) (domain.Tweet, error)
+	listFn          func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error)
+	createFn        func(userId string, tweet domain.Tweet) (domain.Tweet, error)
+	deleteFn        func(userID, tweetID string) error
+	unRetweetFn     func(retweetedByUserID, tweetId string) error
+	createWithTTLFn func(userId string, tweet domain.Tweet, duration time.Duration) (domain.Tweet, error)
+}
+
+func (s stubTweetRepo) TweetsCount(userId string) (uint64, error) {
+	if s.tweetsCountFn != nil {
+		return s.tweetsCountFn(userId)
+	}
+	return 0, nil
+}
+func (s stubTweetRepo) GetViewsCount(tweetId string) (uint64, error) {
+	if s.getViewsCountFn != nil {
+		return s.getViewsCountFn(tweetId)
+	}
+	return 0, nil
+}
+func (s stubTweetRepo) IsBlocklisted(tweetId string) bool {
+	if s.isBlocklistedFn != nil {
+		return s.isBlocklistedFn(tweetId)
+	}
+	return false
+}
+func (s stubTweetRepo) Blocklist(tweetId string) error {
+	if s.blocklistFn != nil {
+		return s.blocklistFn(tweetId)
+	}
+	return nil
+}
+func (s stubTweetRepo) Get(userID, tweetID string) (domain.Tweet, error) {
+	if s.getFn != nil {
+		return s.getFn(userID, tweetID)
+	}
+	return domain.Tweet{Id: tweetID, UserId: userID, Text: "cached"}, nil
+}
+func (s stubTweetRepo) List(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+	if s.listFn != nil {
+		return s.listFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubTweetRepo) Create(userId string, tweet domain.Tweet) (domain.Tweet, error) {
+	if s.createFn != nil {
+		return s.createFn(userId, tweet)
+	}
+	tweet.Id = "tweet-new"
+	return tweet, nil
+}
+func (s stubTweetRepo) Delete(userID, tweetID string) error {
+	if s.deleteFn != nil {
+		return s.deleteFn(userID, tweetID)
+	}
+	return nil
+}
+func (s stubTweetRepo) UnRetweet(retweetedByUserID, tweetId string) error {
+	if s.unRetweetFn != nil {
+		return s.unRetweetFn(retweetedByUserID, tweetId)
+	}
+	return nil
+}
+func (s stubTweetRepo) CreateWithTTL(userId string, tweet domain.Tweet, duration time.Duration) (domain.Tweet, error) {
+	if s.createWithTTLFn != nil {
+		return s.createWithTTLFn(userId, tweet, duration)
+	}
+	return tweet, nil
+}
+
+type stubTweetBroadcaster struct {
+	publishFn func(ownerId, dest string, bt []byte) error
+}
+
+func (s stubTweetBroadcaster) PublishUpdateToFollowers(ownerId, dest string, bt []byte) error {
+	if s.publishFn != nil {
+		return s.publishFn(ownerId, dest, bt)
+	}
+	return nil
+}
+
+type stubTweetUserRepo struct {
+	getFn func(userId string) (domain.User, error)
+}
+
+func (s stubTweetUserRepo) Get(userId string) (domain.User, error) {
+	if s.getFn != nil {
+		return s.getFn(userId)
+	}
+	return domain.User{Id: userId, NodeId: "node-2"}, nil
+}
+
+type stubTweetLikeRepo struct {
+	likeFn       func(tweetId, userId string) (uint64, error)
+	unlikeFn     func(tweetId, userId string) (uint64, error)
+	likesCountFn func(tweetId string) (uint64, error)
+	likersFn     func(tweetId string, limit *uint64, cursor *string) ([]string, string, error)
+}
+
+func (s stubTweetLikeRepo) Like(tweetId, userId string) (uint64, error) {
+	if s.likeFn != nil {
+		return s.likeFn(tweetId, userId)
+	}
+	return 0, nil
+}
+func (s stubTweetLikeRepo) Unlike(tweetId, userId string) (uint64, error) {
+	if s.unlikeFn != nil {
+		return s.unlikeFn(tweetId, userId)
+	}
+	return 0, nil
+}
+func (s stubTweetLikeRepo) LikesCount(tweetId string) (uint64, error) {
+	if s.likesCountFn != nil {
+		return s.likesCountFn(tweetId)
+	}
+	return 0, nil
+}
+func (s stubTweetLikeRepo) Likers(tweetId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.likersFn != nil {
+		return s.likersFn(tweetId, limit, cursor)
+	}
+	return nil, "", nil
+}
+
+type stubTweetRetweetRepo struct {
+	getFn           func(userID, tweetID string) (domain.Tweet, error)
+	newRetweetFn    func(tweet domain.Tweet) (domain.Tweet, error)
+	unRetweetFn     func(retweetedByUserID, tweetId string) error
+	retweetsCountFn func(tweetId string) (uint64, error)
+	retweetersFn    func(tweetId string, limit *uint64, cursor *string) ([]string, string, error)
+}
+
+func (s stubTweetRetweetRepo) Get(userID, tweetID string) (domain.Tweet, error) {
+	if s.getFn != nil {
+		return s.getFn(userID, tweetID)
+	}
+	return domain.Tweet{Id: tweetID, UserId: userID}, nil
+}
+func (s stubTweetRetweetRepo) NewRetweet(tweet domain.Tweet) (domain.Tweet, error) {
+	if s.newRetweetFn != nil {
+		return s.newRetweetFn(tweet)
+	}
+	return tweet, nil
+}
+func (s stubTweetRetweetRepo) UnRetweet(retweetedByUserID, tweetId string) error {
+	if s.unRetweetFn != nil {
+		return s.unRetweetFn(retweetedByUserID, tweetId)
+	}
+	return nil
+}
+func (s stubTweetRetweetRepo) RetweetsCount(tweetId string) (uint64, error) {
+	if s.retweetsCountFn != nil {
+		return s.retweetsCountFn(tweetId)
+	}
+	return 0, nil
+}
+func (s stubTweetRetweetRepo) Retweeters(tweetId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.retweetersFn != nil {
+		return s.retweetersFn(tweetId, limit, cursor)
+	}
+	return nil, "", nil
+}
+
+type stubRepliesCounter struct {
+	repliesCountFn func(tweetId string) (uint64, error)
+}
+
+func (s stubRepliesCounter) RepliesCount(tweetId string) (uint64, error) {
+	if s.repliesCountFn != nil {
+		return s.repliesCountFn(tweetId)
+	}
+	return 0, nil
+}
+
+func TestStreamNewTweetHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		_, err := h(marshal(t, event.NewTweetEvent{Text: "hello"}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty tweet text", func(t *testing.T) {
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		_, err := h(marshal(t, event.NewTweetEvent{UserId: owner}), nil)
+		if err == nil || err.Error() != "empty tweet text" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("tweet text too long", func(t *testing.T) {
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		longText := make([]byte, tweetCharLimit+1)
+		for i := range longText {
+			longText[i] = 'a'
+		}
+		_, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: string(longText)}), nil)
+		if err == nil || err.Error() != "tweet text is too long" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("moderated tweet gets blocklisted", func(t *testing.T) {
+		blocklisted := false
+		fail := domain.FAIL
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{blocklistFn: func(tweetId string) error {
+			blocklisted = true
+			return nil
+		}}, stubTimelineRepo{})
+		_, err := h(marshal(t, event.NewTweetEvent{Id: "t1", UserId: owner, Text: "bad", Moderation: &domain.TweetModeration{IsOk: fail}}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !blocklisted {
+			t.Fatal("expected tweet to be blocklisted")
+		}
+	})
+
+	t.Run("create error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{createFn: func(userId string, tweet domain.Tweet) (domain.Tweet, error) {
+			return domain.Tweet{}, repoErr
+		}}, stubTimelineRepo{})
+		_, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: "hello"}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("own tweet - success with broadcast", func(t *testing.T) {
+		published := false
+		h := StreamNewTweetHandler(stubTweetBroadcaster{publishFn: func(ownerId, dest string, bt []byte) error {
+			published = true
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		resp, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: "hello"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "hello" {
+			t.Fatalf("unexpected response: %v", resp)
+		}
+		if !published {
+			t.Fatal("expected broadcast to be called")
+		}
+	})
+
+	t.Run("other user tweet - no broadcast", func(t *testing.T) {
+		published := false
+		h := StreamNewTweetHandler(stubTweetBroadcaster{publishFn: func(ownerId, dest string, bt []byte) error {
+			published = true
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{})
+		resp, err := h(marshal(t, event.NewTweetEvent{UserId: "other-1", Text: "from friend"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "from friend" {
+			t.Fatalf("unexpected response: %v", resp)
+		}
+		if published {
+			t.Fatal("should not broadcast other user's tweet")
+		}
+	})
+}
+
+func TestStreamGetTweetHandler(t *testing.T) {
+	owner := "owner-1"
+	tweetId := "tweet-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetTweetEvent{TweetId: tweetId}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty tweet id", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetTweetEvent{UserId: owner}), nil)
+		if err == nil || err.Error() != "empty tweet id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("blocklisted tweet", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{isBlocklistedFn: func(tweetId string) bool { return true }}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		if err == nil || err.Error() != "tweet is moderated" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("own tweet - local fetch", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{})
+		resp, err := h(marshal(t, event.GetTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Id != tweetId {
+			t.Fatalf("unexpected response: %v", resp)
+		}
+	})
+
+	t.Run("other user tweet - user not found fallback", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubStreamer{})
+		resp, err := h(marshal(t, event.GetTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "cached" {
+			t.Fatalf("expected cached tweet fallback: %v", resp)
+		}
+	})
+
+	t.Run("other user tweet - node offline fallback", func(t *testing.T) {
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}})
+		resp, err := h(marshal(t, event.GetTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "cached" {
+			t.Fatalf("expected cached tweet fallback: %v", resp)
+		}
+	})
+
+	t.Run("other user tweet - remote error response falls back to local", func(t *testing.T) {
+		errResp, _ := json.Marshal(event.ResponseError{Code: 500, Message: "remote error"})
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return errResp, nil
+		}})
+		resp, err := h(marshal(t, event.GetTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "cached" {
+			t.Fatalf("expected local fallback on remote error, got: %v", resp)
+		}
+	})
+
+	t.Run("other user tweet - remote success", func(t *testing.T) {
+		remoteTweet, _ := json.Marshal(domain.Tweet{Id: tweetId, UserId: "other-1", Text: "remote tweet"})
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return remoteTweet, nil
+		}})
+		resp, err := h(marshal(t, event.GetTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "remote tweet" {
+			t.Fatalf("expected remote tweet: %v", resp)
+		}
+	})
+
+	t.Run("other user tweet - stream error", func(t *testing.T) {
+		streamErr := errors.New("stream broken")
+		h := StreamGetTweetHandler(stubTweetRepo{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetUserRepo{}, stubStreamer{genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+			return nil, streamErr
+		}})
+		_, err := h(marshal(t, event.GetTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("expected stream error: %v", err)
+		}
+	})
+}
+
+func TestStreamGetTweetsHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetTweetsHandler(stubTweetRepo{}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetTweetsHandler(stubTweetRepo{}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetAllTweetsEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("tweets exist locally - returns immediately", func(t *testing.T) {
+		h := StreamGetTweetsHandler(stubTweetRepo{listFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			return []domain.Tweet{{Id: "t1", UserId: owner, Text: "hello"}}, "end", nil
+		}}, stubTweetUserRepo{}, stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}})
+		resp, err := h(marshal(t, event.GetAllTweetsEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.TweetsResponse)
+		if len(r.Tweets) != 1 {
+			t.Fatalf("expected 1 tweet, got %d", len(r.Tweets))
+		}
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamGetTweetsHandler(stubTweetRepo{listFn: func(userId string, limit *uint64, cursor *string) ([]domain.Tweet, string, error) {
+			return nil, "", repoErr
+		}}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetAllTweetsEvent{UserId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+}
+
+func TestStreamDeleteTweetHandler(t *testing.T) {
+	owner := "owner-1"
+	tweetId := "tweet-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTweetLikeRepo{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTweetLikeRepo{})
+		_, err := h(marshal(t, event.DeleteTweetEvent{TweetId: tweetId}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty tweet id", func(t *testing.T) {
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTweetLikeRepo{})
+		_, err := h(marshal(t, event.DeleteTweetEvent{UserId: owner}), nil)
+		if err == nil || err.Error() != "empty tweet id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{deleteFn: func(userID, tweetID string) error {
+			return repoErr
+		}}, stubTweetLikeRepo{})
+		_, err := h(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("own tweet delete - broadcasts", func(t *testing.T) {
+		published := false
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{publishFn: func(ownerId, dest string, bt []byte) error {
+			published = true
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTweetLikeRepo{})
+		resp, err := h(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !published {
+			t.Fatal("expected broadcast to be called")
+		}
+	})
+
+	t.Run("other user tweet delete - no broadcast", func(t *testing.T) {
+		published := false
+		h := StreamDeleteTweetHandler(stubTweetBroadcaster{publishFn: func(ownerId, dest string, bt []byte) error {
+			published = true
+			return nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTweetLikeRepo{})
+		resp, err := h(marshal(t, event.DeleteTweetEvent{UserId: "other-1", TweetId: tweetId}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if published {
+			t.Fatal("should not broadcast other user's tweet delete")
+		}
+	})
+}
+
+func TestStreamGetTweetStatsHandler(t *testing.T) {
+	owner := "owner-1"
+	tweetId := "tweet-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty tweet id", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetTweetStatsEvent{UserId: owner}), nil)
+		if err == nil || err.Error() != "empty tweet id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("own tweet stats - concurrent gathering", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(
+			stubTweetRepo{tweetsCountFn: func(userId string) (uint64, error) { return 10, nil }, getViewsCountFn: func(tweetId string) (uint64, error) { return 100, nil }},
+			stubTweetLikeRepo{likesCountFn: func(tweetId string) (uint64, error) { return 5, nil }},
+			stubTweetRetweetRepo{retweetsCountFn: func(tweetId string) (uint64, error) { return 3, nil }},
+			stubRepliesCounter{repliesCountFn: func(tweetId string) (uint64, error) { return 2, nil }},
+			stubTweetUserRepo{},
+			stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}},
+		)
+		resp, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId, UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(event.TweetStatsResponse)
+		if stats.TweetsCount != 10 || stats.ViewsCount != 100 || stats.LikeCount != 5 || stats.RetweetsCount != 3 || stats.RepliesCount != 2 {
+			t.Fatalf("unexpected stats: %+v", stats)
+		}
+	})
+
+	t.Run("other user tweet stats - user not found", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}})
+		resp, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId, UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(event.TweetStatsResponse)
+		if stats.TweetId != tweetId {
+			t.Fatalf("expected tweet id in response: %v", stats)
+		}
+	})
+
+	t.Run("other user tweet stats - node offline", func(t *testing.T) {
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: owner},
+			genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+				return nil, warpnet.ErrNodeIsOffline
+			},
+		})
+		resp, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId, UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(event.TweetStatsResponse)
+		if stats.TweetId != tweetId {
+			t.Fatalf("expected tweet id in response: %v", stats)
+		}
+	})
+
+	t.Run("other user tweet stats - remote success", func(t *testing.T) {
+		remoteStats, _ := json.Marshal(event.TweetStatsResponse{
+			TweetId:     tweetId,
+			LikeCount:   42,
+			ViewsCount:  1000,
+			RepliesCount: 7,
+		})
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: owner},
+			genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+				return remoteStats, nil
+			},
+		})
+		resp, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId, UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		stats := resp.(event.TweetStatsResponse)
+		if stats.LikeCount != 42 {
+			t.Fatalf("expected remote stats: %+v", stats)
+		}
+	})
+
+	t.Run("other user tweet stats - stream error", func(t *testing.T) {
+		streamErr := errors.New("broken")
+		h := StreamGetTweetStatsHandler(stubTweetRepo{}, stubTweetLikeRepo{}, stubTweetRetweetRepo{}, stubRepliesCounter{}, stubTweetUserRepo{}, stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: owner},
+			genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+				return nil, streamErr
+			},
+		})
+		_, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: tweetId, UserId: "other-1"}), nil)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("expected stream error: %v", err)
+		}
+	})
+
+	t.Run("own tweet stats - strips retweet prefix", func(t *testing.T) {
+		var capturedTweetId string
+		h := StreamGetTweetStatsHandler(
+			stubTweetRepo{},
+			stubTweetLikeRepo{likesCountFn: func(tweetId string) (uint64, error) {
+				capturedTweetId = tweetId
+				return 0, nil
+			}},
+			stubTweetRetweetRepo{},
+			stubRepliesCounter{},
+			stubTweetUserRepo{},
+			stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}},
+		)
+		_, err := h(marshal(t, event.GetTweetStatsEvent{TweetId: domain.RetweetPrefix + tweetId, UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if capturedTweetId != tweetId {
+			t.Fatalf("expected stripped tweet id %q, got %q", tweetId, capturedTweetId)
+		}
+	})
+}

--- a/core/handler/user_test.go
+++ b/core/handler/user_test.go
@@ -1,0 +1,381 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+)
+
+type stubUserFetcher struct {
+	createFn        func(user domain.User) (domain.User, error)
+	getFn           func(userId string) (domain.User, error)
+	listFn          func(limit *uint64, cursor *string) ([]domain.User, string, error)
+	whoToFollowFn   func(limit *uint64, cursor *string) ([]domain.User, string, error)
+	updateFn        func(userId string, newUser domain.User) (domain.User, error)
+	createWithTTLFn func(user domain.User, ttl time.Duration) (domain.User, error)
+}
+
+func (s stubUserFetcher) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
+}
+func (s stubUserFetcher) Get(userId string) (domain.User, error) {
+	if s.getFn != nil {
+		return s.getFn(userId)
+	}
+	return domain.User{Id: userId, NodeId: "node-2", Network: warpnet.WarpnetName}, nil
+}
+func (s stubUserFetcher) List(limit *uint64, cursor *string) ([]domain.User, string, error) {
+	if s.listFn != nil {
+		return s.listFn(limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubUserFetcher) WhoToFollow(limit *uint64, cursor *string) ([]domain.User, string, error) {
+	if s.whoToFollowFn != nil {
+		return s.whoToFollowFn(limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubUserFetcher) Update(userId string, newUser domain.User) (domain.User, error) {
+	if s.updateFn != nil {
+		return s.updateFn(userId, newUser)
+	}
+	return newUser, nil
+}
+func (s stubUserFetcher) CreateWithTTL(user domain.User, ttl time.Duration) (domain.User, error) {
+	if s.createWithTTLFn != nil {
+		return s.createWithTTLFn(user, ttl)
+	}
+	return user, nil
+}
+
+type stubUserTweetsCounter struct {
+	tweetsCountFn func(userID string) (uint64, error)
+}
+
+func (s stubUserTweetsCounter) TweetsCount(userID string) (uint64, error) {
+	if s.tweetsCountFn != nil {
+		return s.tweetsCountFn(userID)
+	}
+	return 0, nil
+}
+
+type stubUserFollowsCounter struct {
+	getFollowersCountFn  func(userId string) (uint64, error)
+	getFollowingsCountFn func(userId string) (uint64, error)
+	getFollowersFn       func(userId string, limit *uint64, cursor *string) ([]string, string, error)
+	getFollowingsFn      func(userId string, limit *uint64, cursor *string) ([]string, string, error)
+}
+
+func (s stubUserFollowsCounter) GetFollowersCount(userId string) (uint64, error) {
+	if s.getFollowersCountFn != nil {
+		return s.getFollowersCountFn(userId)
+	}
+	return 0, nil
+}
+func (s stubUserFollowsCounter) GetFollowingsCount(userId string) (uint64, error) {
+	if s.getFollowingsCountFn != nil {
+		return s.getFollowingsCountFn(userId)
+	}
+	return 0, nil
+}
+func (s stubUserFollowsCounter) GetFollowers(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.getFollowersFn != nil {
+		return s.getFollowersFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+func (s stubUserFollowsCounter) GetFollowings(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.getFollowingsFn != nil {
+		return s.getFollowingsFn(userId, limit, cursor)
+	}
+	return nil, "", nil
+}
+
+type stubUserStreamer struct {
+	genericStreamFn func(nodeId string, path stream.WarpRoute, data any) ([]byte, error)
+	nodeInfo        warpnet.NodeInfo
+}
+
+func (s stubUserStreamer) GenericStream(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+	if s.genericStreamFn != nil {
+		return s.genericStreamFn(nodeId, path, data)
+	}
+	return nil, nil
+}
+func (s stubUserStreamer) NodeInfo() warpnet.NodeInfo { return s.nodeInfo }
+
+func TestStreamGetUserHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetUserEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("own profile - with counts", func(t *testing.T) {
+		h := StreamGetUserHandler(
+			stubUserTweetsCounter{tweetsCountFn: func(userID string) (uint64, error) { return 10, nil }},
+			stubUserFollowsCounter{
+				getFollowersCountFn:  func(userId string) (uint64, error) { return 100, nil },
+				getFollowingsCountFn: func(userId string) (uint64, error) { return 50, nil },
+			},
+			stubUserFetcher{getFn: func(userId string) (domain.User, error) {
+				return domain.User{Id: owner, Username: "test"}, nil
+			}},
+			stubAuth{owner: domain.Owner{UserId: owner}},
+			stubUserStreamer{},
+		)
+		resp, err := h(marshal(t, event.GetUserEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		u := resp.(domain.User)
+		if u.TweetsCount != 10 || u.FollowersCount != 100 || u.FollowingsCount != 50 {
+			t.Fatalf("unexpected counts: tweets=%d followers=%d followings=%d", u.TweetsCount, u.FollowersCount, u.FollowingsCount)
+		}
+	})
+
+	t.Run("own profile - repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, repoErr
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetUserEvent{UserId: owner}), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("other user profile - success", func(t *testing.T) {
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{getFn: func(userId string) (domain.User, error) {
+			return domain.User{Id: userId, NodeId: "node-2", Username: "other"}, nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		resp, err := h(marshal(t, event.GetUserEvent{UserId: "other-1"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		u := resp.(domain.User)
+		if u.Username != "other" {
+			t.Fatalf("unexpected user: %v", u)
+		}
+	})
+
+	t.Run("other user profile - missing node id", func(t *testing.T) {
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{getFn: func(userId string) (domain.User, error) {
+			return domain.User{Id: userId, NodeId: ""}, nil
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetUserEvent{UserId: "other-1"}), nil)
+		if err == nil {
+			t.Fatal("expected error for missing node id")
+		}
+	})
+
+	t.Run("other user profile - not found", func(t *testing.T) {
+		h := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, stubUserFetcher{getFn: func(userId string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}, stubAuth{owner: domain.Owner{UserId: owner}}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetUserEvent{UserId: "other-1"}), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestStreamGetUsersHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetUsersHandler(stubUserFetcher{}, stubUserStreamer{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetUsersHandler(stubUserFetcher{}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetAllUsersEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("users exist locally - returns immediately", func(t *testing.T) {
+		h := StreamGetUsersHandler(stubUserFetcher{listFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+			return []domain.User{{Id: "u1"}}, "end", nil
+		}}, stubUserStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}})
+		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.UsersResponse)
+		if len(r.Users) != 1 {
+			t.Fatalf("expected 1 user, got %d", len(r.Users))
+		}
+	})
+
+	t.Run("no users locally - fetches and returns", func(t *testing.T) {
+		callCount := 0
+		h := StreamGetUsersHandler(stubUserFetcher{listFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, "", nil
+			}
+			return []domain.User{{Id: "u1"}}, "end", nil
+		}}, stubUserStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}})
+		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.UsersResponse)
+		if len(r.Users) != 1 {
+			t.Fatalf("expected 1 user, got %d", len(r.Users))
+		}
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamGetUsersHandler(stubUserFetcher{listFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+			return nil, "", repoErr
+		}}, stubUserStreamer{})
+		_, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+}
+
+func TestStreamGetWhoToFollowHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetWhoToFollowHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{}, stubUserFollowsCounter{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetWhoToFollowHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{}, stubUserFollowsCounter{})
+		_, err := h(marshal(t, event.GetAllUsersEvent{}), nil)
+		if err == nil || err.Error() != "empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("filters out self and already followed", func(t *testing.T) {
+		h := StreamGetWhoToFollowHandler(
+			stubAuth{owner: domain.Owner{UserId: owner, NodeId: "node-1", Username: "test"}},
+			stubUserFetcher{
+				whoToFollowFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+					return []domain.User{
+						{Id: owner, Network: warpnet.WarpnetName},
+						{Id: "already-followed", Network: warpnet.WarpnetName},
+						{Id: "new-user", Network: warpnet.WarpnetName},
+					}, "end", nil
+				},
+				getFn: func(userId string) (domain.User, error) {
+					return domain.User{Id: owner, Network: warpnet.WarpnetName}, nil
+				},
+			},
+			stubUserFollowsCounter{getFollowingsFn: func(userId string, limit *uint64, cursor *string) ([]string, string, error) {
+				return []string{"already-followed"}, "", nil
+			}},
+		)
+		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.UsersResponse)
+		if len(r.Users) != 1 || r.Users[0].Id != "new-user" {
+			t.Fatalf("expected only new-user, got: %v", r.Users)
+		}
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamGetWhoToFollowHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{whoToFollowFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+			return nil, "", repoErr
+		}}, stubUserFollowsCounter{})
+		_, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+
+	t.Run("empty results", func(t *testing.T) {
+		h := StreamGetWhoToFollowHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{}, stubUserFollowsCounter{})
+		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		r := resp.(event.UsersResponse)
+		if len(r.Users) != 0 {
+			t.Fatalf("expected empty users: %v", r.Users)
+		}
+	})
+}
+
+func TestStreamUpdateProfileHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamUpdateProfileHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{})
+		_, err := h([]byte("{"), nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		h := StreamUpdateProfileHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{updateFn: func(userId string, newUser domain.User) (domain.User, error) {
+			newUser.Id = userId
+			return newUser, nil
+		}})
+		resp, err := h(marshal(t, event.NewUserEvent{Bio: "new bio"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		u := resp.(domain.User)
+		if u.Bio != "new bio" {
+			t.Fatalf("unexpected bio: %v", u)
+		}
+		if u.Id != owner {
+			t.Fatalf("expected owner id to be used: %v", u)
+		}
+	})
+
+	t.Run("update error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		h := StreamUpdateProfileHandler(stubAuth{owner: domain.Owner{UserId: owner}}, stubUserFetcher{updateFn: func(userId string, newUser domain.User) (domain.User, error) {
+			return domain.User{}, repoErr
+		}})
+		_, err := h(marshal(t, event.NewUserEvent{Bio: "new bio"}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error: %v", err)
+		}
+	})
+}

--- a/core/handler/user_test.go
+++ b/core/handler/user_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Warp-net/warpnet/database"
 	"github.com/Warp-net/warpnet/domain"
 	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
 )
 
 type stubUserFetcher struct {
@@ -236,18 +237,53 @@ func TestStreamGetUsersHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("no users locally - fetches and returns", func(t *testing.T) {
-		callCount := 0
-		h := StreamGetUsersHandler(stubUserFetcher{listFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
-			callCount++
-			if callCount == 1 {
-				return nil, "", nil
-			}
-			return []domain.User{{Id: "u1"}}, "end", nil
-		}}, stubUserStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: owner}})
-		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: owner}), nil)
+	t.Run("no users locally - fetches from remote and returns", func(t *testing.T) {
+		requestUser := "requester-1"
+		fetchedUsers := []domain.User{{Id: "u1"}}
+		listCallCount := 0
+		genericStreamCalled := 0
+		persistedUsers := 0
+
+		h := StreamGetUsersHandler(
+			stubUserFetcher{
+				listFn: func(limit *uint64, cursor *string) ([]domain.User, string, error) {
+					listCallCount++
+					if persistedUsers == 0 {
+						return nil, "", nil
+					}
+					return fetchedUsers, "end", nil
+				},
+				getFn: func(userId string) (domain.User, error) {
+					return domain.User{Id: userId, NodeId: "node-2"}, nil
+				},
+				createFn: func(user domain.User) (domain.User, error) {
+					persistedUsers++
+					return user, nil
+				},
+			},
+			stubUserStreamer{
+				nodeInfo: warpnet.NodeInfo{OwnerId: owner},
+				genericStreamFn: func(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+					genericStreamCalled++
+					resp := event.UsersResponse{Users: fetchedUsers, Cursor: "end"}
+					b, _ := json.Marshal(resp)
+					return b, nil
+				},
+			},
+		)
+
+		resp, err := h(marshal(t, event.GetAllUsersEvent{UserId: requestUser}), nil)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
+		}
+		if genericStreamCalled != 1 {
+			t.Fatalf("expected GenericStream to be called once, got %d", genericStreamCalled)
+		}
+		if persistedUsers != len(fetchedUsers) {
+			t.Fatalf("expected %d persisted users, got %d", len(fetchedUsers), persistedUsers)
+		}
+		if listCallCount < 2 {
+			t.Fatalf("expected local list to be retried after refresh, got %d calls", listCallCount)
 		}
 		r := resp.(event.UsersResponse)
 		if len(r.Users) != 1 {

--- a/database/auth-repo_test.go
+++ b/database/auth-repo_test.go
@@ -50,7 +50,7 @@ func (s *AuthRepoTestSuite) SetupSuite() {
 	var err error
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
-	s.repo = NewAuthRepo(s.db)
+	s.repo = NewAuthRepo(s.db, "test")
 
 	err = s.repo.Authenticate("test", "test")
 	s.Require().NoError(err)

--- a/database/chat-repo_test.go
+++ b/database/chat-repo_test.go
@@ -55,7 +55,7 @@ func (s *ChatRepoSuite) SetupSuite() {
 
 	s.db = db
 
-	authRepo := NewAuthRepo(db)
+	authRepo := NewAuthRepo(db, "test")
 	err = authRepo.Authenticate(rand.Text(), rand.Text())
 	s.Require().NoError(err)
 

--- a/database/like-repo_test.go
+++ b/database/like-repo_test.go
@@ -50,7 +50,7 @@ func (s *LikeRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	authRepo := NewAuthRepo(s.db)
+	authRepo := NewAuthRepo(s.db, "test")
 	err = authRepo.Authenticate("test", "test")
 	s.Require().NoError(err)
 

--- a/database/node-repo_test.go
+++ b/database/node-repo_test.go
@@ -56,7 +56,7 @@ func (s *NodeRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	auth := NewAuthRepo(s.db)
+	auth := NewAuthRepo(s.db, "test")
 	s.Require().NoError(auth.Authenticate("test", "test"))
 
 	s.repo = NewNodeRepo(s.db)

--- a/database/notification-repo_test.go
+++ b/database/notification-repo_test.go
@@ -25,7 +25,7 @@ func (s *NotificationsRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	authRepo := NewAuthRepo(s.db)
+	authRepo := NewAuthRepo(s.db, "test")
 	err = authRepo.Authenticate("test", "test")
 	s.Require().NoError(err)
 

--- a/database/replies-repo_test.go
+++ b/database/replies-repo_test.go
@@ -52,7 +52,7 @@ func (s *ReplyRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	auth := NewAuthRepo(s.db)
+	auth := NewAuthRepo(s.db, "test")
 	s.Require().NoError(auth.Authenticate("test", "test"))
 
 	s.repo = NewRepliesRepo(s.db, nil)

--- a/database/timeline-repo_test.go
+++ b/database/timeline-repo_test.go
@@ -52,7 +52,7 @@ func (s *TimelineRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	auth := NewAuthRepo(s.db)
+	auth := NewAuthRepo(s.db, "test")
 	s.Require().NoError(auth.Authenticate("test", "test"))
 
 	s.repo = NewTimelineRepo(s.db)

--- a/database/tweet-repo_test.go
+++ b/database/tweet-repo_test.go
@@ -51,7 +51,7 @@ func (s *TweetRepoTestSuite) SetupSuite() {
 	var err error
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
-	auth := NewAuthRepo(s.db)
+	auth := NewAuthRepo(s.db, "test")
 	s.Require().NoError(auth.Authenticate("test", "test"))
 
 	s.repo = NewTweetRepo(s.db, nil)

--- a/database/user-repo_test.go
+++ b/database/user-repo_test.go
@@ -51,7 +51,7 @@ func (s *UserRepoTestSuite) SetupSuite() {
 	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
 	s.Require().NoError(err)
 
-	authRepo := NewAuthRepo(s.db)
+	authRepo := NewAuthRepo(s.db, "test")
 	err = authRepo.Authenticate("test", "test")
 	s.Require().NoError(err)
 


### PR DESCRIPTION
## Summary
This PR adds extensive unit test coverage for the handler package, including tests for following, tweeting, user management, moderation, timeline, stats, info, and pairing handlers. Additionally, it fixes a critical bug in the unfollow handler and improves error handling in remote response parsing.

## Key Changes

### Test Coverage
- **following_test.go**: 678 lines of tests covering `StreamFollowHandler` and `StreamUnfollowHandler` with scenarios for self-follows, remote follows, error handling, and broadcaster subscription
- **tweet_test.go**: 669 lines of tests for tweet operations including creation, retrieval, moderation, and remote node interactions
- **user_test.go**: 381 lines of tests for user profile retrieval and user listing with count aggregation
- **moderation_test.go**: 194 lines of tests for moderation result handling and notification logic
- **timeline_test.go**: 111 lines of tests for timeline retrieval with pagination
- **stats_test.go**: 110 lines of tests for node statistics reporting
- **info_test.go**: 90 lines of tests for node info retrieval and peer discovery
- **pair_test.go**: 66 lines of tests for node pairing authentication

### Bug Fixes
- **following.go**: Fixed argument order in `StreamUnfollowHandler` - changed `followRepo.Unfollow(ev.FollowingId, ev.FollowerId)` to `followRepo.Unfollow(ev.FollowerId, ev.FollowingId)` to correctly pass follower first, then following user

### Error Handling Improvements
- **tweet.go** and **reply.go**: Enhanced remote response parsing to properly detect and handle `ResponseError` responses before attempting to unmarshal as domain objects, preventing silent failures when remote nodes return errors
- **pair.go**: Improved error handling in node pairing validation

## Notable Implementation Details
- Comprehensive stub implementations for all repository and service dependencies
- Tests cover both happy paths and error scenarios including network failures, database errors, and validation failures
- Tests verify correct argument ordering and state transitions
- Proper handling of fallback mechanisms when remote nodes are offline or return errors

https://claude.ai/code/session_011Fsybz2dkTaBZazCJ2x3bX