### PR TITLE
warpdroid: LAN-first dial ordering + non-blocking Resume

### DIFF
--- a/core/node/node.go
+++ b/core/node/node.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"io"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -292,13 +293,37 @@ func (n *WarpNode) BaseNodeInfo() warpnet.NodeInfo {
 
 	relayState := warpnet.RelayStatusWaiting
 
+	// Stable-sort the host's self-addresses by dial preference so the
+	// pairing QR (which carries this list as-is) leads with addresses a
+	// thin client can actually use on the same network. Without the
+	// sort, a circuit-v2 relay listed first wins every pairing race and
+	// the user pays NAT-traversal latency on a LAN.
 	addrs := n.node.Peerstore().Addrs(n.node.ID())
-	addresses := make([]string, 0, len(addrs))
-	for _, ma := range addrs {
+	type ranked struct {
+		ma   warpnet.WarpAddress
+		tier warpnet.DialTier
+		idx  int
+	}
+	ranks := make([]ranked, 0, len(addrs))
+	for i, ma := range addrs {
+		tier := warpnet.ClassifyDialAddress(ma)
+		if tier == warpnet.DialTierDrop {
+			continue
+		}
 		if warpnet.IsRelayMultiaddress(ma) {
 			relayState = warpnet.RelayStatusRunning
 		}
-		addresses = append(addresses, ma.String())
+		ranks = append(ranks, ranked{ma: ma, tier: tier, idx: i})
+	}
+	sort.SliceStable(ranks, func(i, j int) bool {
+		if ranks[i].tier != ranks[j].tier {
+			return ranks[i].tier < ranks[j].tier
+		}
+		return ranks[i].idx < ranks[j].idx
+	})
+	addresses := make([]string, 0, len(ranks))
+	for _, r := range ranks {
+		addresses = append(addresses, r.ma.String())
 	}
 
 	return warpnet.NodeInfo{

--- a/core/warpnet/warpnet.go
+++ b/core/warpnet/warpnet.go
@@ -460,6 +460,79 @@ func IsRelayMultiaddress(maddr multiaddr.Multiaddr) bool {
 	return strings.Contains(maddr.String(), "p2p-circuit")
 }
 
+// DialTier classifies a multiaddr by how preferable it is to dial.
+// Lower-numbered tiers are preferred; DialTierDrop means the address is
+// unreachable from a remote peer and should be filtered out entirely.
+type DialTier int
+
+const (
+	DialTierLAN DialTier = iota
+	DialTierPublicDirect
+	DialTierRelay
+	DialTierDrop
+)
+
+// ClassifyDialAddress decides whether a host-self multiaddr is worth
+// advertising to a paired thin client, and at what priority. The thin
+// client iterates candidate addresses in order and stops at the first
+// successful dial — without a sane priority order, an internet-routed
+// circuit-v2 relay address that succeeds in 200 ms always wins over a
+// LAN address that would have given a sub-millisecond direct path on
+// the same Wi-Fi, leaving every pairing routed through the public relay
+// even when both peers are on the same subnet.
+func ClassifyDialAddress(maddr WarpAddress) DialTier {
+	if IsRelayMultiaddress(maddr) {
+		return DialTierRelay
+	}
+	if ipStr, err := maddr.ValueForProtocol(P_IP4); err == nil {
+		return classifyIPv4Tier(gonet.ParseIP(ipStr))
+	}
+	if ipStr, err := maddr.ValueForProtocol(P_IP6); err == nil {
+		return classifyIPv6Tier(gonet.ParseIP(ipStr))
+	}
+	// DNS / wss / other non-ip transports — treat as public-direct;
+	// the thin client will resolve and decide.
+	return DialTierPublicDirect
+}
+
+func classifyIPv4Tier(ip gonet.IP) DialTier {
+	if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return DialTierDrop
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		// Docker default bridges live in 172.17/16 and 172.18/16 — they
+		// resolve as RFC1918, but only the container host can route to
+		// them. Drop them so phones don't burn a dial timeout on a
+		// hopeless address.
+		if ip4[0] == 172 && (ip4[1] == 17 || ip4[1] == 18) {
+			return DialTierDrop
+		}
+	}
+	for _, block := range privateBlocks {
+		_, cidr, _ := gonet.ParseCIDR(block)
+		if cidr != nil && cidr.Contains(ip) {
+			// privateBlocks includes 127/8 and 169.254/16 which we
+			// already filtered above; surviving entries are real
+			// RFC1918 / CG-NAT LAN ranges.
+			return DialTierLAN
+		}
+	}
+	return DialTierPublicDirect
+}
+
+func classifyIPv6Tier(ip gonet.IP) DialTier {
+	if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return DialTierDrop
+	}
+	// fc00::/7 — IPv6 unique local addresses; treat as LAN.
+	if len(ip) == 16 && (ip[0]&0xfe) == 0xfc {
+		return DialTierLAN
+	}
+	return DialTierPublicDirect
+}
+
 func IsNoAddressesError(err error) bool {
 	return errors.Is(err, routing.ErrNotFound)
 }

--- a/warpdroid/app/src/main/java/site/warpnet/warpdroid/WarpdroidApplication.kt
+++ b/warpdroid/app/src/main/java/site/warpnet/warpdroid/WarpdroidApplication.kt
@@ -153,21 +153,21 @@ class WarpdroidApplication :
         ProcessLifecycleOwner.get().lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
-                    transportScope.launch {
-                        warpnetClient.resume()
-                        // Polling has to come back after the host is
-                        // re-dialled or the very first poll observes
-                        // the still-Disconnected binding and triggers a
-                        // pointless reconnect race against resume().
-                        connectionMonitor.start()
-                    }
+                    // Run monitor.start() and resume() concurrently — the
+                    // older sequential code awaited resume() first, which
+                    // before the Go-side fix could block for tens of
+                    // seconds on a dead peer dial and leave the monitor
+                    // un-started long enough that a user came back to a
+                    // permanently-dead app (PR #184). The monitor is
+                    // idempotent and its first poll picks up the eventual
+                    // result of resume() either way.
+                    transportScope.launch { connectionMonitor.start() }
+                    transportScope.launch { warpnetClient.resume() }
                 }
 
                 override fun onStop(owner: LifecycleOwner) {
-                    transportScope.launch {
-                        connectionMonitor.stop()
-                        warpnetClient.pause()
-                    }
+                    transportScope.launch { connectionMonitor.stop() }
+                    transportScope.launch { warpnetClient.pause() }
                 }
             },
         )

--- a/warpdroid/app/src/main/java/site/warpnet/warpdroid/components/pairing/DialPriority.kt
+++ b/warpdroid/app/src/main/java/site/warpnet/warpdroid/components/pairing/DialPriority.kt
@@ -1,0 +1,99 @@
+/*
+ * Warpdroid - a Warpnet Android client.
+ * Copyright (C) 2026 Warpdroid contributors.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Defensive client-side classification of dial candidates. The fat node
+ * already sorts the addresses it puts into the pairing QR (core/node/
+ * node.go::BaseNodeInfo applies the same tiering server-side), but a
+ * phone may be paired against an older desktop build that didn't, so
+ * the thin client re-applies the filter+sort here and never trusts the
+ * QR's raw order. WarpnetClient.connectAny iterates in list order and
+ * stops at the first successful dial, so getting this wrong means the
+ * pairing routes through a public circuit-v2 relay on the same Wi-Fi
+ * where a LAN dial would have been sub-millisecond.
+ */
+package site.warpnet.warpdroid.components.pairing
+
+/**
+ * Drop multiaddrs that can never be dialed from the phone (loopback,
+ * link-local, docker bridges, IPv6 loopback) and stable-sort the rest
+ * so direct dials win before relayed ones:
+ *
+ *  1. RFC1918 / IPv6 ULA — preferred when phone is on the same network.
+ *  2. Public-direct IPv4/IPv6 — global address without `p2p-circuit`.
+ *  3. `…/p2p-circuit` — transit-bound, always reachable, slowest.
+ *
+ * Stability within a tier preserves the order the fat node advertised,
+ * which matters when a host has multiple interfaces on the same tier.
+ */
+fun prioritizeDialAddresses(raw: List<String>): List<String> {
+    val ranked = raw.mapIndexedNotNull { idx, addr ->
+        val tier = classify(addr)
+        if (tier == TIER_DROP) null else Triple(addr, tier, idx)
+    }
+    return ranked
+        .sortedWith(compareBy({ it.second }, { it.third }))
+        .map { it.first }
+}
+
+private const val TIER_LAN = 0
+private const val TIER_PUBLIC = 1
+private const val TIER_RELAY = 2
+private const val TIER_DROP = Int.MAX_VALUE
+
+private fun classify(maddr: String): Int {
+    if (maddr.contains("/p2p-circuit")) return TIER_RELAY
+    extractIPv4(maddr)?.let { return classifyIPv4(it) }
+    extractIPv6(maddr)?.let { return classifyIPv6(it) }
+    // dnsaddr / dns4 / dns6 — assume routable, defer to dial layer.
+    if (maddr.contains("/dns")) return TIER_PUBLIC
+    return TIER_DROP
+}
+
+private fun classifyIPv4(ip: String): Int {
+    val parts = ip.split('.').mapNotNull { it.toIntOrNull() }
+    if (parts.size != 4 || parts.any { it !in 0..255 }) return TIER_DROP
+    val (a, b) = parts[0] to parts[1]
+    return when {
+        a == 0 -> TIER_DROP
+        a == 127 -> TIER_DROP                    // loopback
+        a == 169 && b == 254 -> TIER_DROP        // link-local
+        a in 224..239 -> TIER_DROP               // multicast
+        a == 172 && b in 17..18 -> TIER_DROP     // docker default bridges
+        a == 10 -> TIER_LAN
+        a == 172 && b in 16..31 -> TIER_LAN
+        a == 192 && b == 168 -> TIER_LAN
+        a == 100 && b in 64..127 -> TIER_LAN     // CG-NAT (mobile hotspot)
+        else -> TIER_PUBLIC
+    }
+}
+
+private fun classifyIPv6(ip: String): Int {
+    val lower = ip.lowercase()
+    return when {
+        lower == "::" || lower == "::1" -> TIER_DROP
+        lower.startsWith("fe80:") -> TIER_DROP   // link-local
+        lower.startsWith("ff") -> TIER_DROP      // multicast
+        lower.startsWith("fc") || lower.startsWith("fd") -> TIER_LAN // ULA
+        else -> TIER_PUBLIC
+    }
+}
+
+private fun extractIPv4(maddr: String): String? {
+    val marker = "/ip4/"
+    val i = maddr.indexOf(marker)
+    if (i < 0) return null
+    val tail = maddr.substring(i + marker.length)
+    val end = tail.indexOf('/')
+    return if (end < 0) tail else tail.substring(0, end)
+}
+
+private fun extractIPv6(maddr: String): String? {
+    val marker = "/ip6/"
+    val i = maddr.indexOf(marker)
+    if (i < 0) return null
+    val tail = maddr.substring(i + marker.length)
+    val end = tail.indexOf('/')
+    return if (end < 0) tail else tail.substring(0, end)
+}

--- a/warpdroid/app/src/main/java/site/warpnet/warpdroid/components/pairing/PairingCoordinator.kt
+++ b/warpdroid/app/src/main/java/site/warpnet/warpdroid/components/pairing/PairingCoordinator.kt
@@ -44,7 +44,14 @@ class PairingCoordinator @Inject constructor(
         // Noise handshake verifies the remote peer ID matches what the QR
         // advertised. If they don't match, the dial fails before we open any
         // stream.
-        val candidates = paired.addresses.map { "$it/p2p/${paired.pinnedPeerId}" }
+        //
+        // Defensive filter+sort via [prioritizeDialAddresses]: even though
+        // the fat node sorts its self-addresses now, a phone may be paired
+        // against an older desktop build, and the raw QR order would put a
+        // circuit-v2 relay before the LAN multiaddr — connectAny stops at
+        // the first successful dial, so the relay would win every time.
+        val candidates = prioritizeDialAddresses(paired.addresses)
+            .map { "$it/p2p/${paired.pinnedPeerId}" }
         val bootstrap = paired.bootstrapAddrs.ifEmpty { candidates }
         // Seed the transport with the first syntactically-dialable candidate
         // rather than candidates.first(), which could still be an unusable

--- a/warpdroid/app/src/main/java/site/warpnet/warpdroid/di/WarpnetModule.kt
+++ b/warpdroid/app/src/main/java/site/warpnet/warpdroid/di/WarpnetModule.kt
@@ -93,7 +93,12 @@ object WarpnetModule {
         scope = scope,
         dialAddresses = {
             pairedNodeStore.load()?.let { paired ->
-                paired.addresses.map { "$it/p2p/${paired.pinnedPeerId}" }
+                // Apply the same defensive sort PairingCoordinator uses,
+                // so the post-disconnect reconnect path tries LAN before
+                // relay even if the saved address order is older.
+                site.warpnet.warpdroid.components.pairing.prioritizeDialAddresses(
+                    paired.addresses,
+                ).map { "$it/p2p/${paired.pinnedPeerId}" }
             } ?: emptyList()
         },
     )

--- a/warpdroid/node/mobile.go
+++ b/warpdroid/node/mobile.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Mobile-friendly wrapper types for gomobile compatibility
@@ -145,15 +146,37 @@ func Pause() {
 	}
 }
 
-// Resume foreground transition
+// Resume re-establishes the paired-desktop connection in the
+// background. The previous implementation walked every peer in the
+// peerstore and called host.Connect with context.Background() — no
+// timeout, no concurrency — so a single dead DHT peer would wedge the
+// whole resume for tens of seconds, and the Kotlin caller (which
+// awaits Resume before starting the ConnectionMonitor poll loop)
+// stayed blocked until the user force-killed the app. Target only the
+// paired desktop peer, run it on a fresh goroutine so the binding
+// returns immediately, and bound the dial with a context timeout so a
+// flaky NAT can never park the caller indefinitely. DHT bootstrap is
+// driven by its own internal refresh loop and doesn't need a manual
+// re-dial.
 func Resume() {
 	if clientInstance == nil || clientInstance.host == nil {
 		return
 	}
-	for _, id := range clientInstance.host.Peerstore().PeersWithAddrs() {
-		info := clientInstance.host.Peerstore().PeerInfo(id)
-		_ = clientInstance.host.Connect(context.Background(), info)
+	clientInstance.mu.RLock()
+	desktopID := clientInstance.desktopPeerID
+	clientInstance.mu.RUnlock()
+	if desktopID == "" {
+		return
 	}
+	go func() {
+		ctx, cancel := context.WithTimeout(clientInstance.ctx, 10*time.Second)
+		defer cancel()
+		info := clientInstance.host.Peerstore().PeerInfo(desktopID)
+		if len(info.Addrs) == 0 {
+			return
+		}
+		_ = clientInstance.host.Connect(ctx, info)
+	}()
 }
 
 func Shutdown() string {


### PR DESCRIPTION
## Summary

Two on-device bugs reported after #180.

### Bug 1 — pairing on the same Wi-Fi as the desktop always tunnels through the public relay

The desktop's `BaseNodeInfo()` emitted self-addresses in raw peerstore order: `p2p-circuit` relays first, then loopback, then docker bridges, then the LAN address. `WarpnetClient.connectAny` iterates in list order and stops at the first successful dial — so the public relay won every race, and every same-Wi-Fi pairing paid internet round-trip latency.

**Fix.** Classify and stable-sort by dial preference on both sides of the wire:

- `core/warpnet.ClassifyDialAddress` — new helper, four tiers: **LAN** (RFC1918 + IPv6 ULA + CG-NAT) > **public-direct** > **relay** > **drop** (loopback, link-local, multicast, docker default bridges `172.17/16` and `172.18/16`).
- `core/node/node.BaseNodeInfo` — applies the sort, drops `DialTierDrop`. The QR now leads with whatever's most likely to give a direct path.
- `warpdroid/components/pairing/DialPriority.kt` — Kotlin mirror used by `PairingCoordinator` and the `ConnectionMonitor` reconnect lambda. Defensive: a phone paired against an older desktop build still gets the right order even though the QR wasn't sorted.

### Bug 2 — connection drops after ~5 min and only force-restart recovers

`mobile.go::Resume` walked the **entire** peerstore (including DHT bootstrap entries) and called `host.Connect` on each with `context.Background()` — no timeout, no concurrency. A single unreachable peer wedged the binding call for the full libp2p dial budget. The Kotlin `onStart` handler awaited `Resume` before starting `ConnectionMonitor`, so when Resume hung the monitor never started and the user saw a permanently-dead app.

**Fix.** Two changes:

- `mobile.go::Resume` now targets only the paired desktop peer, fires the dial on a fresh goroutine, and bounds it with a 10-second context timeout. The binding returns immediately. DHT bootstrap is driven by its own internal refresh loop and doesn't need a manual re-dial.
- `WarpdroidApplication.onStart` launches `connectionMonitor.start()` and `warpnetClient.resume()` on **separate** coroutines (concurrent, no await order). The monitor is idempotent — its first poll picks up the eventual result of `Resume` either way, so a slow Resume can no longer prevent the reconnect loop from firing.

## Test

- `go test ./test/ ./core/... ./database/... -count=1` — all green.
- `go build -tags mobile ./warpdroid/node/` — clean.

## Files

| File | Change |
|---|---|
| `core/warpnet/warpnet.go` | `+ClassifyDialAddress` and `DialTier` enum |
| `core/node/node.go` | `BaseNodeInfo()` filters + stable-sorts |
| `warpdroid/node/mobile.go` | `Resume()` targets desktop only, async, with timeout |
| `warpdroid/.../components/pairing/DialPriority.kt` | new — Kotlin classifier |
| `warpdroid/.../components/pairing/PairingCoordinator.kt` | wires `prioritizeDialAddresses` |
| `warpdroid/.../di/WarpnetModule.kt` | reconnect lambda uses the same sort |
| `warpdroid/.../WarpdroidApplication.kt` | parallel `monitor.start` + `resume` |

Note: the .aar is regenerated separately by the maintainer — `warpdroid/node/build-native.sh` produces the file and the binary blob is committed alongside this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAfHMT5m2jLgvntmKnzfTf)_