### PR TITLE
Show a video post's own frame as its preview

### DIFF
--- a/frontend/src/components/TweetBlock.vue
+++ b/frontend/src/components/TweetBlock.vue
@@ -123,30 +123,31 @@ resulting from the use or misuse of this software.
           <p v-else class="mt-1 text-dark italic">View quoted tweet</p>
         </template>
       </div>
-      <div v-if="tweetImages.length === 1" class="mt-2">
+      <div v-if="galleryImages.length === 1" class="mt-2">
         <img
-            :src="tweetImages[0]"
+            :src="galleryImages[0]"
             alt="Tweet image"
             class="rounded-lg max-w-full border border-lighter cursor-zoom-in"
-            @click.stop="openImageView(tweetImages[0])"
+            @click.stop="openImageView(galleryImages[0])"
         />
       </div>
-      <div v-else-if="tweetImages.length === 2" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter">
-        <img v-for="(img, i) in tweetImages" :key="i" :src="img" alt="Tweet image" class="w-full h-48 object-cover cursor-zoom-in" @click.stop="openImageView(img)" />
+      <div v-else-if="galleryImages.length === 2" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter">
+        <img v-for="(img, i) in galleryImages" :key="i" :src="img" alt="Tweet image" class="w-full h-48 object-cover cursor-zoom-in" @click.stop="openImageView(img)" />
       </div>
-      <div v-else-if="tweetImages.length === 3" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter" style="height:300px">
-        <img :src="tweetImages[0]" alt="Tweet image" class="row-span-2 w-full h-full object-cover cursor-zoom-in" style="grid-row: span 2" @click.stop="openImageView(tweetImages[0])" />
-        <img :src="tweetImages[1]" alt="Tweet image" class="w-full h-full object-cover cursor-zoom-in" @click.stop="openImageView(tweetImages[1])" />
-        <img :src="tweetImages[2]" alt="Tweet image" class="w-full h-full object-cover cursor-zoom-in" @click.stop="openImageView(tweetImages[2])" />
+      <div v-else-if="galleryImages.length === 3" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter" style="height:300px">
+        <img :src="galleryImages[0]" alt="Tweet image" class="row-span-2 w-full h-full object-cover cursor-zoom-in" style="grid-row: span 2" @click.stop="openImageView(galleryImages[0])" />
+        <img :src="galleryImages[1]" alt="Tweet image" class="w-full h-full object-cover cursor-zoom-in" @click.stop="openImageView(galleryImages[1])" />
+        <img :src="galleryImages[2]" alt="Tweet image" class="w-full h-full object-cover cursor-zoom-in" @click.stop="openImageView(galleryImages[2])" />
       </div>
-      <div v-else-if="tweetImages.length >= 4" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter">
-        <img v-for="(img, i) in tweetImages.slice(0, 4)" :key="i" :src="img" alt="Tweet image" class="w-full h-36 object-cover cursor-zoom-in" @click.stop="openImageView(img)" />
+      <div v-else-if="galleryImages.length >= 4" class="mt-2 grid grid-cols-2 gap-1 rounded-lg overflow-hidden border border-lighter">
+        <img v-for="(img, i) in galleryImages.slice(0, 4)" :key="i" :src="img" alt="Tweet image" class="w-full h-36 object-cover cursor-zoom-in" @click.stop="openImageView(img)" />
       </div>
       <YoutubeEmbed v-if="youtubeId" :videoId="youtubeId" />
-      <div v-if="tweet.video_key" class="mt-2">
+      <div v-if="hasVideo" class="mt-2">
         <video
             v-if="videoSrc"
             :src="videoSrc"
+            :poster="videoPoster || undefined"
             controls
             autoplay
             playsinline
@@ -173,16 +174,36 @@ resulting from the use or misuse of this software.
             @click.stop="loadVideo"
             type="button"
             :disabled="videoLoading"
-            class="w-full rounded-lg border border-lighter bg-lighter hover:bg-lightblue transition-colors py-8 flex flex-col items-center justify-center text-dark"
+            class="relative w-full overflow-hidden rounded-lg border border-lighter transition-colors flex flex-col items-center justify-center"
+            :class="videoPoster ? 'bg-black' : 'bg-lighter hover:bg-lightblue py-8 text-dark'"
             :aria-label="videoLoading ? 'Loading video' : 'Play video'"
         >
-          <i
-              :class="videoLoading ? 'fas fa-circle-notch fa-spin' : 'fas fa-play-circle'"
-              class="text-3xl mb-2"
+          <img
+              v-if="videoPoster"
+              :src="videoPoster"
+              alt=""
               aria-hidden="true"
-          ></i>
-          <span class="text-sm font-semibold">{{ videoLoading ? 'Loading video…' : 'Play video' }}</span>
-          <span v-if="!videoLoading" class="text-xs mt-1">Loads only when you play it</span>
+              class="w-full max-h-96 object-contain"
+          />
+          <span
+              class="flex flex-col items-center justify-center"
+              :class="videoPoster ? 'absolute inset-0' : ''"
+          >
+            <!-- Over a still the label needs its own dark backing: a frame can
+                 be any brightness, so a light one would swallow white text. -->
+            <span
+                class="flex flex-col items-center"
+                :class="videoPoster ? 'rounded-lg bg-black bg-opacity-80 px-4 py-3 text-white' : ''"
+            >
+              <i
+                  :class="videoLoading ? 'fas fa-circle-notch fa-spin' : 'fas fa-play-circle'"
+                  class="text-3xl mb-2"
+                  aria-hidden="true"
+              ></i>
+              <span class="text-sm font-semibold">{{ videoLoading ? 'Loading video…' : 'Play video' }}</span>
+              <span v-if="!videoLoading" class="text-xs mt-1">Loads only when you play it</span>
+            </span>
+          </span>
         </button>
       </div>
       <div
@@ -362,8 +383,20 @@ export default {
   },
   computed: {
     youtubeId() {
-      if (this.tweet && this.tweet.video_key) return null;
+      if (this.hasVideo) return null;
       return extractYoutubeId(this.tweet && this.tweet.text);
+    },
+    hasVideo() {
+      return !!(this.tweet && this.tweet.video_key);
+    },
+    // A video post carries its first frame as the first image key (see the
+    // composer in Home.vue), so it stands in as the poster rather than being
+    // shown as a separate attachment.
+    videoPoster() {
+      return this.hasVideo ? (this.tweetImages[0] || '') : '';
+    },
+    galleryImages() {
+      return this.hasVideo ? [] : this.tweetImages;
     },
   },
   methods: {

--- a/frontend/src/lib/video.js
+++ b/frontend/src/lib/video.js
@@ -42,6 +42,87 @@ export function normalizeVideoDataUrl(dataUrl, file) {
     return `data:${mime};base64,${dataUrl.slice(comma + 1)}`;
 }
 
+export const POSTER_MAX_WIDTH = 640;
+export const POSTER_SEEK_SECONDS = 1;
+export const POSTER_TIMEOUT_MS = 10000;
+
+// Grabs a frame near the start of a freshly picked video so the post can show a
+// still instead of a blank placeholder. Best effort: resolves to null whenever
+// the browser cannot decode the file (e.g. HEVC .mov outside Safari).
+export function captureVideoPoster(file, opts = {}) {
+    const {
+        maxWidth = POSTER_MAX_WIDTH,
+        seekSeconds = POSTER_SEEK_SECONDS,
+        timeoutMs = POSTER_TIMEOUT_MS,
+        createElement = tag => (typeof document === "undefined" ? null : document.createElement(tag)),
+        createObjectURL = f => (typeof URL === "undefined" || !URL.createObjectURL ? null : URL.createObjectURL(f)),
+        revokeObjectURL = url => {
+            if (typeof URL !== "undefined" && URL.revokeObjectURL) URL.revokeObjectURL(url);
+        },
+    } = opts;
+
+    return new Promise(resolve => {
+        const video = file ? createElement("video") : null;
+        const url = video ? createObjectURL(file) : null;
+        if (!url) {
+            resolve(null);
+            return;
+        }
+
+        let settled = false;
+        const finish = poster => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            video.onloadeddata = null;
+            video.onseeked = null;
+            video.onerror = null;
+            revokeObjectURL(url);
+            resolve(poster || null);
+        };
+        const timer = setTimeout(() => finish(null), timeoutMs);
+
+        video.onerror = () => finish(null);
+        video.onloadeddata = () => {
+            const duration = Number(video.duration);
+            // The opening second is often a fade-in or a black lead-in, so take
+            // the frame a second in, or the midpoint of a clip too short for that.
+            const target = Number.isFinite(duration) && duration > 0
+                ? Math.min(seekSeconds, duration / 2)
+                : seekSeconds;
+            if (target > 0) {
+                video.currentTime = target;
+                return;
+            }
+            finish(drawPoster(video, maxWidth, createElement));
+        };
+        video.onseeked = () => finish(drawPoster(video, maxWidth, createElement));
+        video.muted = true;
+        video.playsInline = true;
+        video.preload = "metadata";
+        video.src = url;
+    });
+}
+
+function drawPoster(video, maxWidth, createElement) {
+    const {videoWidth: width, videoHeight: height} = video;
+    if (!width || !height) return null;
+
+    const canvas = createElement("canvas");
+    const ctx = canvas && canvas.getContext ? canvas.getContext("2d") : null;
+    if (!ctx) return null;
+
+    const scale = Math.min(1, maxWidth / width);
+    canvas.width = Math.round(width * scale);
+    canvas.height = Math.round(height * scale);
+    try {
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        return canvas.toDataURL("image/jpeg", 0.7);
+    } catch (err) {
+        return null;
+    }
+}
+
 export function validateVideoFile(file) {
     if (!file) {
         return "No video file selected.";

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -231,7 +231,7 @@ import {defineAsyncComponent} from "vue";
 import {warpnetService} from "@/service/service";
 import {parseDeepLink} from "@/lib/deeplink";
 import {toast} from "@/lib/toast";
-import {acceptedVideoAccept, normalizeVideoDataUrl, validateVideoFile} from "@/lib/video";
+import {acceptedVideoAccept, captureVideoPoster, normalizeVideoDataUrl, validateVideoFile} from "@/lib/video";
 
 export default {
   name: "Home",
@@ -263,6 +263,7 @@ export default {
       altModalIndex: -1,
       videoAttachment: null,
       videoKey: '',
+      videoPosterKey: '',
       videoUploading: false,
       posting: false,
       loadingMore: false,
@@ -370,7 +371,13 @@ export default {
 
       this.videoAttachment = {url: URL.createObjectURL(file), name: file.name};
       this.videoKey = '';
+      this.videoPosterKey = '';
       this.videoUploading = true;
+
+      const posterKey = await this.uploadVideoPoster(file);
+      if (this.videoAttachment) {
+        this.videoPosterKey = posterKey;
+      }
 
       try {
         const dataUrl = normalizeVideoDataUrl(await this.readFileAsDataURL(file), file);
@@ -387,6 +394,18 @@ export default {
         this.videoUploading = false;
       }
     },
+    // Best effort: a still beats an empty placeholder in the feed, but a clip
+    // the browser cannot decode must still post without one.
+    async uploadVideoPoster(file) {
+      try {
+        const poster = await captureVideoPoster(file);
+        if (!poster) return '';
+        return await warpnetService.uploadImage(poster) || '';
+      } catch (err) {
+        console.error('Failed to upload video poster:', err);
+        return '';
+      }
+    },
     readFileAsDataURL(file) {
       return new Promise((resolve, reject) => {
         const reader = new FileReader();
@@ -401,6 +420,7 @@ export default {
       }
       this.videoAttachment = null;
       this.videoKey = '';
+      this.videoPosterKey = '';
     },
     openAltModal(index) {
       this.altModalIndex = index;
@@ -419,6 +439,12 @@ export default {
         if (missing.length > 0) {
           const extra = await warpnetService.uploadImages(missing);
           imageKeys = imageKeys.concat(extra);
+        }
+        if (this.videoKey && this.videoPosterKey) {
+          // The captured frame rides along as the first image so readers can
+          // see a still without fetching the clip. The composer never mixes
+          // images and video, so it stays unambiguous on the other side.
+          imageKeys = [this.videoPosterKey, ...imageKeys];
         }
         await warpnetService.createTweet({text: draftText, imageKeys, videoKey: this.videoKey});
 

--- a/frontend/tests/components/TweetBlockVideo.spec.js
+++ b/frontend/tests/components/TweetBlockVideo.spec.js
@@ -140,6 +140,50 @@ describe('TweetBlock video', () => {
     });
   });
 
+  it('shows the captured frame on the placeholder instead of as an attachment', async () => {
+    warpnetService.getImage.mockImplementation(({key}) =>
+      Promise.resolve(key ? `data:image/jpeg;base64,${key}` : null));
+    const {container, getByLabelText} = renderTweet({...videoTweet, image_keys: ['poster1']});
+
+    await waitFor(() => {
+      expect(getByLabelText('Play video').querySelector('img')).not.toBeNull();
+    });
+    expect(getByLabelText('Play video').querySelector('img').getAttribute('src'))
+      .toBe('data:image/jpeg;base64,poster1');
+    expect(container.querySelector('img[alt="Tweet image"]')).toBeNull();
+    expect(warpnetService.getVideo).not.toHaveBeenCalled();
+  });
+
+  it('hands the captured frame to the player as its poster', async () => {
+    warpnetService.getImage.mockImplementation(({key}) =>
+      Promise.resolve(key ? `data:image/jpeg;base64,${key}` : null));
+    const {container, getByLabelText} = renderTweet({...videoTweet, image_keys: ['poster1']});
+
+    await waitFor(() => {
+      expect(getByLabelText('Play video').querySelector('img')).not.toBeNull();
+    });
+    await fireEvent.click(getByLabelText('Play video'));
+
+    await waitFor(() => {
+      expect(container.querySelector('video')?.getAttribute('poster'))
+        .toBe('data:image/jpeg;base64,poster1');
+    });
+  });
+
+  it('still renders attachments as a gallery on a post without a video', async () => {
+    warpnetService.getImage.mockImplementation(({key}) =>
+      Promise.resolve(key ? `data:image/jpeg;base64,${key}` : null));
+    const {container} = renderTweet({
+      ...videoTweet,
+      video_key: undefined,
+      image_keys: ['img1', 'img2'],
+    });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('img[alt="Tweet image"]').length).toBe(2);
+    });
+  });
+
   it('renders no video block for a tweet without a video key', async () => {
     const {container} = renderTweet({...videoTweet, video_key: undefined});
 

--- a/frontend/tests/lib/video.spec.js
+++ b/frontend/tests/lib/video.spec.js
@@ -1,11 +1,14 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {
     isAcceptedVideo,
     validateVideoFile,
     acceptedVideoAccept,
     MAX_VIDEO_BYTES,
+    POSTER_MAX_WIDTH,
+    POSTER_SEEK_SECONDS,
     normalizeVideoDataUrl,
     mimeForFile,
+    captureVideoPoster,
 } from '@/lib/video';
 
 const file = (type, name, size = 1024) => ({type, name, size});
@@ -102,6 +105,99 @@ describe('normalizeVideoDataUrl', () => {
     it('leaves the value alone when the file is not a known video', () => {
         const input = 'data:application/octet-stream;base64,AAAA';
         expect(normalizeVideoDataUrl(input, file('', 'notes.txt'))).toBe(input);
+    });
+});
+
+describe('captureVideoPoster', () => {
+    const fakeEnv = (overrides = {}) => {
+        const video = {};
+        const canvas = {
+            getContext: () => ({drawImage: () => {}}),
+            toDataURL: () => 'data:image/jpeg;base64,POSTER',
+        };
+        return {
+            video,
+            canvas,
+            env: {
+                createElement: tag => (tag === 'video' ? video : canvas),
+                createObjectURL: () => 'blob:clip',
+                revokeObjectURL: vi.fn(),
+                ...overrides,
+            },
+        };
+    };
+
+    const decode = (video, {duration = 10, width = 1280, height = 720} = {}) => {
+        video.duration = duration;
+        video.videoWidth = width;
+        video.videoHeight = height;
+        video.onloadeddata();
+    };
+
+    it('returns a JPEG data URL for a decodable clip', async () => {
+        const {video, env} = fakeEnv();
+        const pending = captureVideoPoster(file('video/mp4', 'clip.mp4'), env);
+
+        decode(video);
+        video.onseeked();
+
+        await expect(pending).resolves.toBe('data:image/jpeg;base64,POSTER');
+        expect(env.revokeObjectURL).toHaveBeenCalledWith('blob:clip');
+    });
+
+    it('takes the frame a second in, past any fade-in', async () => {
+        const {video, env} = fakeEnv();
+        const pending = captureVideoPoster(file('video/mp4', 'clip.mp4'), env);
+
+        decode(video);
+        expect(video.currentTime).toBe(POSTER_SEEK_SECONDS);
+
+        video.onseeked();
+        await pending;
+    });
+
+    it('falls back to the midpoint of a clip shorter than that', async () => {
+        const {video, env} = fakeEnv();
+        const pending = captureVideoPoster(file('video/mp4', 'blink.mp4'), env);
+
+        decode(video, {duration: 0.8});
+        expect(video.currentTime).toBe(0.4);
+
+        video.onseeked();
+        await pending;
+    });
+
+    it('downscales a large frame to the poster width', async () => {
+        const {video, canvas, env} = fakeEnv();
+        const pending = captureVideoPoster(file('video/mp4', 'uhd.mp4'), env);
+
+        decode(video, {width: 1920, height: 1080});
+        video.onseeked();
+        await pending;
+
+        expect(canvas.width).toBe(POSTER_MAX_WIDTH);
+        expect(canvas.height).toBe(360);
+    });
+
+    it('resolves null when the browser cannot decode the file', async () => {
+        const {video, env} = fakeEnv();
+        const pending = captureVideoPoster(file('video/quicktime', 'hevc.mov'), env);
+
+        video.onerror();
+
+        await expect(pending).resolves.toBeNull();
+        expect(env.revokeObjectURL).toHaveBeenCalledWith('blob:clip');
+    });
+
+    it('resolves null when the decoder never reports back', async () => {
+        const {env} = fakeEnv();
+        await expect(
+            captureVideoPoster(file('video/mp4', 'stuck.mp4'), {...env, timeoutMs: 0}),
+        ).resolves.toBeNull();
+    });
+
+    it('resolves null without a file', async () => {
+        await expect(captureVideoPoster(null)).resolves.toBeNull();
     });
 });
 


### PR DESCRIPTION
A post with a video rendered as a flat "Play video" button, so the feed gave no hint of what the clip was. The composer now grabs a frame one second in — past the usual fade-in, or the midpoint of a shorter clip — and uploads it through the existing image path. The key rides along as the tweet's first image key, which needs no backend change: the composer never mixes images and video, so a video post's first image is unambiguously its poster. Readers see the still without fetching the clip, and it doubles as the player's poster once they press play.

Capture is best effort. A clip the browser cannot decode (HEVC .mov outside Safari), a missing canvas or a stalled decoder leaves the previous placeholder and never blocks posting the video itself.