### PR TITLE
Fix SelfStream silently swallowing stream read errors

### DIFF
--- a/core/node/node.go
+++ b/core/node/node.go
@@ -372,10 +372,20 @@ func (n *WarpNode) SelfStream(path stream.WarpRoute, data any) (_ []byte, err er
 	_ = streamClient.CloseWrite()
 
 	result, err := io.ReadAll(streamClient)
-	if err != nil && !errors.Is(err, io.EOF) && errors.Is(err, io.ErrClosedPipe) {
+	if !isBenignStreamCloseErr(err) {
 		return result, err
 	}
 	return result, nil
+}
+
+// isBenignStreamCloseErr reports whether err returned from reading a stream is a
+// normal end-of-stream signal rather than a real I/O failure. io.ReadAll never
+// surfaces io.EOF, but a loopback stream may return io.ErrClosedPipe once the
+// peer half is closed; in both cases the response has already been read in full.
+func isBenignStreamCloseErr(err error) bool {
+	return err == nil ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrClosedPipe)
 }
 
 const ErrSelfRequest = warpnet.WarpError("self request is not allowed")

--- a/core/node/node_test.go
+++ b/core/node/node_test.go
@@ -1,0 +1,59 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+)
+
+func TestIsBenignStreamCloseErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil means fully read", err: nil, want: true},
+		{name: "io.EOF is benign", err: io.EOF, want: true},
+		{name: "io.ErrClosedPipe is benign", err: io.ErrClosedPipe, want: true},
+		{name: "wrapped io.EOF is benign", err: fmt.Errorf("read: %w", io.EOF), want: true},
+		{name: "wrapped io.ErrClosedPipe is benign", err: fmt.Errorf("read: %w", io.ErrClosedPipe), want: true},
+		{name: "deadline exceeded is a real failure", err: context.DeadlineExceeded, want: false},
+		{name: "reset is a real failure", err: warpnet.WarpError("stream reset"), want: false},
+		{name: "unexpected EOF is a real failure", err: io.ErrUnexpectedEOF, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBenignStreamCloseErr(tt.err); got != tt.want {
+				t.Fatalf("isBenignStreamCloseErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `WarpNode.SelfStream` (`core/node/node.go`) discarded almost every read error after `io.ReadAll`. The guard returned the error only when it **was** `io.ErrClosedPipe`; every other failure (deadline exceeded, stream reset, connection drop) fell through and a partial/empty body was returned to the caller as a success.
- This is a plausible root cause for blank/empty responses seen on the desktop and Android clients ("blank rows", empty notifications).
- Fixed the predicate so a read error is returned unless it is a benign end-of-stream signal (`io.EOF` or `io.ErrClosedPipe`), and extracted the classification into `isBenignStreamCloseErr` so it is unit-testable without standing up a full libp2p host.

### Before
```go
result, err := io.ReadAll(streamClient)
if err != nil && !errors.Is(err, io.EOF) && errors.Is(err, io.ErrClosedPipe) {
    return result, err
}
return result, nil
```

### After
```go
result, err := io.ReadAll(streamClient)
if !isBenignStreamCloseErr(err) {
    return result, err
}
return result, nil
```

## Test plan
- [x] `go build ./core/node/...`
- [x] `go vet ./core/node/...`
- [x] `go test -short ./core/node/...` — new table test `TestIsBenignStreamCloseErr` covers nil / `io.EOF` / `io.ErrClosedPipe` / wrapped variants (benign) and deadline-exceeded / reset / unexpected-EOF (real failures).