### PR TITLE
Add granular NAT traversal logging

### DIFF
--- a/core/node/holepunch.go
+++ b/core/node/holepunch.go
@@ -1,0 +1,144 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+package node
+
+import (
+	"strings"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
+	log "github.com/sirupsen/logrus"
+)
+
+// NAT traversal is the one subsystem whose failures are invisible from the
+// outside: a node that never punches keeps working, just permanently through a
+// relay. These two hooks report DCUtR progress and the relay/direct state of
+// every connection, so that traversal can be diagnosed without turning on
+// libp2p's global debug logging.
+
+// shortID trims a peer ID to its last 6 characters, matching the node event log.
+func shortID(id warpnet.WarpPeerID) string {
+	s := id.String()
+	if len(s) <= 6 {
+		return s
+	}
+	return "..." + s[len(s)-6:]
+}
+
+// holePunchTracer reports every step of the DCUtR exchange. Outcomes are logged
+// at info, individual attempts at debug: a punch normally takes up to three
+// attempts, and only the outcome is interesting once it works.
+type holePunchTracer struct{}
+
+func (holePunchTracer) Trace(evt *holepunch.Event) {
+	if evt == nil {
+		return
+	}
+	peer := shortID(evt.Remote)
+
+	switch e := evt.Evt.(type) {
+	case *holepunch.StartHolePunchEvt:
+		log.Infof(
+			"holepunch: start: peer %s, rtt %s, their addresses %s",
+			peer, e.RTT, strings.Join(e.RemoteAddrs, " "),
+		)
+	case *holepunch.HolePunchAttemptEvt:
+		log.Debugf("holepunch: attempt %d: peer %s", e.Attempt, peer)
+	case *holepunch.EndHolePunchEvt:
+		if e.Success {
+			log.Infof("holepunch: success: peer %s, took %s", peer, e.EllapsedTime)
+			return
+		}
+		log.Warnf("holepunch: failed: peer %s, took %s, reason: %s", peer, e.EllapsedTime, e.Error)
+	case *holepunch.DirectDialEvt:
+		// A successful direct dial means the peer was reachable without any
+		// punching, so DCUtR stops there.
+		if e.Success {
+			log.Infof("holepunch: direct dial succeeded, no punch needed: peer %s, took %s", peer, e.EllapsedTime)
+			return
+		}
+		log.Debugf("holepunch: direct dial failed, punching: peer %s, took %s", peer, e.EllapsedTime)
+	case *holepunch.ProtocolErrorEvt:
+		log.Warnf("holepunch: protocol error: peer %s, reason: %s", peer, e.Error)
+	}
+}
+
+// connTracer logs how we are connected to a peer rather than merely that we are.
+// Only relay usage and relay-to-direct upgrades reach info level; the rest is
+// debug, because a busy node opens connections constantly.
+type connTracer struct{}
+
+func (connTracer) Listen(network.Network, warpnet.WarpAddress)      {}
+func (connTracer) ListenClose(network.Network, warpnet.WarpAddress) {}
+
+func (connTracer) Connected(n network.Network, c network.Conn) {
+	if c == nil {
+		return
+	}
+	peer := shortID(c.RemotePeer())
+	addr := c.RemoteMultiaddr()
+
+	if isRelayed(c) {
+		log.Infof("holepunch: connected through a relay: peer %s, address %s", peer, addr)
+		return
+	}
+
+	// A direct connection that appears while a relayed one is still open is a
+	// completed traversal: this is the line to grep for when asking whether
+	// hole punching works in the wild.
+	for _, other := range n.ConnsToPeer(c.RemotePeer()) {
+		if other != c && isRelayed(other) {
+			log.Infof("holepunch: upgraded relay to direct: peer %s, address %s", peer, addr)
+			return
+		}
+	}
+	log.Debugf("holepunch: connected directly: peer %s, address %s", peer, addr)
+}
+
+func (connTracer) Disconnected(n network.Network, c network.Conn) {
+	if c == nil {
+		return
+	}
+	if !isRelayed(c) {
+		log.Debugf("holepunch: direct connection closed: peer %s", shortID(c.RemotePeer()))
+		return
+	}
+	// libp2p drops the relayed connection once a punch succeeds. Seeing the
+	// direct one outlive it is the confirmation that the upgrade stuck. The
+	// opposite case is not reported: at shutdown every connection closes, so an
+	// empty connection set says nothing about traversal.
+	for _, other := range n.ConnsToPeer(c.RemotePeer()) {
+		if other != c && !isRelayed(other) {
+			log.Infof("holepunch: relayed connection closed, staying direct: peer %s", shortID(c.RemotePeer()))
+			return
+		}
+	}
+	log.Debugf("holepunch: relayed connection closed: peer %s", shortID(c.RemotePeer()))
+}
+
+func isRelayed(c network.Conn) bool {
+	return c.Stat().Limited || warpnet.IsRelayMultiaddress(c.RemoteMultiaddr())
+}

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -130,6 +130,8 @@ func NewWarpNode(
 		return nil, fmt.Errorf("node: failed to init node: %w", err)
 	}
 
+	node.Network().Notify(connTracer{})
+
 	pool, err := stream.NewStreamPool(ctx, node)
 	if err != nil {
 		return nil, err

--- a/core/node/options.go
+++ b/core/node/options.go
@@ -40,6 +40,7 @@ import (
 	libp2pConfig "github.com/libp2p/go-libp2p/config"
 	p2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -59,7 +60,7 @@ var CommonOptions = []libp2p.Option{
 	libp2p.EnableAutoNATv2(),
 	libp2p.EnableRelay(),
 	libp2p.EnableRelayService(relay.WithDefaultResources()), // for member nodes that have static IP
-	libp2p.EnableHolePunching(),
+	libp2p.EnableHolePunching(holepunch.WithTracer(holePunchTracer{})),
 	libp2p.EnableNATService(),
 	libp2p.NATPortMap(),
 }


### PR DESCRIPTION
NAT traversal is the one subsystem whose failure is invisible from the outside: a node that never punches keeps working, just permanently through a relay. Nothing reported DCUtR progress, so answering "does hole punching work in the wild" required turning on libp2p's global debug logging.

Add two narrow hooks in core/node:

  - holePunchTracer, wired into CommonOptions via holepunch.WithTracer, logs the DCUtR exchange: start with the peer's candidate addresses and RTT, outcome with elapsed time, protocol errors, and whether a plain direct dial made punching unnecessary.
  - connTracer, a network.Notifiee registered in NewWarpNode, logs how we are connected rather than merely that we are: relay usage, relay-to-direct upgrades, and a relayed connection closing while the direct one survives.

Outcomes are info, per-attempt detail is debug, failures are warnings, so the default log level stays readable. A successful traversal reads as four lines, and a public node such as a relay stays silent.

Verified against the deploy/natlab harness: both NATed peers logged start, upgraded relay to direct, and success, while the public relay logged nothing.