### PR TITLE
Fix FixedBackoff growing exponentially in retrier

### DIFF
--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -102,7 +102,7 @@ func (r *retrier) Try(ctx context.Context, f RetrierFunc) (err error) {
 		case NoBackoff:
 
 		case FixedBackoff:
-			interval += interval
+			interval += r.minInterval
 		case ExponentialBackoff:
 			interval *= 2
 		}

--- a/retrier/retrier_test.go
+++ b/retrier/retrier_test.go
@@ -96,6 +96,31 @@ func TestTry_FixedBackoff(t *testing.T) {
 	assert.True(t, elapsed >= 20*time.Millisecond, "fixed backoff should add delay")
 }
 
+// TestTry_FixedBackoff_GrowsLinearlyNotExponentially guards against the
+// regression where FixedBackoff doubled the interval each attempt and was
+// therefore indistinguishable from ExponentialBackoff. With minInterval=10ms
+// and four failing attempts the linear schedule sleeps 20+30+40+50=140ms,
+// whereas the old doubling schedule slept 20+40+80+160=300ms.
+func TestTry_FixedBackoff_GrowsLinearlyNotExponentially(t *testing.T) {
+	const minInterval = 10 * time.Millisecond
+	r := New(minInterval, 8, FixedBackoff)
+	calls := 0
+	start := time.Now()
+	err := r.Try(context.Background(), func() error {
+		calls++
+		if calls < 5 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, calls)
+	assert.GreaterOrEqual(t, elapsed, 120*time.Millisecond, "linear backoff should accumulate ~140ms")
+	assert.Less(t, elapsed, 250*time.Millisecond, "exponential doubling (~300ms) must be excluded")
+}
+
 func TestTry_ExponentialBackoff(t *testing.T) {
 	r := New(10*time.Millisecond, 3, ExponentialBackoff)
 	calls := 0


### PR DESCRIPTION
## Summary
- `retrier.FixedBackoff` advanced the delay with `interval += interval`, i.e. it **doubled** every attempt — making it identical to `ExponentialBackoff`. The `interval` operand was almost certainly a typo for the fixed step `r.minInterval`.
- Real callers were affected: `cmd/node/member/node/member-node.go` constructs `retrier.New(time.Second, 5, retrier.FixedBackoff)` and was silently getting 1s, 2s, 4s, 8s, 16s instead of a fixed-step schedule.
- Fixed with `interval += r.minInterval` so the three modes are now distinct: `NoBackoff` constant, `FixedBackoff` linear (by `minInterval`), `ExponentialBackoff` doubling — mirroring the existing `interval *= 2`.

### Before / After
```go
case FixedBackoff:
-    interval += interval      // doubles -> same as ExponentialBackoff
+    interval += r.minInterval // fixed linear step
case ExponentialBackoff:
    interval *= 2
```

## Test plan
- [x] `go vet ./retrier/...`
- [x] `go test -short ./retrier/...`
- [x] New regression test `TestTry_FixedBackoff_GrowsLinearlyNotExponentially`: with `minInterval=10ms` and 4 failing attempts the linear schedule (~140ms) is asserted to stay under the previous doubling schedule (~300ms). The pre-fix code fails this test.