### PR TITLE
fix(ui): DM badge no longer double-counts in the notifications counter

### DIFF
--- a/frontend/src/components/SideNav.vue
+++ b/frontend/src/components/SideNav.vue
@@ -438,10 +438,7 @@ export default {
       this.newNotifications = Math.max(0, (resp.unread_count || 0) - unreadMessages);
     });
 
-    const resp = await warpnetService.getNotifications(true)
-    if (resp) {
-      this.newNotifications = resp.unread_count;
-    }
+    await warpnetService.getNotifications(true)
   },
   beforeUnmount() {
     if (this.unsubscribeNotifications) {


### PR DESCRIPTION
SideNav's bell badge was overwritten with the raw unread_count right after the subscribe callback set it to unread_count minus unread message notifications, so a new DM bumped both the bell and the DM badge. Drop the override; the subscribe callback owns both counters.