### PR TITLE
Restore Codeberg mirroring in a pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Mirrors pushed code to the Codeberg mirror (codeberg.org/Warpnet/warpnet).
+# Tags are not mirrored here: the Release workflow owns tagging.
+
+# Re-entry guard: the mirror push below invokes `git push` again, which would
+# otherwise re-trigger this hook (this recursion previously spawned runaway
+# hook/`git push codeberg` processes that hung for hours).
+if [ -n "${WARPNET_PREPUSH:-}" ]; then
+    exit 0
+fi
+export WARPNET_PREPUSH=1
+
+# Never mirror a push that is already aimed at the mirror.
+case "${2:-}" in
+    *codeberg.org*) exit 0 ;;
+esac
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+# Only the long-lived branches exist on the mirror; feature branches stay local.
+case "$BRANCH" in
+    main|develop) ;;
+    *) exit 0 ;;
+esac
+
+echo "Pre-push hook: mirroring $BRANCH to codeberg..."
+
+# Best-effort: bounded by a timeout so an unreachable or slow mirror can never
+# block the push, and --no-verify keeps the inner push out of this hook.
+timeout --kill-after=5 20 git push --no-verify codeberg "$BRANCH" \
+    || echo "warn: mirroring $BRANCH to codeberg failed or timed out (continuing)"
+
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ check-heap:
 update-deps:
 	go get -v -u all && go mod vendor
 
+setup-hooks:
+	git config core.hooksPath .githooks
+
 ssh-do:
 	ssh root@207.154.221.44
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1213,6 +1213,16 @@ commits the bump to `main`, tags `v<version>`, and pushes the tag to GitHub +
 the Codeberg mirror before building the release artifacts. Don't bump the
 version by hand.
 
+### Codeberg mirror
+
+Pushing `main` or `develop` also mirrors that branch to
+[codeberg.org/Warpnet/warpnet](https://codeberg.org/Warpnet/warpnet) via the
+`.githooks/pre-push` hook; install it once with `make setup-hooks`
+(`git config core.hooksPath .githooks`). The mirror push is best-effort and
+bounded by a timeout, so an unreachable Codeberg never blocks the push to
+GitHub. Feature branches are not mirrored, and tags are left to the Release
+workflow above.
+
 ### Branches & PRs
 
 1. Fork, then branch: `git checkout -b <IssueNumber>/<ShortFeatureName>`.


### PR DESCRIPTION
Commit 2e339108 ("Drop git hooks") removed .githooks/pre-push and moved the Codeberg push into the Release workflow. That path effectively never runs: it is workflow_dispatch-only and its mirror step exits silently when CODEBERG_SSH_KEY is unset, so nothing has reached the mirror since v0.7.545.

Restore the hook, mirroring code instead of tags: pushing main or develop also pushes that branch to codeberg. Tagging stays in the Release workflow, and pre-commit is deliberately not restored so version bumping remains CI's job.

Keep the guards the old hook had earned: the WARPNET_PREPUSH re-entry guard (the inner push used to re-trigger the hook and leave runaway processes hanging), a bounded timeout, --no-verify, and exit 0 on failure so an unreachable Codeberg never blocks the push to GitHub. Skip pushes already aimed at the mirror so they do not self-mirror.