### PR TITLE
Refactor user handler and improve notification sorting

### DIFF
--- a/core/handler/notification.go
+++ b/core/handler/notification.go
@@ -67,11 +67,16 @@ func StreamGetNotificationsHandler(
 		}
 
 		var unreadCount uint64
-		sort.SliceStable(notifications, func(i, j int) bool {
-			if !notifications[i].IsRead {
+		for _, n := range notifications {
+			if !n.IsRead {
 				unreadCount++
 			}
-			return notifications[i].IsRead
+		}
+		sort.SliceStable(notifications, func(i, j int) bool {
+			if notifications[i].IsRead != notifications[j].IsRead {
+				return !notifications[i].IsRead
+			}
+			return notifications[i].CreatedAt.After(notifications[j].CreatedAt)
 		})
 		return event.GetNotificationsResponse{
 			Cursor:        cur,

--- a/core/handler/user.go
+++ b/core/handler/user.go
@@ -95,7 +95,7 @@ func StreamGetUserHandler(
 		if isMe {
 			u, err := repo.Get(ownerId)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("get user: owner %v", err)
 			}
 			followersCount, err := followRepo.GetFollowersCount(u.Id)
 			if err != nil {
@@ -118,38 +118,44 @@ func StreamGetUserHandler(
 		}
 
 		otherUser, err := repo.Get(ev.UserId)
-		if errors.Is(err, database.ErrUserNotFound) {
-			return nil, err
-		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("get user: other user %v", err)
 		}
-
-		otherUserData, err := streamer.GenericStream(
-			otherUser.NodeId,
-			event.PUBLIC_GET_USER,
-			ev,
-		)
-		if errors.Is(err, warpnet.ErrNodeIsOffline) {
-			otherUser.IsOffline = true
-			_, err = repo.Update(otherUser.Id, otherUser)
-			return otherUser, err
+		if otherUser.NodeId == "" {
+			return otherUser, fmt.Errorf("get user: node id is not found")
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		var possibleError event.ResponseError
-		if _ = json.Unmarshal(otherUserData, &possibleError); possibleError.Message != "" {
-			return nil, fmt.Errorf("unmarshal other user error response: %w", possibleError)
-		}
-
-		if err = json.Unmarshal(otherUserData, &otherUser); err != nil {
-			return nil, fmt.Errorf("get other user: response unmarshal: %w %s", err, otherUserData)
-		}
-		_, err = repo.Update(otherUser.Id, otherUser)
-		return otherUser, err
+		go func() {
+			updatedUser := updateOtherUser(ev, otherUser, streamer)
+			_, err = repo.Update(updatedUser.Id, updatedUser)
+		}()
+		return otherUser, nil
 	}
+}
+
+func updateOtherUser(ev event.GetUserEvent, user domain.User, streamer UserStreamer) domain.User {
+	otherUserData, err := streamer.GenericStream(
+		user.NodeId,
+		event.PUBLIC_GET_USER,
+		ev,
+	)
+	if errors.Is(err, warpnet.ErrNodeIsOffline) {
+		user.IsOffline = true
+		return user
+	}
+	if err != nil {
+		log.Errorf("stream: get other user: %v", err)
+		return user
+	}
+
+	var possibleError event.ResponseError
+	if _ = json.Unmarshal(otherUserData, &possibleError); possibleError.Message != "" {
+		log.Errorf("stream: unmarshal other user error response: %v", possibleError)
+	}
+
+	if err = json.Unmarshal(otherUserData, &user); err != nil {
+		log.Errorf("stream: get other user: response unmarshal: %v %s", err, otherUserData)
+	}
+	return user
 }
 
 func StreamGetUsersHandler(

--- a/database/notification-repo.go
+++ b/database/notification-repo.go
@@ -84,7 +84,10 @@ func (repo *NotificationsRepo) Add(not domain.Notification) error {
 	}
 	defer txn.Rollback()
 
-	return txn.SetWithTTL(notKey, bt, time.Hour*24)
+	if err = txn.SetWithTTL(notKey, bt, time.Hour*24); err != nil {
+		return err
+	}
+	return txn.Commit()
 }
 
 func (repo *NotificationsRepo) List(userId string, limit *uint64, cursor *string) ([]domain.Notification, string, error) {


### PR DESCRIPTION
## Summary
This PR improves error handling, code organization, and notification sorting logic across the user and notification handlers.

## Key Changes

### User Handler (`core/handler/user.go`)
- **Enhanced error messages**: Wrapped errors with contextual information (e.g., "get user: owner %v") for better debugging
- **Refactored async user update**: Extracted the `updateOtherUser()` function to handle remote user data fetching asynchronously via goroutine, improving handler responsiveness
- **Improved error handling**: Changed error handling strategy to log errors instead of returning them from the async operation, allowing the handler to return immediately with the user object
- **Added validation**: Added check for empty `NodeId` before attempting to stream user data
- **Graceful degradation**: Errors during async user update are now logged rather than propagated, allowing the handler to return the user object even if the update fails

### Notification Handler (`core/handler/notification.go`)
- **Fixed sorting logic**: Corrected the notification sort to properly separate read/unread notifications and sort by creation date
- **Separated concerns**: Moved unread count calculation into a separate loop for clarity
- **Improved sort stability**: Now sorts unread notifications first, then by creation timestamp in descending order

### Notification Repository (`database/notification-repo.go`)
- **Fixed transaction handling**: Added explicit `txn.Commit()` call after `SetWithTTL()` to ensure the transaction is properly committed
- **Improved error handling**: Added error check for the `SetWithTTL()` operation before committing

## Notable Implementation Details
- The `updateOtherUser()` function is now non-blocking, allowing the API to respond faster while user data is updated in the background
- Error logging in the async update function uses `log.Errorf()` to maintain observability without blocking the response
- Notification sorting now correctly prioritizes unread items and maintains chronological order within each group

https://claude.ai/code/session_01AUCCvim8uvdbArwKNk6tAo