### PR TITLE
Declare the relay node publicly reachable

### DIFF
--- a/cmd/node/relay/node/relay-node.go
+++ b/cmd/node/relay/node/relay-node.go
@@ -130,6 +130,12 @@ func NewRelayNode(
 		),
 		libp2p.Routing(dHashTable.StartRouting),
 		node.EnableAutoRelayWithStaticRelays(infos, ownNodeId)(),
+		// A relay serves circuit v2 only after AutoNAT reports public
+		// reachability, and until then peers reject it as "doesn't speak circuit
+		// v2". This node is deployed on a static public address by definition,
+		// so state that instead of waiting to be probed - NATed peers need the
+		// relay before they can help confirm it.
+		libp2p.ForceReachabilityPublic(),
 	}
 	opts = append(opts, node.CommonOptions...)
 


### PR DESCRIPTION
relaysvc starts the circuit v2 hop service only on an EvtLocalReachabilityChanged{Public} event, so until AutoNAT confirms the node is public it is not a relay at all: AutoRelay rejects it with "doesn't speak circuit v2". That is a chicken and egg problem, because AutoNAT needs peers to probe the address, and NATed peers need a working relay to reach the network in the first place.

A relay node is deployed on a static public address by definition - see deploy/docker-compose-testnet.yml, which pins NODE_HOST_V4 and uses host networking - so state that rather than waiting to be probed.

Observed in the deploy/natlab lab, where a relay that was public by construction spent tens of seconds being rejected by both peers.