### PR TITLE
Include full AuthNodeInfo in QR code for mobile pairing

### DIFF
--- a/frontend/src/service/service.js
+++ b/frontend/src/service/service.js
@@ -126,7 +126,10 @@ export const warpnetService = {
 
         warpnetService.setOwnerProfile(resp.identity.owner)
 
-        const qrData = JSON.stringify(resp.identity);
+        // The QR carries the full AuthNodeInfo envelope (identity + node_info)
+        // so the mobile pairing client gets both the credentials and the
+        // multiaddrs/peer-id it needs to dial this node.
+        const qrData = JSON.stringify(resp);
         resp.identity.token = null // for security reasons
 
         const qrCode = await buildQRCode(qrData)


### PR DESCRIPTION
## Summary
Updated the QR code generation to include the complete AuthNodeInfo envelope instead of just the identity portion. This ensures mobile pairing clients receive both authentication credentials and network connectivity information needed to establish a connection.

## Changes
- Modified QR code data to serialize the full `resp` object (AuthNodeInfo envelope) instead of just `resp.identity`
- Added clarifying comments explaining that the QR code now carries both identity credentials and node_info (multiaddrs/peer-id)
- Maintained existing security practice of clearing the token after QR code generation

## Implementation Details
The QR code now contains the complete response envelope, which includes:
- Identity information (credentials for authentication)
- Node info (multiaddrs and peer-id required for dialing the node)

This allows mobile clients to perform pairing with all necessary information in a single QR scan, rather than requiring separate channels for connectivity details.

https://claude.ai/code/session_01WH7BHNPkRhwbKoRNpXcWgZ