### PR TITLE
Tell users in the DM window that messages are E2E encrypted

### DIFF
--- a/frontend/src/views/Messages.vue
+++ b/frontend/src/views/Messages.vue
@@ -114,6 +114,14 @@ resulting from the use or misuse of this software.
         </button>
       </div>
 
+      <!-- Privacy notice -->
+      <div class="px-5 py-2 border-b border-lighter bg-white flex items-center justify-center">
+        <i class="fas fa-lock text-xs text-dark mr-2" aria-hidden="true"></i>
+        <p class="text-xs text-dark text-center">
+          Messages are end-to-end encrypted and stored only on your device and theirs.
+        </p>
+      </div>
+
       <!-- Messages -->
       <div ref="messagesScroll" class="flex-1 overflow-y-scroll px-5 pt-5 no-scrollbar" v-scroll:top="loadMore">
         <div class="flex flex-col">

--- a/frontend/src/views/Messages.vue
+++ b/frontend/src/views/Messages.vue
@@ -118,7 +118,7 @@ resulting from the use or misuse of this software.
       <div class="px-5 py-2 border-b border-lighter bg-white flex items-center justify-center">
         <i class="fas fa-lock text-xs text-dark mr-2" aria-hidden="true"></i>
         <p class="text-xs text-dark text-center">
-          Messages are end-to-end encrypted and stored only on your device and theirs.
+          Message sending is end-to-end encrypted and stored only on your device and theirs.
         </p>
       </div>
 


### PR DESCRIPTION
Adds a privacy notice between the chat header and the message list, outside the scroll container so it stays visible.

The claim rests on the transport: the libp2p noise session runs directly between the two participants' nodes, and /CHATS and /MESSAGES are never gossiped, DHT'd or replicated to relays, bootstrap or moderator nodes. Offline messages queue in the sender's own outbox, never a third party's.