### PR TITLE
Add end-to-end NAT hole punch harness

### DIFF
--- a/deploy/natlab/Dockerfile
+++ b/deploy/natlab/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.26
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      iproute2 iptables iputils-ping \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /warpnet
+WORKDIR /warpnet
+
+ENV CGO_ENABLED=0
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build -mod=vendor -o /usr/local/bin/natlab ./deploy/natlab
+
+RUN cp /warpnet/deploy/natlab/topology.sh /usr/local/bin/topology.sh \
+    && chmod +x /usr/local/bin/topology.sh
+
+ENTRYPOINT ["/usr/local/bin/topology.sh"]

--- a/deploy/natlab/README.md
+++ b/deploy/natlab/README.md
@@ -1,0 +1,90 @@
+# natlab — end-to-end NAT hole punch harness
+
+Runs a real Warpnet hole punch between two peers sitting behind two independent
+`MASQUERADE` NATs. No second machine and no `sudo`: the whole topology lives in
+the network namespace of one privileged container, and `--network none` keeps it
+off every real network, so it can never reach mainnet or testnet.
+
+```sh
+./deploy/natlab/run.sh                  # build image + run the lab
+FORCE_PRIVATE=1 ./deploy/natlab/run.sh  # skip AutoNAT reachability probing
+```
+
+## Topology
+
+```
+root ns of the container = "the internet"
+  bridge inet 11.0.0.0/24
+  ├── relay          11.0.0.1     public: circuit relay + AutoNAT server + observer
+  ├── [ns rtr-a] wan 11.0.0.11    MASQUERADE, lan 10.1.0.1/24
+  │        └── [ns host-a] 10.1.0.2  peer A — dials B over the circuit
+  └── [ns rtr-b] wan 11.0.0.12    MASQUERADE, lan 10.2.0.1/24
+           └── [ns host-b] 10.2.0.2  peer B — accepts, drives DCUtR
+```
+
+Each router does port-preserving SNAT with no inbound port forwarding:
+endpoint-independent mapping with address-dependent filtering — the NAT class
+DCUtR is expected to traverse. Unsolicited inbound is dropped silently rather
+than rejected, because a RST would abort the peer's dial instead of letting TCP
+retransmit, and the retransmission is what makes a simultaneous open succeed.
+
+The peers are built from the production `node.CommonOptions`, so the camouflage
+transport, PSK, Noise, AutoNAT v2, AutoRelay and DCUtR are all the real thing.
+
+## What it asserts
+
+A green run is not "the peers connected" — the relay alone would satisfy that.
+It requires all of:
+
+- peer B holds a circuit reservation, and a plain TCP dial from host-a to
+  `11.0.0.12:4001` **fails** while B is listening (proves the NAT is real);
+- `EndHolePunch{Success:true}` from the DCUtR tracer on both sides;
+- a connection that is neither `Limited` nor `/p2p-circuit`, whose remote
+  address is the peer's **public** NAT address (proves the packets crossed the
+  NAT instead of taking a LAN shortcut);
+- a ping stream opened *without* `AllowLimitedConn`, so it physically cannot
+  fall back to the relay, landing on that same connection.
+
+## Findings this harness produced
+
+**1. Hole punching is dead in the shipped transport.** Against unmodified
+`vendor/`, the run fails with `hole punch service never got a public address`:
+the DCUtR stream handler is never even registered. `camouflage.go:dialRaw` only
+reuses the listen port when libp2p injects a shared `tcpreuse.ConnMgr`, and
+`config.go:480` forbids a shared TCP listener together with a PSK — which
+Warpnet always sets. So `sharedTCP` is always nil, every dial leaves from an
+ephemeral port, identify's observed address does not match a listen address and
+is discarded, and `HolePunchAddrs()` stays empty forever. The stock TCP
+transport does not have this problem: with `sharedTcp == nil` it falls back to
+`t.reuse.DialContext` (`tcp.go:242`), and reuseport defaults to on.
+
+`camouflage-reuseport.patch` closes the gap — give the transport its own
+`reuseport.Transport` for both `Listen` and `dialRaw`, mirroring the stock
+transport. With it applied the lab passes, with and without `FORCE_PRIVATE`:
+
+```
+PASS DCUtR reported a successful hole punch
+PASS peer A got a direct conn to 11.0.0.12
+PASS peer B got a direct conn to 11.0.0.11
+HOLE PUNCH VERIFIED: 11.0.0.11 <-> 11.0.0.12 across two independent NATs
+```
+
+The patch belongs in the `libp2p-camouflage-transport` repo, not in `vendor/`.
+To reproduce both arms:
+
+```sh
+git apply deploy/natlab/camouflage-reuseport.patch   # green
+git checkout -- vendor/                              # red
+```
+
+**2. A relay only relays once AutoNAT calls it public.** `relaysvc` starts the
+circuit v2 hop service on `EvtLocalReachabilityChanged{Public}` only, so until
+then AutoRelay rejects it with `doesn't speak circuit v2`. The lab relay states
+`ForceReachabilityPublic()` instead of waiting.
+
+**3. `observedaddrs.ActivationThresh = 2` does not block the punch.**
+`HolePunchAddrs` deliberately asks for addresses with a single observer
+(`addrs_manager.go:456`), so one relay is enough for candidates. The threshold
+only gates the *advertised* address set. Worth noting that the three production
+relays share one IP, and `getObserver` keys IPv4 observers by full address, so
+all three count as a single observer for that threshold.

--- a/deploy/natlab/camouflage-reuseport.patch
+++ b/deploy/natlab/camouflage-reuseport.patch
@@ -1,0 +1,47 @@
+diff --git a/vendor/github.com/Warp-net/libp2p-camouflage-transport/camouflage.go b/vendor/github.com/Warp-net/libp2p-camouflage-transport/camouflage.go
+index f4f4320d..19f7aca8 100644
+--- a/vendor/github.com/Warp-net/libp2p-camouflage-transport/camouflage.go
++++ b/vendor/github.com/Warp-net/libp2p-camouflage-transport/camouflage.go
+@@ -37,6 +37,7 @@ import (
+ 	"github.com/libp2p/go-libp2p/core/network"
+ 	"github.com/libp2p/go-libp2p/core/peer"
+ 	"github.com/libp2p/go-libp2p/core/transport"
++	"github.com/libp2p/go-libp2p/p2p/net/reuseport"
+ 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+ 	"github.com/libp2p/go-libp2p/p2p/transport/tcpreuse"
+ 	ma "github.com/multiformats/go-multiaddr"
+@@ -147,6 +148,7 @@ func WithHandshakeTimeout(d time.Duration) Option {
+ // traffic fragmentation to evade DPI.
+ type CamouflageTransport struct {
+ 	inner     *tcp.TcpTransport
++	reuse     reuseport.Transport
+ 	upgrader  transport.Upgrader
+ 	rcmgr     network.ResourceManager
+ 	sharedTCP *tcpreuse.ConnMgr
+@@ -314,6 +316,9 @@ func (t *CamouflageTransport) dialRaw(ctx context.Context, raddr ma.Multiaddr) (
+ 	if t.sharedTCP != nil {
+ 		return t.sharedTCP.DialContext(ctx, raddr)
+ 	}
++	if tcpreuse.ReuseportIsAvailable() {
++		return t.reuse.DialContext(ctx, raddr)
++	}
+ 	var d manet.Dialer
+ 	return d.DialContext(ctx, raddr)
+ }
+@@ -335,7 +340,15 @@ func (t *CamouflageTransport) Listen(laddr ma.Multiaddr) (transport.Listener, er
+ 			return nil, err
+ 		}
+ 	} else {
+-		mal, err := manet.Listen(laddr)
++		var (
++			mal manet.Listener
++			err error
++		)
++		if tcpreuse.ReuseportIsAvailable() {
++			mal, err = t.reuse.Listen(laddr)
++		} else {
++			mal, err = manet.Listen(laddr)
++		}
+ 		if err != nil {
+ 			return nil, err
+ 		}

--- a/deploy/natlab/main.go
+++ b/deploy/natlab/main.go
@@ -1,0 +1,517 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// natlab is the node side of the NAT hole-punch harness. It builds a libp2p
+// host from the production node.CommonOptions and reports DCUtR progress, so
+// that topology.sh can assert a real hole punch happened between two peers
+// sitting behind two independent MASQUERADE NATs.
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/Warp-net/warpnet/core/node"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	log "github.com/sirupsen/logrus"
+)
+
+// The lab runs on its own PSK so it can never talk to mainnet or testnet.
+const (
+	labNetwork = "natlab"
+	labVersion = "0.0.1"
+)
+
+// Everything is configured through the environment on purpose: importing
+// warpnet/config runs pflag.Parse() from its init(), which rejects any flag of
+// ours before main() is even reached.
+var (
+	role         = envStr("NATLAB_ROLE", "")
+	seed         = envStr("NATLAB_SEED", "")
+	listenIP     = envStr("NATLAB_IP", "")
+	listenPort   = envInt("NATLAB_PORT", 4001)
+	relayAddr    = envStr("NATLAB_RELAY", "")
+	targetID     = envStr("NATLAB_TARGET", "")
+	dialCircuit  = envBool("NATLAB_DIAL_CIRCUIT")
+	readyFile    = envStr("NATLAB_READY_FILE", "")
+	waitFile     = envStr("NATLAB_WAIT_FILE", "")
+	doneFile     = envStr("NATLAB_DONE_FILE", "")
+	forcePrivate = envBool("NATLAB_FORCE_PRIVATE")
+	timeout      = envDuration("NATLAB_TIMEOUT", 120*time.Second)
+)
+
+func envStr(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	v, err := strconv.Atoi(envStr(key, ""))
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+func envBool(key string) bool {
+	switch envStr(key, "") {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	d, err := time.ParseDuration(envStr(key, ""))
+	if err != nil {
+		return def
+	}
+	return d
+}
+
+func main() {
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.InfoLevel)
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: time.TimeOnly})
+
+	if role == "print-id" {
+		id, err := peerIDFromSeed(seed)
+		if err != nil {
+			fatal(err)
+		}
+		fmt.Println(id.String())
+		return
+	}
+
+	if err := run(); err != nil {
+		report("RESULT=FAIL", "role="+role, "err="+quote(err.Error()))
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	switch role {
+	case "relay":
+		return runRelay(ctx)
+	case "peer":
+		return runPeer(ctx)
+	default:
+		return fmt.Errorf("unknown role %q", role)
+	}
+}
+
+// runRelay starts the public node: it is the circuit relay, the AutoNAT server
+// and the only observer of the NATed peers' external addresses.
+func runRelay(ctx context.Context) error {
+	h, tracer, err := newHost(nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = h.Close() }()
+	_ = tracer
+
+	report("event=relay_up", "id="+h.ID().String(), "addrs="+quote(addrsString(h.Addrs())))
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-interrupt:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+// runPeer starts a NATed node: it reserves a slot on the relay, then either
+// dials the other peer over the circuit or waits to be dialed. Either way the
+// DCUtR exchange that follows must upgrade the connection to a direct one.
+func runPeer(ctx context.Context) error {
+	relayInfo, err := addrInfo(relayAddr)
+	if err != nil {
+		return fmt.Errorf("bad NATLAB_RELAY: %w", err)
+	}
+	target, err := peer.Decode(targetID)
+	if err != nil {
+		return fmt.Errorf("bad NATLAB_TARGET: %w", err)
+	}
+
+	h, tracer, err := newHost([]peer.AddrInfo{*relayInfo})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = h.Close() }()
+
+	report("event=peer_up", "id="+h.ID().String(), "addrs="+quote(addrsString(h.Addrs())))
+
+	h.Network().Notify(&connLogger{})
+
+	if err := h.Connect(ctx, *relayInfo); err != nil {
+		return fmt.Errorf("connect to relay: %w", err)
+	}
+	report("event=relay_connected", "relay="+relayInfo.ID.String())
+
+	circuit, err := waitCircuitAddr(ctx, h)
+	if err != nil {
+		return err
+	}
+	report("event=reservation", "circuit="+quote(circuit))
+
+	// The hole punch service registers its stream handler only once it has a
+	// public address to offer (holepunch.Service.waitForPublicAddr). Until then
+	// the peer answers "protocols not supported: [/libp2p/dcutr]" and the other
+	// side's single punch attempt is wasted.
+	if err := waitDCUtRReady(ctx, h); err != nil {
+		return err
+	}
+	report("event=dcutr_ready")
+
+	if readyFile != "" {
+		if err := os.WriteFile(readyFile, []byte(circuit+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write ready file: %w", err)
+		}
+	}
+
+	if dialCircuit {
+		peerCircuit, err := waitForFile(ctx, waitFile)
+		if err != nil {
+			return err
+		}
+		info, err := addrInfo(peerCircuit)
+		if err != nil {
+			return fmt.Errorf("bad peer circuit addr: %w", err)
+		}
+		if info.ID != target {
+			return fmt.Errorf("circuit addr is for %s, want %s", info.ID, target)
+		}
+		if err := h.Connect(ctx, *info); err != nil {
+			return fmt.Errorf("connect over circuit: %w", err)
+		}
+		report("event=circuit_connected", "peer="+target.String())
+	}
+
+	direct, err := waitDirectConn(ctx, h, target)
+	if err != nil {
+		return err
+	}
+	report(
+		"event=direct_conn",
+		"peer="+target.String(),
+		"local="+quote(direct.LocalMultiaddr().String()),
+		"remote="+quote(direct.RemoteMultiaddr().String()),
+	)
+
+	// A direct connection whose remote address is public proves the packets
+	// crossed the peer's NAT rather than taking a LAN shortcut.
+	if !manet.IsPublicAddr(direct.RemoteMultiaddr()) {
+		return fmt.Errorf("direct conn is not via a public address: %s", direct.RemoteMultiaddr())
+	}
+
+	if err := pingOver(ctx, h, target, direct); err != nil {
+		return err
+	}
+
+	report("RESULT=PASS", "role=peer", "id="+h.ID().String(), "punched="+fmt.Sprint(tracer.punched()))
+
+	// Whoever finishes first must not tear the punched connection down under
+	// the other peer: closing the host closes the shared TCP connection, and
+	// the peer still verifying it would see it vanish.
+	if doneFile != "" {
+		if dialCircuit {
+			if err := os.WriteFile(doneFile, []byte("done\n"), 0o600); err != nil {
+				return fmt.Errorf("write done file: %w", err)
+			}
+		} else if _, err := waitForFile(ctx, doneFile); err != nil {
+			return fmt.Errorf("peer never confirmed the punch: %w", err)
+		}
+	}
+	return nil
+}
+
+func newHost(relays []peer.AddrInfo) (warpnet.P2PNode, *hpTracer, error) {
+	privKey, err := security.GenerateKeyFromSeed([]byte(seed))
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	selfID, err := warpnet.IDFromPublicKey(privKey.Public().(ed25519.PublicKey))
+	if err != nil {
+		return nil, nil, fmt.Errorf("derive peer id: %w", err)
+	}
+	version, err := semver.NewVersion(labVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	psk, err := security.GeneratePSK(labNetwork, version)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate psk: %w", err)
+	}
+
+	tracer := &hpTracer{}
+
+	opts := []libp2p.Option{
+		node.WarpIdentity(privKey),
+		libp2p.PrivateNetwork(warpnet.PSK(psk)),
+		libp2p.ListenAddrStrings(fmt.Sprintf("/ip4/%s/tcp/%d", listenIP, listenPort)),
+	}
+	if len(relays) > 0 {
+		opts = append(opts, node.EnableAutoRelayWithStaticRelays(relays, selfID)())
+	}
+	opts = append(opts, node.CommonOptions...)
+	// Re-apply with a tracer: CommonOptions enables hole punching without one,
+	// and the option only overwrites HolePunchingOptions.
+	opts = append(opts, libp2p.EnableHolePunching(holepunch.WithTracer(tracer)))
+	if role == "relay" {
+		// The circuit v2 hop service only starts once reachability is
+		// confirmed public (relaysvc.reachabilityChanged). The lab relay does
+		// sit on a public address, so state that instead of waiting for
+		// AutoNAT to agree.
+		opts = append(opts, libp2p.ForceReachabilityPublic())
+	}
+	if forcePrivate {
+		opts = append(opts, libp2p.ForceReachabilityPrivate())
+	}
+
+	h, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("new host: %w", err)
+	}
+	return h, tracer, nil
+}
+
+// waitCircuitAddr waits until AutoNAT declares us private and AutoRelay has a
+// confirmed reservation, which is what makes us dialable over the relay.
+func waitCircuitAddr(ctx context.Context, h warpnet.P2PNode) (string, error) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		for _, a := range h.Addrs() {
+			if !warpnet.IsRelayMultiaddress(a) {
+				continue
+			}
+			return fmt.Sprintf("%s/p2p/%s", a, h.ID()), nil
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return "", fmt.Errorf("no relay reservation: %w", ctx.Err())
+		}
+	}
+}
+
+// waitDCUtRReady waits until our own host answers the DCUtR protocol, which is
+// the observable proof that hole punching has a public address to work with.
+func waitDCUtRReady(ctx context.Context, h warpnet.P2PNode) error {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		for _, p := range h.Mux().Protocols() {
+			if p == holepunch.Protocol {
+				return nil
+			}
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return fmt.Errorf("hole punch service never got a public address: %w", ctx.Err())
+		}
+	}
+}
+
+// waitDirectConn waits for a connection to target that is neither limited nor
+// routed through a relay, i.e. the result of a successful hole punch.
+func waitDirectConn(ctx context.Context, h warpnet.P2PNode, target peer.ID) (network.Conn, error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		for _, c := range h.Network().ConnsToPeer(target) {
+			if c.Stat().Limited || warpnet.IsRelayMultiaddress(c.RemoteMultiaddr()) {
+				continue
+			}
+			return c, nil
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			for _, c := range h.Network().Conns() {
+				report(
+					"event=conn_dump",
+					"peer="+c.RemotePeer().String(),
+					"remote="+quote(c.RemoteMultiaddr().String()),
+					"limited="+fmt.Sprint(c.Stat().Limited),
+					"direction="+c.Stat().Direction.String(),
+				)
+			}
+			return nil, fmt.Errorf("no direct connection to %s: %w", target, ctx.Err())
+		}
+	}
+}
+
+// pingOver pings target and verifies libp2p picked the hole-punched connection.
+func pingOver(ctx context.Context, h warpnet.P2PNode, target peer.ID, direct network.Conn) error {
+	pingCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	s, err := h.NewStream(pingCtx, target, ping.ID)
+	if err != nil {
+		return fmt.Errorf("open ping stream: %w", err)
+	}
+	used := s.Conn().RemoteMultiaddr().String()
+	_ = s.Close()
+	if used != direct.RemoteMultiaddr().String() {
+		return fmt.Errorf("ping stream used %s, not the direct conn %s", used, direct.RemoteMultiaddr())
+	}
+
+	res := <-ping.Ping(pingCtx, h, target)
+	if res.Error != nil {
+		return fmt.Errorf("ping over direct conn: %w", res.Error)
+	}
+	report("event=ping_ok", "peer="+target.String(), "rtt="+res.RTT.String(), "via="+quote(used))
+	return nil
+}
+
+// connLogger traces the full lifecycle of every connection, which is what tells
+// a punch that never happened apart from one that happened and was then torn
+// down.
+type connLogger struct{}
+
+func (connLogger) Listen(network.Network, ma.Multiaddr)      {}
+func (connLogger) ListenClose(network.Network, ma.Multiaddr) {}
+
+func (connLogger) Connected(_ network.Network, c network.Conn) {
+	report(
+		"event=conn_open",
+		"peer="+c.RemotePeer().String(),
+		"remote="+quote(c.RemoteMultiaddr().String()),
+		"limited="+fmt.Sprint(c.Stat().Limited),
+		"direction="+c.Stat().Direction.String(),
+	)
+}
+
+func (connLogger) Disconnected(_ network.Network, c network.Conn) {
+	report(
+		"event=conn_close",
+		"peer="+c.RemotePeer().String(),
+		"remote="+quote(c.RemoteMultiaddr().String()),
+		"limited="+fmt.Sprint(c.Stat().Limited),
+		"direction="+c.Stat().Direction.String(),
+	)
+}
+
+// hpTracer records DCUtR events so the log carries direct evidence of the
+// punch, not just its end result.
+type hpTracer struct {
+	success atomic.Bool
+}
+
+func (t *hpTracer) Trace(evt *holepunch.Event) {
+	payload, err := json.Marshal(evt.Evt)
+	if err != nil {
+		payload = []byte(`{}`)
+	}
+	if end, ok := evt.Evt.(*holepunch.EndHolePunchEvt); ok && end.Success {
+		t.success.Store(true)
+	}
+	report("event=dcutr", "type="+evt.Type, "remote="+evt.Remote.String(), "evt="+quote(string(payload)))
+}
+
+func (t *hpTracer) punched() bool { return t.success.Load() }
+
+func peerIDFromSeed(s string) (peer.ID, error) {
+	privKey, err := security.GenerateKeyFromSeed([]byte(s))
+	if err != nil {
+		return "", err
+	}
+	return warpnet.IDFromPublicKey(privKey.Public().(ed25519.PublicKey))
+}
+
+func addrInfo(s string) (*peer.AddrInfo, error) {
+	maddr, err := ma.NewMultiaddr(s)
+	if err != nil {
+		return nil, err
+	}
+	return peer.AddrInfoFromP2pAddr(maddr)
+}
+
+func waitForFile(ctx context.Context, path string) (string, error) {
+	if path == "" {
+		return "", errors.New("no -wait-file given")
+	}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		bt, err := os.ReadFile(path)
+		if err == nil && len(strings.TrimSpace(string(bt))) > 0 {
+			return strings.TrimSpace(string(bt)), nil
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return "", fmt.Errorf("waiting for %s: %w", path, ctx.Err())
+		}
+	}
+}
+
+func addrsString(addrs []ma.Multiaddr) string {
+	out := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		out = append(out, a.String())
+	}
+	return strings.Join(out, ",")
+}
+
+// report writes a machine-readable line that topology.sh greps for.
+func report(fields ...string) {
+	fmt.Printf("NATLAB %s\n", strings.Join(fields, " "))
+	_ = os.Stdout.Sync()
+}
+
+func quote(s string) string { return "'" + s + "'" }
+
+func fatal(err error) {
+	report("RESULT=FAIL", "err="+quote(err.Error()))
+	os.Exit(1)
+}

--- a/deploy/natlab/run.sh
+++ b/deploy/natlab/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Runs the NAT hole-punch harness. No sudo needed: membership in the docker
+# group is enough, and --privileged gives the container CAP_NET_ADMIN inside
+# its own network namespace. --network none keeps the lab off every real
+# network, so nothing can reach mainnet, testnet or the host LAN.
+#
+#   ./deploy/natlab/run.sh                 # build + run
+#   FORCE_PRIVATE=1 ./deploy/natlab/run.sh # skip AutoNAT reachability probing
+#   ./deploy/natlab/run.sh --shell         # interactive shell in the lab
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+image=${IMAGE:-warpnet-natlab:latest}
+
+cd "$repo_root"
+
+echo "== building $image"
+docker build -f deploy/natlab/Dockerfile -t "$image" .
+
+run_args=(
+  --rm
+  --privileged
+  --network none
+  -e "FORCE_PRIVATE=${FORCE_PRIVATE:-0}"
+  -e "PEER_TIMEOUT=${PEER_TIMEOUT:-180s}"
+)
+
+if [ "${1:-}" = "--shell" ]; then
+  echo "== opening a shell in the lab (run /usr/local/bin/topology.sh by hand)"
+  exec docker run -it "${run_args[@]}" --entrypoint /bin/bash "$image"
+fi
+
+echo "== running the lab"
+exec docker run "${run_args[@]}" "$image"

--- a/deploy/natlab/topology.sh
+++ b/deploy/natlab/topology.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# Builds a real NAT topology inside the container's own network namespace and
+# runs a Warpnet hole punch across it. Requires CAP_NET_ADMIN (docker
+# --privileged); nothing outside the container is touched.
+#
+#   root ns of the container = "the internet"
+#     bridge inet 11.0.0.0/24
+#     ├── relay          11.0.0.1     public: circuit relay + AutoNAT server
+#     ├── [ns rtr-a] wan 11.0.0.11    MASQUERADE, lan 10.1.0.1/24
+#     │        └── [ns host-a] 10.1.0.2  peer A (dials over the circuit)
+#     └── [ns rtr-b] wan 11.0.0.12    MASQUERADE, lan 10.2.0.1/24
+#              └── [ns host-b] 10.2.0.2  peer B (accepts, drives DCUtR)
+#
+# 11.0.0.0/24 is used for the fake internet on purpose: go-multiaddr counts
+# 100.64.0.0/10 as private (RFC 6598), so a CGNAT range would make libp2p
+# discard the observed addresses and no hole punch candidate would exist.
+
+set -euo pipefail
+
+NATLAB_BIN=${NATLAB_BIN:-/usr/local/bin/natlab}
+LOG_DIR=${LOG_DIR:-/var/log/natlab}
+RUN_DIR=${RUN_DIR:-/run/natlab}
+PORT=${PORT:-4001}
+PEER_TIMEOUT=${PEER_TIMEOUT:-180s}
+FORCE_PRIVATE=${FORCE_PRIVATE:-0}
+
+RELAY_IP=11.0.0.1
+WAN_A=11.0.0.11
+WAN_B=11.0.0.12
+LAN_A_GW=10.1.0.1
+LAN_A_HOST=10.1.0.2
+LAN_B_GW=10.2.0.1
+LAN_B_HOST=10.2.0.2
+
+RELAY_SEED=natlab-relay
+SEED_A=natlab-peer-a
+SEED_B=natlab-peer-b
+
+pids=()
+
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+die() { printf '\033[31mFAIL: %s\033[0m\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  local pid
+  for pid in "${pids[@]:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+  for ns in host-a host-b rtr-a rtr-b; do
+    ip netns del "$ns" 2>/dev/null || true
+  done
+  ip link del inet 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------- topology
+
+build_router() {
+  local rtr=$1 host=$2 wan_if=$3 wan_ip=$4 lan_if=$5 lan_gw=$6 host_if=$7 host_ip=$8 lan_cidr=$9
+
+  ip netns add "$rtr"
+  ip netns add "$host"
+
+  # WAN leg: router <-> the fake internet bridge.
+  ip link add "$wan_if" type veth peer name "br-$wan_if"
+  ip link set "br-$wan_if" master inet up
+  ip link set "$wan_if" netns "$rtr"
+  ip -n "$rtr" addr add "$wan_ip/24" dev "$wan_if"
+  ip -n "$rtr" link set "$wan_if" up
+
+  # LAN leg: router <-> the NATed host.
+  ip link add "$lan_if" type veth peer name "$host_if"
+  ip link set "$lan_if" netns "$rtr"
+  ip link set "$host_if" netns "$host"
+  ip -n "$rtr" addr add "$lan_gw/24" dev "$lan_if"
+  ip -n "$rtr" link set "$lan_if" up
+  ip -n "$rtr" link set lo up
+  ip -n "$host" addr add "$host_ip/24" dev "$host_if"
+  ip -n "$host" link set "$host_if" up
+  ip -n "$host" link set lo up
+  ip -n "$host" route add default via "$lan_gw"
+
+  ip netns exec "$rtr" sh -c 'echo 1 > /proc/sys/net/ipv4/ip_forward'
+
+  # Port-preserving source NAT and no inbound port forwarding at all:
+  # endpoint-independent mapping with address-dependent filtering, the NAT
+  # class DCUtR is expected to traverse.
+  ip netns exec "$rtr" iptables -t nat -A POSTROUTING -s "$lan_cidr" -o "$wan_if" -j MASQUERADE
+  ip netns exec "$rtr" iptables -A FORWARD -i "$wan_if" -o "$lan_if" -m conntrack --ctstate NEW,INVALID -j DROP
+  # Unsolicited inbound must be dropped silently, not rejected. An unmatched
+  # SYN is destined to the router itself (INPUT, not FORWARD), and the default
+  # RST would abort the peer's dial instead of letting TCP retransmit - which
+  # is exactly what makes a simultaneous open succeed on a real NAT.
+  ip netns exec "$rtr" iptables -A INPUT -i "$wan_if" -m conntrack --ctstate NEW,INVALID -j DROP
+}
+
+say "building topology"
+ip link add inet type bridge
+ip addr add "$RELAY_IP/24" dev inet
+ip link set inet up
+
+build_router rtr-a host-a wan-a "$WAN_A" lan-a "$LAN_A_GW" eth-a "$LAN_A_HOST" 10.1.0.0/24
+build_router rtr-b host-b wan-b "$WAN_B" lan-b "$LAN_B_GW" eth-b "$LAN_B_HOST" 10.2.0.0/24
+
+mkdir -p "$LOG_DIR" "$RUN_DIR"
+rm -f "$RUN_DIR"/*.addr "$RUN_DIR"/*.done
+
+ip -brief addr show
+for ns in rtr-a rtr-b host-a host-b; do
+  printf '  %-7s %s\n' "$ns" "$(ip -n "$ns" -brief addr show | tr '\n' ' ')"
+done
+
+say "sanity: NATed hosts can reach the relay"
+ip netns exec host-a ping -c1 -W2 "$RELAY_IP" >/dev/null || die "host-a cannot reach the relay"
+ip netns exec host-b ping -c1 -W2 "$RELAY_IP" >/dev/null || die "host-b cannot reach the relay"
+echo "  ok: both LANs egress through their NAT"
+
+# ------------------------------------------------------------------- nodes
+
+# natlab takes no command-line flags: warpnet/config parses pflags from its
+# init() and would reject them, so everything goes through the environment.
+# The last line is the ID: warpnet prints a version banner to stdout on init.
+peer_id() {
+  NATLAB_ROLE=print-id NATLAB_SEED="$1" "$NATLAB_BIN" | tail -n1 | tr -d '[:space:]'
+}
+
+RELAY_ID=$(peer_id "$RELAY_SEED")
+ID_A=$(peer_id "$SEED_A")
+ID_B=$(peer_id "$SEED_B")
+RELAY_MADDR="/ip4/$RELAY_IP/tcp/$PORT/p2p/$RELAY_ID"
+
+say "peer identities"
+printf '  relay  %s\n  peer-a %s\n  peer-b %s\n' "$RELAY_ID" "$ID_A" "$ID_B"
+
+say "starting relay in the root namespace"
+env NATLAB_ROLE=relay NATLAB_SEED="$RELAY_SEED" NATLAB_IP="$RELAY_IP" \
+  NATLAB_PORT="$PORT" NATLAB_TIMEOUT="$PEER_TIMEOUT" \
+  "$NATLAB_BIN" >"$LOG_DIR/relay.log" 2>&1 &
+pids+=($!)
+
+for _ in $(seq 40); do
+  grep -q 'event=relay_up' "$LOG_DIR/relay.log" 2>/dev/null && break
+  sleep 0.25
+done
+grep -q 'event=relay_up' "$LOG_DIR/relay.log" || { tail -30 "$LOG_DIR/relay.log"; die "relay did not start"; }
+grep 'NATLAB' "$LOG_DIR/relay.log" | tail -2
+
+say "starting peer B behind NAT B ($WAN_B)"
+ip netns exec host-b env NATLAB_ROLE=peer NATLAB_SEED="$SEED_B" NATLAB_IP="$LAN_B_HOST" \
+  NATLAB_PORT="$PORT" NATLAB_RELAY="$RELAY_MADDR" NATLAB_TARGET="$ID_A" \
+  NATLAB_READY_FILE="$RUN_DIR/b.addr" NATLAB_DONE_FILE="$RUN_DIR/a.done" \
+  NATLAB_TIMEOUT="$PEER_TIMEOUT" \
+  NATLAB_FORCE_PRIVATE="$FORCE_PRIVATE" \
+  "$NATLAB_BIN" >"$LOG_DIR/peer-b.log" 2>&1 &
+pids+=($!)
+
+say "waiting for peer B's relay reservation"
+for _ in $(seq 240); do
+  [ -s "$RUN_DIR/b.addr" ] && break
+  grep -q 'RESULT=FAIL' "$LOG_DIR/peer-b.log" 2>/dev/null && break
+  sleep 0.5
+done
+[ -s "$RUN_DIR/b.addr" ] || { tail -40 "$LOG_DIR/peer-b.log"; die "peer B never got a reservation"; }
+echo "  circuit: $(cat "$RUN_DIR/b.addr")"
+
+say "control: unsolicited inbound to NAT B must be blocked"
+if ip netns exec host-a timeout 4 bash -c "exec 3<>/dev/tcp/$WAN_B/$PORT" 2>/dev/null; then
+  die "direct dial to $WAN_B:$PORT succeeded - this is not a real NAT, the punch would be meaningless"
+fi
+echo "  ok: peer B is unreachable without hole punching, while it is listening"
+
+say "starting peer A behind NAT A ($WAN_A) and dialing B over the relay"
+ip netns exec host-a env NATLAB_ROLE=peer NATLAB_SEED="$SEED_A" NATLAB_IP="$LAN_A_HOST" \
+  NATLAB_PORT="$PORT" NATLAB_RELAY="$RELAY_MADDR" NATLAB_TARGET="$ID_B" \
+  NATLAB_DIAL_CIRCUIT=1 NATLAB_WAIT_FILE="$RUN_DIR/b.addr" \
+  NATLAB_READY_FILE="$RUN_DIR/a.addr" NATLAB_DONE_FILE="$RUN_DIR/a.done" \
+  NATLAB_TIMEOUT="$PEER_TIMEOUT" \
+  NATLAB_FORCE_PRIVATE="$FORCE_PRIVATE" \
+  "$NATLAB_BIN" >"$LOG_DIR/peer-a.log" 2>&1 &
+pid_a=$!
+pids+=("$pid_a")
+
+say "waiting for the hole punch"
+rc_a=0
+wait "$pid_a" || rc_a=$?
+
+# Peer B reports independently; give it a moment to finish its own assertions.
+for _ in $(seq 40); do
+  grep -qE 'RESULT=(PASS|FAIL)' "$LOG_DIR/peer-b.log" && break
+  sleep 0.5
+done
+
+# ------------------------------------------------------------------ report
+
+say "DCUtR trace"
+grep -h 'event=dcutr' "$LOG_DIR/peer-a.log" "$LOG_DIR/peer-b.log" || echo "  (no DCUtR events)"
+
+say "connections"
+grep -h 'event=direct_conn' "$LOG_DIR/peer-a.log" "$LOG_DIR/peer-b.log" || echo "  (none)"
+grep -h 'event=ping_ok' "$LOG_DIR/peer-a.log" "$LOG_DIR/peer-b.log" || true
+
+say "NAT conntrack state on rtr-a"
+if ip netns exec rtr-a test -r /proc/net/nf_conntrack; then
+  ip netns exec rtr-a grep -E "dst=$WAN_B|src=$WAN_B" /proc/net/nf_conntrack || echo "  (no entry for $WAN_B)"
+else
+  echo "  (/proc/net/nf_conntrack unavailable on this kernel)"
+fi
+
+say "verdict"
+fail=0
+check() {
+  if eval "$2" >/dev/null 2>&1; then
+    printf '  \033[32mPASS\033[0m %s\n' "$1"
+  else
+    printf '  \033[31mFAIL\033[0m %s\n' "$1"
+    fail=1
+  fi
+}
+
+check "peer B reserved a relay slot"            "grep -q 'event=reservation' '$LOG_DIR/peer-b.log'"
+check "peer A connected over the circuit"       "grep -q 'event=circuit_connected' '$LOG_DIR/peer-a.log'"
+check "DCUtR reported a successful hole punch"  "grep -q 'type=EndHolePunch' '$LOG_DIR/peer-a.log' '$LOG_DIR/peer-b.log' && grep -q '\"Success\":true' '$LOG_DIR/peer-a.log' '$LOG_DIR/peer-b.log'"
+check "peer A got a direct conn to $WAN_B"      "grep -q \"event=direct_conn.*remote='/ip4/$WAN_B\" '$LOG_DIR/peer-a.log'"
+check "peer B got a direct conn to $WAN_A"      "grep -q \"event=direct_conn.*remote='/ip4/$WAN_A\" '$LOG_DIR/peer-b.log'"
+check "peer A ping traversed the direct conn"   "grep -q 'event=ping_ok' '$LOG_DIR/peer-a.log'"
+check "peer A exited clean"                     "[ $rc_a -eq 0 ]"
+check "peer B reported PASS"                    "grep -q 'RESULT=PASS' '$LOG_DIR/peer-b.log'"
+
+if [ "$fail" -ne 0 ]; then
+  say "peer A log (tail)"; tail -40 "$LOG_DIR/peer-a.log"
+  say "peer B log (tail)"; tail -40 "$LOG_DIR/peer-b.log"
+  say "relay log (tail)";  tail -20 "$LOG_DIR/relay.log"
+  die "hole punch harness did not pass"
+fi
+
+printf '\n\033[32mHOLE PUNCH VERIFIED: %s <-> %s across two independent NATs\033[0m\n' "$WAN_A" "$WAN_B"


### PR DESCRIPTION
Hole punching could only be tested against the real internet with a second machine, so it was not tested at all. This builds a genuine NAT lab locally: two peers, each behind its own iptables MASQUERADE router in its own network namespace, and a public relay, all inside one privileged container. No sudo (docker group is enough) and --network none keeps the lab off every real network, so it cannot reach mainnet or testnet.

The peers are built from the production node.CommonOptions, so the camouflage transport, PSK, Noise, AutoNAT v2, AutoRelay and DCUtR are the real thing.

A green run is not "the peers connected" - the relay alone would satisfy that. It requires that a plain TCP dial to the peer's public address fails while the peer is listening, that the DCUtR tracer reports success on both sides, that the resulting connection is neither limited nor a circuit and its remote address is public, and that a ping stream opened without AllowLimitedConn lands on it.

The harness immediately found that hole punching never worked in the shipped build: the camouflage transport only reuses the listen port when libp2p injects a shared tcpreuse.ConnMgr, but libp2p forbids a shared TCP listener together with a PSK, which Warpnet always sets. Every dial therefore leaves from an ephemeral port, identify's observed address is discarded because it does not match a listen address, and the DCUtR stream handler is never registered. camouflage-reuseport.patch fixes it and makes the lab pass; the fix belongs upstream in libp2p-camouflage-transport, so vendor/ is untouched here and the run stays red until it lands. README.md documents both arms.