### PR TITLE
Make ActivityPub GatewayNodeID a configurable per-node setting

### DIFF
--- a/cmd/node/member/node/member-node.go
+++ b/cmd/node/member/node/member-node.go
@@ -101,6 +101,12 @@ func NewMemberNode(
 	deviceRepo := database.NewDevicesRepo(db)
 	owner := authRepo.GetOwner()
 
+	// Apply the owner's configured ActivityPub gateway id (empty falls back to
+	// the built-in default) before seeding the entry user and starting discovery.
+	if gw, err := database.NewSettingsRepo(db).GetGatewaySettings(owner.UserId); err == nil {
+		mastodon.SetGatewayNodeID(gw.NodeID)
+	}
+
 	// Seed the mastodon gateway user with a plain repo so it doesn't notify.
 	mastodon.SeedEntryUser(database.NewUserRepo(db))
 
@@ -620,6 +626,14 @@ func (m *MemberNode) settingsHandlers(authRepo AuthProvider, r *memberRepos) []w
 		{
 			event.PRIVATE_POST_NOTIFICATION_SETTINGS,
 			handler.StreamUpdateNotificationSettingsHandler(r.settingsRepo, authRepo),
+		},
+		{
+			event.PRIVATE_GET_GATEWAY_SETTINGS,
+			handler.StreamGetGatewaySettingsHandler(r.settingsRepo, authRepo),
+		},
+		{
+			event.PRIVATE_POST_GATEWAY_SETTINGS,
+			handler.StreamUpdateGatewaySettingsHandler(r.settingsRepo, authRepo),
 		},
 	}
 }

--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -304,7 +304,7 @@ func (s *discoveryService) handleAsMember(peer discoveredPeer) {
 	if info.IsRelay() {
 		return
 	}
-	if pi.ID.String() == mastodon.GatewayNodeID {
+	if pi.ID.String() == mastodon.GatewayNodeID() {
 		return
 	}
 

--- a/core/handler/settings.go
+++ b/core/handler/settings.go
@@ -28,6 +28,7 @@ resulting from the use or misuse of this software.
 package handler
 
 import (
+	"github.com/Warp-net/warpnet/core/mastodon"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/domain"
 	"github.com/Warp-net/warpnet/event"
@@ -38,6 +39,12 @@ import (
 type SettingsStorer interface {
 	GetNotificationSettings(userId string) (domain.NotificationSettings, error)
 	SetNotificationSettings(userId string, s domain.NotificationSettings) error
+}
+
+// GatewaySettingsStorer is the narrow surface the gateway-settings handlers need.
+type GatewaySettingsStorer interface {
+	GetGatewaySettings(userId string) (domain.GatewaySettings, error)
+	SetGatewaySettings(userId string, s domain.GatewaySettings) error
 }
 
 // SettingsAuthStorer resolves the local node owner.
@@ -76,5 +83,45 @@ func StreamUpdateNotificationSettingsHandler(
 			return nil, err
 		}
 		return event.GetNotificationSettingsResponse(ev), nil
+	}
+}
+
+func StreamGetGatewaySettingsHandler(
+	repo GatewaySettingsStorer,
+	authRepo SettingsAuthStorer,
+) warpnet.WarpHandlerFunc {
+	return func(buf []byte, s warpnet.WarpStream) (any, error) {
+		owner := authRepo.GetOwner()
+		settings, err := repo.GetGatewaySettings(owner.UserId)
+		if err != nil {
+			return nil, err
+		}
+		if settings.NodeID == "" {
+			settings.NodeID = mastodon.DefaultGatewayNodeID
+		}
+		return event.GetGatewaySettingsResponse(settings), nil
+	}
+}
+
+func StreamUpdateGatewaySettingsHandler(
+	repo GatewaySettingsStorer,
+	authRepo SettingsAuthStorer,
+) warpnet.WarpHandlerFunc {
+	return func(buf []byte, s warpnet.WarpStream) (any, error) {
+		var ev event.UpdateGatewaySettingsEvent
+		if err := json.Unmarshal(buf, &ev); err != nil {
+			return nil, err
+		}
+		owner := authRepo.GetOwner()
+		if owner.UserId == "" {
+			return nil, warpnet.WarpError("update gateway settings: empty owner")
+		}
+		if ev.NodeID == "" {
+			ev.NodeID = mastodon.DefaultGatewayNodeID
+		}
+		if err := repo.SetGatewaySettings(owner.UserId, ev); err != nil {
+			return nil, err
+		}
+		return event.GetGatewaySettingsResponse(ev), nil
 	}
 }

--- a/core/handler/settings_test.go
+++ b/core/handler/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Warp-net/warpnet/core/mastodon"
 	"github.com/Warp-net/warpnet/domain"
 	"github.com/Warp-net/warpnet/event"
 )
@@ -108,6 +109,129 @@ func TestStreamUpdateNotificationSettingsHandler(t *testing.T) {
 			setFn: func(string, domain.NotificationSettings) error { return repoErr },
 		}, stubAuth{owner: domain.Owner{UserId: owner}})
 		if _, err := h(marshal(t, event.UpdateNotificationSettingsEvent{}), nil); !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error, got %v", err)
+		}
+	})
+}
+
+type stubGatewayRepo struct {
+	getFn func(userId string) (domain.GatewaySettings, error)
+	setFn func(userId string, s domain.GatewaySettings) error
+}
+
+func (s stubGatewayRepo) GetGatewaySettings(userId string) (domain.GatewaySettings, error) {
+	if s.getFn != nil {
+		return s.getFn(userId)
+	}
+	return domain.GatewaySettings{}, nil
+}
+
+func (s stubGatewayRepo) SetGatewaySettings(userId string, gs domain.GatewaySettings) error {
+	if s.setFn != nil {
+		return s.setFn(userId, gs)
+	}
+	return nil
+}
+
+func TestStreamGetGatewaySettingsHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("returns saved node id", func(t *testing.T) {
+		h := StreamGetGatewaySettingsHandler(stubGatewayRepo{
+			getFn: func(string) (domain.GatewaySettings, error) {
+				return domain.GatewaySettings{NodeID: "12D3KooWCustom"}, nil
+			},
+		}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h([]byte("{}"), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.GetGatewaySettingsResponse).NodeID != "12D3KooWCustom" {
+			t.Fatalf("unexpected settings: %+v", resp)
+		}
+	})
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		h := StreamGetGatewaySettingsHandler(stubGatewayRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h([]byte("{}"), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.GetGatewaySettingsResponse).NodeID != mastodon.DefaultGatewayNodeID {
+			t.Fatalf("expected default node id, got %+v", resp)
+		}
+	})
+
+	t.Run("repo error", func(t *testing.T) {
+		repoErr := errors.New("db failed")
+		h := StreamGetGatewaySettingsHandler(stubGatewayRepo{
+			getFn: func(string) (domain.GatewaySettings, error) { return domain.GatewaySettings{}, repoErr },
+		}, stubAuth{owner: domain.Owner{UserId: owner}})
+		if _, err := h([]byte("{}"), nil); !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error, got %v", err)
+		}
+	})
+}
+
+func TestStreamUpdateGatewaySettingsHandler(t *testing.T) {
+	owner := "owner-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamUpdateGatewaySettingsHandler(stubGatewayRepo{}, stubAuth{owner: domain.Owner{UserId: owner}})
+		if _, err := h([]byte("{"), nil); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty owner", func(t *testing.T) {
+		h := StreamUpdateGatewaySettingsHandler(stubGatewayRepo{}, stubAuth{owner: domain.Owner{}})
+		if _, err := h(marshal(t, event.UpdateGatewaySettingsEvent{NodeID: "x"}), nil); err == nil {
+			t.Fatal("expected empty-owner error")
+		}
+	})
+
+	t.Run("persists and echoes node id", func(t *testing.T) {
+		var saved domain.GatewaySettings
+		h := StreamUpdateGatewaySettingsHandler(stubGatewayRepo{
+			setFn: func(userId string, gs domain.GatewaySettings) error {
+				if userId != owner {
+					t.Fatalf("expected owner id %q, got %q", owner, userId)
+				}
+				saved = gs
+				return nil
+			},
+		}, stubAuth{owner: domain.Owner{UserId: owner}})
+		resp, err := h(marshal(t, event.UpdateGatewaySettingsEvent{NodeID: "12D3KooWCustom"}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if saved.NodeID != "12D3KooWCustom" {
+			t.Fatalf("unexpected saved: %+v", saved)
+		}
+		if resp.(event.GetGatewaySettingsResponse).NodeID != "12D3KooWCustom" {
+			t.Fatalf("expected echoed settings, got %+v", resp)
+		}
+	})
+
+	t.Run("empty node id falls back to default", func(t *testing.T) {
+		var saved domain.GatewaySettings
+		h := StreamUpdateGatewaySettingsHandler(stubGatewayRepo{
+			setFn: func(_ string, gs domain.GatewaySettings) error { saved = gs; return nil },
+		}, stubAuth{owner: domain.Owner{UserId: owner}})
+		if _, err := h(marshal(t, event.UpdateGatewaySettingsEvent{NodeID: ""}), nil); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if saved.NodeID != mastodon.DefaultGatewayNodeID {
+			t.Fatalf("expected default node id persisted, got %+v", saved)
+		}
+	})
+
+	t.Run("repo error surfaces", func(t *testing.T) {
+		repoErr := errors.New("db failed")
+		h := StreamUpdateGatewaySettingsHandler(stubGatewayRepo{
+			setFn: func(string, domain.GatewaySettings) error { return repoErr },
+		}, stubAuth{owner: domain.Owner{UserId: owner}})
+		if _, err := h(marshal(t, event.UpdateGatewaySettingsEvent{NodeID: "x"}), nil); !errors.Is(err, repoErr) {
 			t.Fatalf("expected repo error, got %v", err)
 		}
 	})

--- a/core/mastodon/mastodon.go
+++ b/core/mastodon/mastodon.go
@@ -37,15 +37,34 @@ const (
 	// Network is the User.Network tag for accounts bridged in from Mastodon.
 	Network = "mastodon"
 
-	// GatewayNodeID is the libp2p peer id of the ActivityPub gateway,
+	// DefaultGatewayNodeID is the libp2p peer id of the ActivityPub gateway,
 	// deterministically derived from its fixed seed. It is the home node of
-	// every bridged Mastodon user.
-	GatewayNodeID = "12D3KooWRyHvpYFjCzorxuSyXFigPfhYaHh1GW1JmwQJSPdmj4JK"
+	// every bridged Mastodon user, and the fallback when the owner has not
+	// configured a different gateway in settings.
+	DefaultGatewayNodeID = "12D3KooWRyHvpYFjCzorxuSyXFigPfhYaHh1GW1JmwQJSPdmj4JK"
 
 	// EntryHandle is the single Mastodon account seeded locally as the entry
 	// point into the Fediverse; its followings lead to other Mastodon accounts.
 	EntryHandle = "warpnet@mastodon.social"
 )
+
+// gatewayNodeID is the effective gateway peer id. It defaults to
+// DefaultGatewayNodeID and is overridden once at node startup from the owner's
+// settings (see SetGatewayNodeID); it is not mutated afterwards.
+var gatewayNodeID = DefaultGatewayNodeID
+
+// GatewayNodeID returns the effective ActivityPub gateway peer id.
+func GatewayNodeID() string { return gatewayNodeID }
+
+// SetGatewayNodeID overrides the effective gateway peer id from the owner's
+// settings. Called once at startup, before seeding and discovery; an empty id
+// is ignored so DefaultGatewayNodeID stands.
+func SetGatewayNodeID(id string) {
+	if id == "" {
+		return
+	}
+	gatewayNodeID = id
+}
 
 // UserSeeder is the subset of the user repository the seeding needs.
 type UserSeeder interface {
@@ -59,7 +78,7 @@ func SeedEntryUser(repo UserSeeder) {
 	u := domain.User{
 		Id:       EntryHandle,
 		Username: "Warpnet",
-		NodeId:   GatewayNodeID,
+		NodeId:   gatewayNodeID,
 		Network:  Network,
 	}
 	if _, err := repo.Create(u); err != nil {

--- a/database/settings-repo.go
+++ b/database/settings-repo.go
@@ -53,6 +53,13 @@ func settingsKey(userId string) local_store.DatabaseKey {
 		Build()
 }
 
+func gatewaySettingsKey(userId string) local_store.DatabaseKey {
+	return local_store.NewPrefixBuilder(SettingsRepoName).
+		AddRootID(userId).
+		AddParentId("gateway").
+		Build()
+}
+
 // GetNotificationSettings returns the user's notification settings, or a
 // zero-value (email disabled) record when none has been saved yet.
 func (repo *SettingsRepo) GetNotificationSettings(userId string) (domain.NotificationSettings, error) {
@@ -96,6 +103,54 @@ func (repo *SettingsRepo) SetNotificationSettings(userId string, s domain.Notifi
 	}
 	defer txn.Rollback()
 	if err := txn.Set(settingsKey(userId), bt); err != nil {
+		return err
+	}
+	return txn.Commit()
+}
+
+// GetGatewaySettings returns the user's gateway settings, or a zero-value
+// (empty NodeID) record when none has been saved yet.
+func (repo *SettingsRepo) GetGatewaySettings(userId string) (domain.GatewaySettings, error) {
+	if userId == "" {
+		return domain.GatewaySettings{}, local_store.DBError("empty user id")
+	}
+	txn, err := repo.db.NewTxn()
+	if err != nil {
+		return domain.GatewaySettings{}, err
+	}
+	defer txn.Rollback()
+	bt, err := txn.Get(gatewaySettingsKey(userId))
+	if local_store.IsNotFoundError(err) {
+		return domain.GatewaySettings{}, nil
+	}
+	if err != nil {
+		return domain.GatewaySettings{}, err
+	}
+	if err := txn.Commit(); err != nil {
+		return domain.GatewaySettings{}, err
+	}
+	var s domain.GatewaySettings
+	if err := json.Unmarshal(bt, &s); err != nil {
+		return domain.GatewaySettings{}, err
+	}
+	return s, nil
+}
+
+// SetGatewaySettings persists the user's gateway settings.
+func (repo *SettingsRepo) SetGatewaySettings(userId string, s domain.GatewaySettings) error {
+	if userId == "" {
+		return local_store.DBError("empty user id")
+	}
+	bt, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	txn, err := repo.db.NewTxn()
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+	if err := txn.Set(gatewaySettingsKey(userId), bt); err != nil {
 		return err
 	}
 	return txn.Commit()

--- a/database/settings-repo_test.go
+++ b/database/settings-repo_test.go
@@ -72,6 +72,34 @@ func (s *SettingsRepoTestSuite) TestEmptyUserId() {
 	s.Error(s.repo.SetNotificationSettings("", domain.NotificationSettings{}))
 }
 
+func (s *SettingsRepoTestSuite) TestGatewayDefaultsWhenUnset() {
+	user := uuid.New().String()
+	got, err := s.repo.GetGatewaySettings(user)
+	s.Require().NoError(err)
+	s.Empty(got.NodeID)
+}
+
+func (s *SettingsRepoTestSuite) TestGatewaySetGet() {
+	user := uuid.New().String()
+	want := domain.GatewaySettings{NodeID: "12D3KooWCustomGateway"}
+	s.Require().NoError(s.repo.SetGatewaySettings(user, want))
+
+	got, err := s.repo.GetGatewaySettings(user)
+	s.Require().NoError(err)
+	s.Equal(want.NodeID, got.NodeID)
+
+	// Gateway settings must not collide with notification settings for the same user.
+	ns, err := s.repo.GetNotificationSettings(user)
+	s.Require().NoError(err)
+	s.False(ns.EmailEnabled)
+}
+
+func (s *SettingsRepoTestSuite) TestGatewayEmptyUserId() {
+	_, err := s.repo.GetGatewaySettings("")
+	s.Error(err)
+	s.Error(s.repo.SetGatewaySettings("", domain.GatewaySettings{}))
+}
+
 func TestSettingsRepoTestSuite(t *testing.T) {
 	suite.Run(t, new(SettingsRepoTestSuite))
 }

--- a/domain/warpnet.go
+++ b/domain/warpnet.go
@@ -354,6 +354,12 @@ type NotificationSettings struct {
 	Types map[NotificationType]bool `json:"types"`
 }
 
+// GatewaySettings holds the ActivityPub gateway peer id this node bridges
+// through. An empty NodeID means "use the built-in default".
+type GatewaySettings struct {
+	NodeID string `json:"node_id"`
+}
+
 type ModerationResult bool
 
 const (

--- a/event/event.go
+++ b/event/event.go
@@ -532,6 +532,16 @@ type GetNotificationSettingsResponse = domain.NotificationSettings
 // UpdateNotificationSettingsEvent defines model for UpdateNotificationSettingsEvent.
 type UpdateNotificationSettingsEvent = domain.NotificationSettings
 
+// GetGatewaySettingsEvent defines model for GetGatewaySettingsEvent.
+// The owner is resolved server-side, so the request carries no fields.
+type GetGatewaySettingsEvent struct{}
+
+// GetGatewaySettingsResponse defines model for GetGatewaySettingsResponse.
+type GetGatewaySettingsResponse = domain.GatewaySettings
+
+// UpdateGatewaySettingsEvent defines model for UpdateGatewaySettingsEvent.
+type UpdateGatewaySettingsEvent = domain.GatewaySettings
+
 // BookmarkEvent defines model for BookmarkEvent.
 type BookmarkEvent struct {
 	UserId      domain.ID `json:"user_id"`

--- a/event/paths.go
+++ b/event/paths.go
@@ -48,6 +48,8 @@ const (
 	PRIVATE_POST_NOTIFICATIONS_READ    = "/private/post/notifications/read/0.0.0"
 	PRIVATE_GET_NOTIFICATION_SETTINGS  = "/private/get/notification/settings/0.0.0"
 	PRIVATE_POST_NOTIFICATION_SETTINGS = "/private/post/notification/settings/0.0.0"
+	PRIVATE_GET_GATEWAY_SETTINGS       = "/private/get/gateway/settings/0.0.0"
+	PRIVATE_POST_GATEWAY_SETTINGS      = "/private/post/gateway/settings/0.0.0"
 	PRIVATE_GET_MESSAGE                = "/private/get/message/0.0.0"
 	PRIVATE_GET_MESSAGES               = "/private/get/messages/0.0.0"
 	PRIVATE_GET_TIMELINE               = "/private/get/timeline/0.0.0"

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -185,6 +185,13 @@ const routes = [
     meta: { protected: true },
   },
   {
+    path: "/settings/gateway",
+    name: "SettingsGateway",
+    component: () =>
+      import(/* webpackChunkName: "settings-gateway" */ "../views/Settings/Gateway.vue"),
+    meta: { protected: true },
+  },
+  {
     path: "/who-to-follow",
     name: "WhoToFollow",
     component: () =>

--- a/frontend/src/service/service.js
+++ b/frontend/src/service/service.js
@@ -37,6 +37,8 @@ export const PRIVATE_POST_NOTIFICATION_READ = "/private/post/notification/read/0
 export const PRIVATE_POST_NOTIFICATIONS_READ = "/private/post/notifications/read/0.0.0"
 export const PRIVATE_GET_NOTIFICATION_SETTINGS = "/private/get/notification/settings/0.0.0"
 export const PRIVATE_POST_NOTIFICATION_SETTINGS = "/private/post/notification/settings/0.0.0"
+export const PRIVATE_GET_GATEWAY_SETTINGS = "/private/get/gateway/settings/0.0.0"
+export const PRIVATE_POST_GATEWAY_SETTINGS = "/private/post/gateway/settings/0.0.0"
 export const PRIVATE_POST_BOOKMARK = "/private/post/bookmark/0.0.0"
 export const PRIVATE_POST_UNBOOKMARK = "/private/post/unbookmark/0.0.0"
 export const PRIVATE_GET_BOOKMARKS = "/private/get/bookmarks/0.0.0"
@@ -934,6 +936,29 @@ export const warpnetService = {
         });
         if (!resp || resp.code || !('email_enabled' in resp)) {
             throw new Error(resp?.message || 'Failed to save notification settings');
+        }
+        return resp;
+    },
+
+    // getGatewaySettings returns the node's ActivityPub gateway settings; the
+    // node fills node_id with the built-in default when nothing is stored yet.
+    async getGatewaySettings() {
+        const resp = await this.sendToNode({
+            path: PRIVATE_GET_GATEWAY_SETTINGS,
+            body: {},
+        });
+        return resp || {};
+    },
+
+    // updateGatewaySettings persists the gateway node id and confirms the node
+    // echoed it back. An empty id makes the node fall back to its default.
+    async updateGatewaySettings(nodeId) {
+        const resp = await this.sendToNode({
+            path: PRIVATE_POST_GATEWAY_SETTINGS,
+            body: { node_id: (nodeId || '').trim() },
+        });
+        if (!resp || resp.code || !('node_id' in resp)) {
+            throw new Error(resp?.message || 'Failed to save gateway settings');
         }
         return resp;
     },

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -70,6 +70,7 @@ export default {
         { name: 'SettingsMutes', label: 'Muted users', hint: 'Users you have muted', icon: 'fas fa-volume-mute' },
         { name: 'SettingsFilters', label: 'Filters', hint: 'Hide tweets matching keywords', icon: 'fas fa-filter' },
         { name: 'SettingsNotifications', label: 'Email notifications', hint: 'Send notifications to your email', icon: 'fas fa-envelope' },
+        { name: 'SettingsGateway', label: 'Fediverse gateway', hint: 'ActivityPub gateway node id', icon: 'fas fa-network-wired' },
       ],
     };
   },

--- a/frontend/src/views/Settings/Gateway.vue
+++ b/frontend/src/views/Settings/Gateway.vue
@@ -1,0 +1,129 @@
+<!-- Warpnet - Decentralized Social Network -->
+<template>
+  <div id="app" class="flex container h-screen w-full">
+    <SideNav />
+    <div class="w-full h-full overflow-y-scroll no-scrollbar">
+      <div class="px-5 py-3 border-b border-lighter flex items-center">
+        <button
+          @click="$router.push({ name: 'Settings' })"
+          class="rounded-full md:pr-2 focus:outline-none hover:bg-lightblue"
+          aria-label="Back"
+        >
+          <i class="fas fa-arrow-left text-blue"></i>
+        </button>
+        <h1 class="text-xl font-bold ml-4">Fediverse gateway</h1>
+      </div>
+
+      <Loader :loading="loading" />
+
+      <form v-if="!loading" @submit.prevent="save" class="p-5 space-y-4 max-w-xl">
+        <p class="text-sm text-dark">
+          Bridged Mastodon accounts resolve through the ActivityPub gateway node.
+          Change its peer id only if you run your own gateway. Changes take effect
+          after the node restarts.
+        </p>
+
+        <label class="block">
+          <span class="font-bold">Gateway node id</span>
+          <input
+            type="text"
+            v-model="nodeId"
+            spellcheck="false"
+            autocomplete="off"
+            placeholder="12D3Koo…"
+            class="mt-1 w-full rounded border border-lighter bg-white p-2 font-mono text-sm"
+          />
+        </label>
+
+        <p class="text-sm text-dark">
+          Default:
+          <button
+            type="button"
+            @click="nodeId = DEFAULT_GATEWAY_NODE_ID"
+            class="font-mono text-blue hover:underline break-all"
+          >{{ DEFAULT_GATEWAY_NODE_ID }}</button>
+        </p>
+
+        <button
+          type="submit"
+          :disabled="saving"
+          class="text-white bg-blue rounded-full font-semibold px-5 py-2 hover:bg-darkblue disabled:opacity-50"
+        >
+          {{ saving ? 'Saving…' : 'Save' }}
+        </button>
+        <p v-if="savedMessage" class="text-sm font-medium" :class="saveError ? 'text-red-600' : 'text-green-700'">
+          <i :class="saveError ? 'fas fa-exclamation-circle' : 'fas fa-check-circle'" aria-hidden="true"></i>
+          {{ savedMessage }}
+        </p>
+      </form>
+    </div>
+    <DefaultRightBar :profile="ownerProfile" />
+  </div>
+</template>
+
+<script>
+import {defineAsyncComponent} from "vue";
+import {warpnetService} from "@/service/service";
+import {toast} from "@/lib/toast";
+
+// Mirror of mastodon.DefaultGatewayNodeID; used as the reset value and as a
+// fallback if the node response omits node_id.
+const DEFAULT_GATEWAY_NODE_ID = "12D3KooWRyHvpYFjCzorxuSyXFigPfhYaHh1GW1JmwQJSPdmj4JK";
+
+export default {
+  name: "SettingsGateway",
+  components: {
+    SideNav: defineAsyncComponent(() => import('@/components/SideNav.vue')),
+    DefaultRightBar: defineAsyncComponent(() => import('@/components/DefaultRightBar.vue')),
+    Loader: defineAsyncComponent(() => import('@/components/Loader.vue')),
+  },
+  data() {
+    return {
+      loading: true,
+      saving: false,
+      savedMessage: '',
+      saveError: false,
+      ownerProfile: {},
+      nodeId: DEFAULT_GATEWAY_NODE_ID,
+      DEFAULT_GATEWAY_NODE_ID,
+    };
+  },
+  methods: {
+    async save() {
+      this.saving = true;
+      this.savedMessage = '';
+      this.saveError = false;
+      try {
+        const resp = await warpnetService.updateGatewaySettings(this.nodeId);
+        this.nodeId = resp.node_id || DEFAULT_GATEWAY_NODE_ID;
+        this.savedMessage = 'Settings saved';
+      } catch (err) {
+        console.error('Failed to save gateway settings:', err);
+        this.savedMessage = 'Failed to save';
+        this.saveError = true;
+        toast.error(err?.message || 'Failed to save gateway settings.');
+      } finally {
+        this.saving = false;
+        if (this._savedTimer) clearTimeout(this._savedTimer);
+        this._savedTimer = setTimeout(() => { this.savedMessage = ''; }, 3000);
+      }
+    },
+  },
+  beforeUnmount() {
+    if (this._savedTimer) clearTimeout(this._savedTimer);
+  },
+  async created() {
+    this.ownerProfile = warpnetService.getOwnerProfile();
+    try {
+      const saved = await warpnetService.getGatewaySettings();
+      if (saved && typeof saved === 'object' && saved.node_id) {
+        this.nodeId = saved.node_id;
+      }
+    } catch (err) {
+      console.error('Failed to load gateway settings:', err);
+    } finally {
+      this.loading = false;
+    }
+  },
+};
+</script>


### PR DESCRIPTION
Move the hardcoded mastodon.GatewayNodeID const into a settings-managed value (default = the built-in id). Add get/update gateway-settings handlers mirroring the notification-settings pattern, persist per-owner, and apply the configured id once at startup to drive both entry-user seeding and the discovery skip-check. Add a Vue "Fediverse gateway" settings page to view/change it.