### PR TITLE
Add polls to tweets

### DIFF
--- a/cmd/node/member/node/member-node.go
+++ b/cmd/node/member/node/member-node.go
@@ -349,19 +349,19 @@ func (m *MemberNode) setUserOffline(nodeIdStr streamNodeID) {
 // handler-list builders below so the registration func itself stays
 // small (golangci-lint maintidx).
 type memberRepos struct {
-	timelineRepo     *database.TimelineRepo
-	tweetRepo        *database.TweetRepo
-	likeRepo         *database.LikeRepo
-	pollRepo         *database.PollRepo
-	chatRepo         *database.ChatRepo
-	mediaRepo        *database.MediaRepo
-	notificationRepo *database.NotificationsRepo
-	settingsRepo     *database.SettingsRepo
-	bookmarkRepo     *database.BookmarkRepo
-	blocksRepo       *database.BlocksRepo
-	mutesRepo        *database.MutesRepo
-	subsRepo         *database.SubscriptionsRepo
-	filterRepo       *database.FilterRepo
+	timelineRepo     TimelineProvider
+	tweetRepo        TweetsProvider
+	likeRepo         LikesProvider
+	pollRepo         PollProvider
+	chatRepo         ChatProvider
+	mediaRepo        MediaProvider
+	notificationRepo NotificationProvider
+	settingsRepo     SettingsProvider
+	bookmarkRepo     BookmarkProvider
+	blocksRepo       BlocksProvider
+	mutesRepo        MutesProvider
+	subsRepo         SubscriptionProvider
+	filterRepo       FilterProvider
 }
 
 func (m *MemberNode) setupHandlers(

--- a/cmd/node/member/node/member-node.go
+++ b/cmd/node/member/node/member-node.go
@@ -352,6 +352,7 @@ type memberRepos struct {
 	timelineRepo     *database.TimelineRepo
 	tweetRepo        *database.TweetRepo
 	likeRepo         *database.LikeRepo
+	pollRepo         *database.PollRepo
 	chatRepo         *database.ChatRepo
 	mediaRepo        *database.MediaRepo
 	notificationRepo *database.NotificationsRepo
@@ -378,6 +379,7 @@ func (m *MemberNode) setupHandlers(
 		timelineRepo:     database.NewTimelineRepo(db),
 		tweetRepo:        database.NewTweetRepo(db, statsDB),
 		likeRepo:         database.NewLikeRepo(db, statsDB),
+		pollRepo:         database.NewPollRepo(db, statsDB),
 		chatRepo:         database.NewChatRepo(db),
 		mediaRepo:        database.NewMediaRepo(db),
 		notificationRepo: database.NewNotificationsRepo(db),
@@ -524,6 +526,14 @@ func (m *MemberNode) engagementHandlers(
 		{
 			event.PRIVATE_GET_LIKES,
 			handler.StreamGetLikesHandler(r.likeRepo),
+		},
+		{
+			event.PUBLIC_POST_POLL_VOTE,
+			handler.StreamPollVoteHandler(r.pollRepo, r.tweetRepo, userRepo, m),
+		},
+		{
+			event.PUBLIC_GET_POLL,
+			handler.StreamGetPollHandler(r.pollRepo, r.tweetRepo, userRepo, m),
 		},
 	}
 }

--- a/cmd/node/member/node/types.go
+++ b/cmd/node/member/node/types.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Warp-net/warpnet/core/mdns"
 	corePubsub "github.com/Warp-net/warpnet/core/pubsub"
 	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
 	"github.com/Warp-net/warpnet/database/datastore"
 	"github.com/Warp-net/warpnet/database/local-store"
 	"github.com/Warp-net/warpnet/domain"
@@ -149,4 +150,126 @@ type StatsStorer interface {
 	Decrement(key ds.Key) error
 	GetAggregatedStat(key ds.Key) (uint64, error)
 	Close() error
+}
+
+// Collaborator interfaces for the repos memberRepos bundles: the node wires
+// concrete repos in, handlers and tests can wire anything that fits.
+type BlocksProvider interface {
+	Block(blockerId string, blockeeId string) error
+	List(blockerId string, limit *uint64, cursor *string) ([]string, string, error)
+	Unblock(blockerId string, blockeeId string) error
+}
+
+type BookmarkProvider interface {
+	Bookmark(userId string, tweetId string, ownerUserId string) error
+	List(userId string, limit *uint64, cursor *string) ([]domain.Bookmark, string, error)
+	Unbookmark(userId string, tweetId string) error
+}
+
+type ChatProvider interface {
+	CreateChat(chatId *string, ownerId string, otherUserId string) (domain.Chat, error)
+	CreateMessage(msg domain.ChatMessage) (domain.ChatMessage, error)
+	DeleteChat(chatId string) error
+	DeleteMessage(chatId string, id string) error
+	GetChat(chatId string) (chat domain.Chat, err error)
+	GetMessage(chatId string, id string) (domain.ChatMessage, error)
+	GetUserChats(userId string, limit *uint64, cursor *string) ([]domain.Chat, string, error)
+	ListMessages(chatId string, limit *uint64, cursor *string) ([]domain.ChatMessage, string, error)
+}
+
+type FilterProvider interface {
+	AddKeyword(userId string, filterId string, kw domain.FilterKeyword) (domain.FilterKeyword, error)
+	Create(userId string, f domain.Filter) (domain.Filter, error)
+	Delete(userId string, filterId string) error
+	DeleteKeyword(userId string, keywordId string) error
+	Get(userId string, filterId string) (domain.Filter, error)
+	List(userId string, limit *uint64, cursor *string) ([]domain.Filter, string, error)
+	Update(userId string, f domain.Filter) (domain.Filter, error)
+	UpdateKeyword(userId string, kw domain.FilterKeyword) (domain.FilterKeyword, error)
+}
+
+type LikesProvider interface {
+	Like(tweetId string, userId string, isTransitive bool) (likesNum uint64, err error)
+	Liked(userId string, limit *uint64, cursor *string) ([]domain.LikedTweet, string, error)
+	Likers(tweetId string, limit *uint64, cursor *string) (likers []string, cur string, err error)
+	LikesCount(tweetId string) (likesNum uint64, err error)
+	RemoveLiked(userId string, tweetId string) error
+	SetLiked(userId string, tweetId string, ownerUserId string) error
+	Unlike(tweetId string, userId string, isTransitive bool) (likesNum uint64, err error)
+}
+
+type MediaProvider interface {
+	GetImage(userId string, key string) (database.Base64Image, error)
+	GetImageMeta(userId string, key string) (database.MediaMeta, error)
+	GetVideo(userId string, key string) (database.Base64Video, error)
+	SetForeignImageWithTTL(userId string, key string, img database.Base64Image) error
+	SetForeignVideoWithTTL(userId string, key string, video database.Base64Video) error
+	SetImage(userId string, img database.Base64Image) (_ database.ImageKey, err error)
+	SetImageMeta(userId string, key string, meta database.MediaMeta) error
+	SetVideo(userId string, video database.Base64Video) (_ database.VideoKey, err error)
+}
+
+type MutesProvider interface {
+	List(muterId string, limit *uint64, cursor *string) ([]string, string, error)
+	Mute(muterId string, muteeId string) error
+	Unmute(muterId string, muteeId string) error
+}
+
+type NotificationProvider interface {
+	Get(userId string, notificationId string) (domain.Notification, error)
+	List(userId string, limit *uint64, cursor *string) ([]domain.Notification, string, error)
+	MarkAllRead(userId string) error
+	MarkRead(userId string, notificationId string) error
+	ReverseList(userId string, cursor *string, limit *uint64) ([]domain.Notification, string, error)
+	UnreadCount(userId string) (uint64, error)
+}
+
+type PollProvider interface {
+	Results(tweetId string, optionsNum int) (votes []uint64, err error)
+	Vote(tweetId string, userId string, option int, isTransitive bool) error
+	Voted(tweetId string, userId string) (option int, ok bool, err error)
+}
+
+type SettingsProvider interface {
+	GetGatewaySettings(userId string) (domain.GatewaySettings, error)
+	GetNotificationSettings(userId string) (domain.NotificationSettings, error)
+	SetGatewaySettings(userId string, s domain.GatewaySettings) error
+	SetNotificationSettings(userId string, s domain.NotificationSettings) error
+}
+
+type SubscriptionProvider interface {
+	Subscribe(selfId string, targetUserId string) error
+	Unsubscribe(selfId string, targetUserId string) error
+}
+
+type TimelineProvider interface {
+	AddTweetToTimeline(userId string, tweet domain.Tweet) error
+	DeleteTweetFromTimeline(userID string, tweetID string) error
+	GetTimeline(string, *uint64, *string) ([]domain.Tweet, string, error)
+}
+
+type TweetsProvider interface {
+	AddReply(reply domain.Tweet, isTransitive bool) (domain.Tweet, error)
+	AppendEdit(edit domain.TweetEdit) (domain.TweetEdit, error)
+	Blocklist(tweetId string) error
+	Create(_ string, tweet domain.Tweet) (domain.Tweet, error)
+	CreateWithTTL(userId string, tweet domain.Tweet, duration time.Duration) (domain.Tweet, error)
+	Delete(userID string, tweetID string) error
+	DeleteReply(parentID string, replyID string, isTransitive bool) (domain.Tweet, error)
+	Get(userID string, tweetID string) (tweet domain.Tweet, err error)
+	GetReplies(parentID string, limit *uint64, cursor *string) ([]domain.Tweet, string, error)
+	GetReply(parentID string, replyID string) (domain.Tweet, error)
+	GetViewsCount(tweetId string) (uint64, error)
+	IsBlocklisted(tweetId string) bool
+	List(string, *uint64, *string) ([]domain.Tweet, string, error)
+	NewRetweet(tweet domain.Tweet, isTransitive bool) (_ domain.Tweet, err error)
+	Pin(userId string, tweetId string) (domain.Tweet, error)
+	RecordView(tweetId string, viewerId string) (uint64, error)
+	RepliesCount(tweetId string) (likesNum uint64, err error)
+	Retweeters(tweetId string, limit *uint64, cursor *string) (_ []string, cur string, err error)
+	RetweetsCount(tweetId string) (uint64, error)
+	TweetsCount(userId string) (uint64, error)
+	UnRetweet(retweetedByUserID string, tweetId string, isTransitive bool) error
+	Unpin(userId string, tweetId string) (domain.Tweet, error)
+	Update(tweet domain.Tweet) error
 }

--- a/core/handler/poll.go
+++ b/core/handler/poll.go
@@ -1,0 +1,287 @@
+/*
+
+Warpnet - Decentralized Social Network
+Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+<github.com.mecdy@passmail.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handler
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	log "github.com/sirupsen/logrus"
+)
+
+type PollVotesStorer interface {
+	Vote(tweetId, userId string, option int, isTransitive bool) error
+	Voted(tweetId, userId string) (option int, ok bool, err error)
+	Results(tweetId string, optionsNum int) (votes []uint64, err error)
+}
+
+// PollTweetFetcher resolves the tweet carrying the poll definition. The
+// definition is the only place the option count and deadline live, so it is
+// what bounds a vote.
+type PollTweetFetcher interface {
+	Get(userID, tweetID string) (tweet domain.Tweet, err error)
+}
+
+type PollStreamer interface {
+	GenericStream(nodeId string, path stream.WarpRoute, data any) (_ []byte, err error)
+	NodeInfo() warpnet.NodeInfo
+}
+
+func StreamPollVoteHandler(
+	repo PollVotesStorer,
+	tweetRepo PollTweetFetcher,
+	userRepo LikedUserFetcher,
+	streamer PollStreamer,
+) warpnet.WarpHandlerFunc {
+	return func(buf []byte, s warpnet.WarpStream) (any, error) {
+		var ev event.PollVoteEvent
+		if err := json.Unmarshal(buf, &ev); err != nil {
+			return nil, err
+		}
+		if ev.OwnerId == "" {
+			return nil, warpnet.WarpError("poll: empty owner id")
+		}
+		if ev.UserId == "" {
+			return nil, warpnet.WarpError("poll: empty user id")
+		}
+		if ev.TweetId == "" {
+			return nil, warpnet.WarpError("poll: empty tweet id")
+		}
+		if ev.Option < 0 {
+			return nil, warpnet.WarpError("poll: negative option")
+		}
+
+		tweetId := strings.TrimPrefix(ev.TweetId, domain.RetweetPrefix)
+		optionsNum := ev.OptionsNum
+
+		// The poll definition bounds the vote, but only a node holding the
+		// tweet can see it. Elsewhere the vote is taken on trust — the
+		// author's node, which always holds it, is the one that rejects an
+		// out-of-range or late vote.
+		if poll, ok := localPoll(tweetRepo, ev.UserId, tweetId); ok {
+			if ev.Option >= len(poll.Options) {
+				return nil, warpnet.WarpError("poll: option out of range")
+			}
+			if poll.IsClosed() {
+				return nil, warpnet.WarpError("poll: poll is closed")
+			}
+			optionsNum = len(poll.Options)
+		}
+
+		ownNodeInfo := streamer.NodeInfo()
+		// Mirrors the like path: the network-wide (CRDT) counter is bumped
+		// only on the voter's own node, so a vote stored on both the voter's
+		// and the author's node is counted once.
+		err := repo.Vote(tweetId, ev.OwnerId, ev.Option, ev.OwnerId == ownNodeInfo.OwnerId)
+		if err != nil && !errors.Is(err, database.ErrPollAlreadyVoted) {
+			log.Errorf("poll vote handler failed: %v", err)
+			return nil, err
+		}
+		// An already-recorded vote is not a failure: the event was replayed,
+		// or it reached this node twice. Report the current state.
+		alreadyVoted := err != nil
+
+		if !alreadyVoted && ev.OwnerId != ev.UserId {
+			propagateVote(ev, userRepo, streamer, ownNodeInfo)
+		}
+
+		return pollResults(repo, tweetId, ev.OwnerId, optionsNum)
+	}
+}
+
+// StreamGetPollHandler serves the vote tallies for a tweet's poll. Reads are
+// forwarded to the author's node — it sees every vote — while "did I vote"
+// is answered from this node, which is where the local user's own vote is
+// recorded even when the author is offline.
+func StreamGetPollHandler(
+	repo PollVotesStorer,
+	tweetRepo PollTweetFetcher,
+	userRepo LikedUserFetcher,
+	streamer PollStreamer,
+) warpnet.WarpHandlerFunc {
+	return func(buf []byte, s warpnet.WarpStream) (any, error) {
+		var ev event.GetPollEvent
+		if err := json.Unmarshal(buf, &ev); err != nil {
+			return nil, err
+		}
+		if ev.UserId == "" {
+			return nil, warpnet.WarpError("poll: empty user id")
+		}
+		if ev.TweetId == "" {
+			return nil, warpnet.WarpError("poll: empty tweet id")
+		}
+
+		tweetId := strings.TrimPrefix(ev.TweetId, domain.RetweetPrefix)
+		optionsNum := ev.OptionsNum
+		if poll, ok := localPoll(tweetRepo, ev.UserId, tweetId); ok {
+			optionsNum = len(poll.Options)
+		}
+		if optionsNum <= 0 {
+			return nil, warpnet.WarpError("poll: empty options number")
+		}
+
+		if remote, ok := forwardPollRead(ev, userRepo, streamer); ok {
+			remote.VotedOption = localVotedOption(repo, tweetId, ev.OwnerId)
+			return remote, nil
+		}
+
+		return pollResults(repo, tweetId, ev.OwnerId, optionsNum)
+	}
+}
+
+// localPoll returns the poll definition of a locally stored tweet. ok=false
+// means this node doesn't hold the tweet, or it carries no poll.
+func localPoll(tweetRepo PollTweetFetcher, authorId, tweetId string) (domain.Poll, bool) {
+	if tweetRepo == nil {
+		return domain.Poll{}, false
+	}
+	tweet, err := tweetRepo.Get(authorId, tweetId)
+	if err != nil || tweet.Poll == nil || len(tweet.Poll.Options) == 0 {
+		return domain.Poll{}, false
+	}
+	return *tweet.Poll, true
+}
+
+// propagateVote forwards the vote to the tweet author's node so the tally
+// everyone reads converges. An offline author is not a failure — the vote is
+// already recorded here and the CRDT counter carries it across.
+func propagateVote(
+	ev event.PollVoteEvent,
+	userRepo LikedUserFetcher,
+	streamer PollStreamer,
+	ownNodeInfo warpnet.NodeInfo,
+) {
+	if ev.UserId == ownNodeInfo.OwnerId {
+		return // this node hosts the author: the vote is already where it belongs
+	}
+	author, err := userRepo.Get(ev.UserId)
+	if errors.Is(err, database.ErrUserNotFound) {
+		return
+	}
+	if err != nil {
+		log.Errorf("poll vote: get author: %v", err)
+		return
+	}
+	if author.NodeId == ownNodeInfo.ID.String() {
+		return
+	}
+
+	resp, err := streamer.GenericStream(author.NodeId, event.PUBLIC_POST_POLL_VOTE, ev)
+	if errors.Is(err, warpnet.ErrNodeIsOffline) {
+		return
+	}
+	if err != nil {
+		log.Errorf("poll vote: stream to %s: %v", author.NodeId, err)
+		return
+	}
+
+	var possibleError event.ResponseError
+	if _ = json.Unmarshal(resp, &possibleError); possibleError.Message != "" {
+		log.Errorf("unmarshal other poll vote error response: %s", possibleError.Message)
+	}
+}
+
+// forwardPollRead asks the author's node for the tally. ok=false means
+// handle the read locally.
+func forwardPollRead(
+	ev event.GetPollEvent,
+	userRepo LikedUserFetcher,
+	streamer PollStreamer,
+) (event.PollResultsResponse, bool) {
+	ownNodeInfo := streamer.NodeInfo()
+	if ev.UserId == ownNodeInfo.OwnerId {
+		return event.PollResultsResponse{}, false
+	}
+	author, err := userRepo.Get(ev.UserId)
+	if err != nil || author.NodeId == "" || author.NodeId == ownNodeInfo.ID.String() {
+		return event.PollResultsResponse{}, false
+	}
+
+	resp, err := streamer.GenericStream(author.NodeId, event.PUBLIC_GET_POLL, ev)
+	if err != nil {
+		if !errors.Is(err, warpnet.ErrNodeIsOffline) {
+			log.Errorf("poll read: stream to %s: %v", author.NodeId, err)
+		}
+		return event.PollResultsResponse{}, false
+	}
+
+	var possibleError event.ResponseError
+	if _ = json.Unmarshal(resp, &possibleError); possibleError.Message != "" {
+		log.Errorf("unmarshal other poll read error response: %s", possibleError.Message)
+		return event.PollResultsResponse{}, false
+	}
+
+	var out event.PollResultsResponse
+	if err := json.Unmarshal(resp, &out); err != nil || len(out.Votes) == 0 {
+		return event.PollResultsResponse{}, false
+	}
+	return out, true
+}
+
+// localVotedOption reports the option userId picked, as recorded on this
+// node. nil means no local record of a vote.
+func localVotedOption(repo PollVotesStorer, tweetId, userId string) *int {
+	if userId == "" {
+		return nil
+	}
+	option, ok, err := repo.Voted(tweetId, userId)
+	if err != nil {
+		log.Warnf("poll: voted lookup: %v", err)
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+	return &option
+}
+
+func pollResults(repo PollVotesStorer, tweetId, userId string, optionsNum int) (event.PollResultsResponse, error) {
+	if optionsNum <= 0 {
+		return event.PollResultsResponse{}, warpnet.WarpError("poll: empty options number")
+	}
+	votes, err := repo.Results(tweetId, optionsNum)
+	if err != nil {
+		return event.PollResultsResponse{}, err
+	}
+	var total uint64
+	for _, v := range votes {
+		total += v
+	}
+	return event.PollResultsResponse{
+		TweetId:     tweetId,
+		Votes:       votes,
+		TotalVotes:  total,
+		VotedOption: localVotedOption(repo, tweetId, userId),
+	}, nil
+}

--- a/core/handler/poll_test.go
+++ b/core/handler/poll_test.go
@@ -1,0 +1,407 @@
+/*
+
+Warpnet - Decentralized Social Network
+Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+<github.com.mecdy@passmail.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+)
+
+type stubPollRepo struct {
+	voteFn    func(tweetId, userId string, option int, isTransitive bool) error
+	votedFn   func(tweetId, userId string) (int, bool, error)
+	resultsFn func(tweetId string, optionsNum int) ([]uint64, error)
+}
+
+func (s stubPollRepo) Vote(tweetId, userId string, option int, isTransitive bool) error {
+	if s.voteFn != nil {
+		return s.voteFn(tweetId, userId, option, isTransitive)
+	}
+	return nil
+}
+
+func (s stubPollRepo) Voted(tweetId, userId string) (int, bool, error) {
+	if s.votedFn != nil {
+		return s.votedFn(tweetId, userId)
+	}
+	return 0, false, nil
+}
+
+func (s stubPollRepo) Results(tweetId string, optionsNum int) ([]uint64, error) {
+	if s.resultsFn != nil {
+		return s.resultsFn(tweetId, optionsNum)
+	}
+	return make([]uint64, optionsNum), nil
+}
+
+type stubPollTweetRepo struct {
+	getFn func(userId, tweetId string) (domain.Tweet, error)
+}
+
+func (s stubPollTweetRepo) Get(userId, tweetId string) (domain.Tweet, error) {
+	if s.getFn != nil {
+		return s.getFn(userId, tweetId)
+	}
+	return domain.Tweet{}, database.ErrTweetNotFound
+}
+
+func pollTweet(tweetId, authorId string, expiresAt time.Time) stubPollTweetRepo {
+	return stubPollTweetRepo{getFn: func(_, _ string) (domain.Tweet, error) {
+		return domain.Tweet{
+			Id:     tweetId,
+			UserId: authorId,
+			Poll:   &domain.Poll{Options: []string{"yes", "no"}, ExpiresAt: expiresAt},
+		}, nil
+	}}
+}
+
+func TestStreamPollVoteHandler(t *testing.T) {
+	voter := "owner-1"
+	author := "tweet-owner"
+	tweetId := "tweet-1"
+	future := time.Now().Add(time.Hour)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		if _, err := h([]byte("{"), nil); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty owner id", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, UserId: author, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: empty owner id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty tweet id", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{OwnerId: voter, UserId: author, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: empty tweet id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("negative option", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: -1, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: negative option" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("option out of range", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, pollTweet(tweetId, author, future), stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 2, OptionsNum: 3}), nil)
+		if err == nil || err.Error() != "poll: option out of range" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("closed poll", func(t *testing.T) {
+		h := StreamPollVoteHandler(stubPollRepo{}, pollTweet(tweetId, author, time.Now().Add(-time.Hour)), stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 1, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: poll is closed" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("vote repo error", func(t *testing.T) {
+		repoErr := errors.New("db error")
+		repo := stubPollRepo{voteFn: func(_, _ string, _ int, _ bool) error { return repoErr }}
+		h := StreamPollVoteHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 1, OptionsNum: 2}), nil)
+		if !errors.Is(err, repoErr) {
+			t.Fatalf("expected repo error, got: %v", err)
+		}
+	})
+
+	t.Run("happy path bumps the crdt counter on the voter's own node", func(t *testing.T) {
+		var gotTransitive bool
+		repo := stubPollRepo{
+			voteFn: func(_, gotUser string, gotOption int, isTransitive bool) error {
+				gotTransitive = isTransitive
+				if gotUser != voter {
+					t.Fatalf("expected the voter to be recorded, got %q", gotUser)
+				}
+				if gotOption != 1 {
+					t.Fatalf("unexpected option: %d", gotOption)
+				}
+				return nil
+			},
+			resultsFn: func(_ string, optionsNum int) ([]uint64, error) {
+				return []uint64{3, 4}, nil
+			},
+			votedFn: func(_, _ string) (int, bool, error) { return 1, true, nil },
+		}
+		streamer := stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: voter}}
+		h := StreamPollVoteHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 1, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !gotTransitive {
+			t.Fatal("expected the vote to be transitive on the voter's own node")
+		}
+		out := resp.(event.PollResultsResponse)
+		if out.TotalVotes != 7 {
+			t.Fatalf("unexpected total: %d", out.TotalVotes)
+		}
+		if out.VotedOption == nil || *out.VotedOption != 1 {
+			t.Fatalf("unexpected voted option: %v", out.VotedOption)
+		}
+	})
+
+	t.Run("vote received on the author's node is not transitive", func(t *testing.T) {
+		var gotTransitive = true
+		repo := stubPollRepo{voteFn: func(_, _ string, _ int, isTransitive bool) error {
+			gotTransitive = isTransitive
+			return nil
+		}}
+		streamer := stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: author}}
+		h := StreamPollVoteHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		if _, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 0, OptionsNum: 2}), nil); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if gotTransitive {
+			t.Fatal("expected the vote not to be transitive on the author's node")
+		}
+	})
+
+	t.Run("propagates to the author's node", func(t *testing.T) {
+		var gotPath stream.WarpRoute
+		var gotNode string
+		streamer := stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: voter},
+			genericStreamFn: func(nodeId string, path stream.WarpRoute, _ any) ([]byte, error) {
+				gotNode, gotPath = nodeId, path
+				return nil, nil
+			},
+		}
+		h := StreamPollVoteHandler(stubPollRepo{}, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		if _, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 0, OptionsNum: 2}), nil); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if gotNode != "node-2" || gotPath != event.PUBLIC_POST_POLL_VOTE {
+			t.Fatalf("unexpected propagation: %s %s", gotNode, gotPath)
+		}
+	})
+
+	t.Run("offline author still returns local results", func(t *testing.T) {
+		streamer := stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: voter},
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return nil, warpnet.ErrNodeIsOffline
+			},
+		}
+		repo := stubPollRepo{resultsFn: func(string, int) ([]uint64, error) { return []uint64{1, 0}, nil }}
+		h := StreamPollVoteHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 0, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.PollResultsResponse).TotalVotes != 1 {
+			t.Fatalf("unexpected total: %v", resp)
+		}
+	})
+
+	t.Run("a replayed vote is not an error", func(t *testing.T) {
+		streamed := false
+		streamer := stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: voter},
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				streamed = true
+				return nil, nil
+			},
+		}
+		repo := stubPollRepo{
+			voteFn:    func(string, string, int, bool) error { return database.ErrPollAlreadyVoted },
+			resultsFn: func(string, int) ([]uint64, error) { return []uint64{2, 5}, nil },
+		}
+		h := StreamPollVoteHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 0, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.PollResultsResponse).TotalVotes != 7 {
+			t.Fatalf("unexpected total: %v", resp)
+		}
+		if streamed {
+			t.Fatal("a replayed vote must not be propagated again")
+		}
+	})
+
+	t.Run("unknown tweet trusts the payload's option count", func(t *testing.T) {
+		var gotOptionsNum int
+		repo := stubPollRepo{resultsFn: func(_ string, optionsNum int) ([]uint64, error) {
+			gotOptionsNum = optionsNum
+			return make([]uint64, optionsNum), nil
+		}}
+		streamer := stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: voter}}
+		h := StreamPollVoteHandler(repo, stubPollTweetRepo{}, stubLikeUserRepo{}, streamer)
+
+		if _, err := h(marshal(t, event.PollVoteEvent{TweetId: tweetId, OwnerId: voter, UserId: author, Option: 2, OptionsNum: 4}), nil); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if gotOptionsNum != 4 {
+			t.Fatalf("unexpected options num: %d", gotOptionsNum)
+		}
+	})
+}
+
+func TestStreamGetPollHandler(t *testing.T) {
+	reader := "owner-1"
+	author := "tweet-owner"
+	tweetId := "tweet-1"
+	future := time.Now().Add(time.Hour)
+
+	t.Run("invalid payload", func(t *testing.T) {
+		h := StreamGetPollHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		if _, err := h([]byte("{"), nil); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty user id", func(t *testing.T) {
+		h := StreamGetPollHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetPollEvent{TweetId: tweetId, OwnerId: reader, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: empty user id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty tweet id", func(t *testing.T) {
+		h := StreamGetPollHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetPollEvent{UserId: author, OwnerId: reader, OptionsNum: 2}), nil)
+		if err == nil || err.Error() != "poll: empty tweet id" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("empty options number", func(t *testing.T) {
+		h := StreamGetPollHandler(stubPollRepo{}, stubPollTweetRepo{}, stubLikeUserRepo{}, stubStreamer{})
+		_, err := h(marshal(t, event.GetPollEvent{TweetId: tweetId, UserId: author, OwnerId: reader}), nil)
+		if err == nil || err.Error() != "poll: empty options number" {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("local read on the author's own node", func(t *testing.T) {
+		repo := stubPollRepo{
+			resultsFn: func(_ string, optionsNum int) ([]uint64, error) { return []uint64{1, 2}, nil },
+			votedFn:   func(_, _ string) (int, bool, error) { return 0, true, nil },
+		}
+		streamer := stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: author}}
+		h := StreamGetPollHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.GetPollEvent{TweetId: tweetId, UserId: author, OwnerId: author, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		out := resp.(event.PollResultsResponse)
+		if out.TotalVotes != 3 {
+			t.Fatalf("unexpected total: %d", out.TotalVotes)
+		}
+		if out.VotedOption == nil || *out.VotedOption != 0 {
+			t.Fatalf("unexpected voted option: %v", out.VotedOption)
+		}
+	})
+
+	t.Run("forwarded read keeps the local voted option", func(t *testing.T) {
+		remote, err := json.Marshal(event.PollResultsResponse{
+			TweetId: tweetId, Votes: []uint64{9, 1}, TotalVotes: 10,
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		streamer := stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: reader},
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) { return remote, nil },
+		}
+		repo := stubPollRepo{
+			resultsFn: func(string, int) ([]uint64, error) { return []uint64{0, 1}, nil },
+			votedFn:   func(_, _ string) (int, bool, error) { return 1, true, nil },
+		}
+		h := StreamGetPollHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.GetPollEvent{TweetId: tweetId, UserId: author, OwnerId: reader, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		out := resp.(event.PollResultsResponse)
+		if out.TotalVotes != 10 {
+			t.Fatalf("expected the author's tally, got: %d", out.TotalVotes)
+		}
+		if out.VotedOption == nil || *out.VotedOption != 1 {
+			t.Fatalf("unexpected voted option: %v", out.VotedOption)
+		}
+	})
+
+	t.Run("offline author falls back to the local tally", func(t *testing.T) {
+		streamer := stubStreamer{
+			nodeInfo: warpnet.NodeInfo{OwnerId: reader},
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return nil, warpnet.ErrNodeIsOffline
+			},
+		}
+		repo := stubPollRepo{resultsFn: func(string, int) ([]uint64, error) { return []uint64{0, 1}, nil }}
+		h := StreamGetPollHandler(repo, pollTweet(tweetId, author, future), stubLikeUserRepo{}, streamer)
+
+		resp, err := h(marshal(t, event.GetPollEvent{TweetId: tweetId, UserId: author, OwnerId: reader, OptionsNum: 2}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp.(event.PollResultsResponse).TotalVotes != 1 {
+			t.Fatalf("unexpected total: %v", resp)
+		}
+	})
+}

--- a/core/handler/tweet.go
+++ b/core/handler/tweet.go
@@ -131,6 +131,9 @@ func StreamNewTweetHandler(
 		if utf8.RuneCountInString(ev.Text) > tweetCharLimit {
 			return nil, warpnet.WarpError("tweet text is too long")
 		}
+		if err := validatePoll(ev.Poll); err != nil {
+			return nil, err
+		}
 
 		// A reply is a tweet with a parent: it lives inside its thread, not
 		// in the timeline, so it never reaches the follower-broadcast path.
@@ -174,6 +177,7 @@ func StreamNewTweetHandler(
 				Username:  tweet.Username,
 				ImageKeys: tweet.ImageKeys,
 				VideoKey:  tweet.VideoKey,
+				Poll:      tweet.Poll,
 			}
 			bt, _ := json.Marshal(respTweetEvent)
 			if err := broadcaster.PublishUpdateToFollowers(owner.UserId, event.PRIVATE_POST_TWEET, bt); err != nil {
@@ -182,6 +186,35 @@ func StreamNewTweetHandler(
 		}
 		return tweet, nil
 	}
+}
+
+// validatePoll checks the poll definition a tweet carries. The definition is
+// immutable once the tweet exists, so this is the only chance to reject a
+// malformed one. Whether the poll has already closed is deliberately not
+// checked here: a tweet can legitimately reach a peer after its poll ended,
+// and the vote handler is what refuses a late vote.
+func validatePoll(p *domain.Poll) error {
+	if p == nil {
+		return nil
+	}
+	if len(p.Options) < domain.PollMinOptions {
+		return warpnet.WarpError("poll: too few options")
+	}
+	if len(p.Options) > domain.PollMaxOptions {
+		return warpnet.WarpError("poll: too many options")
+	}
+	if p.ExpiresAt.IsZero() {
+		return warpnet.WarpError("poll: empty expiration time")
+	}
+	for _, opt := range p.Options {
+		if strings.TrimSpace(opt) == "" {
+			return warpnet.WarpError("poll: empty option")
+		}
+		if utf8.RuneCountInString(opt) > domain.PollOptionRuneLimit {
+			return warpnet.WarpError("poll: option is too long")
+		}
+	}
+	return nil
 }
 
 // handleNewReply stores a reply in its thread, notifies the parent tweet's
@@ -213,6 +246,7 @@ func handleNewReply(
 		Username:     ev.Username,
 		ImageKeys:    ev.ImageKeys,
 		VideoKey:     ev.VideoKey,
+		Poll:         ev.Poll,
 	}, ev.UserId == ownNodeInfo.OwnerId)
 	if err != nil {
 		log.Errorf("reply handler failed: %v", err)
@@ -267,6 +301,7 @@ func handleNewReply(
 			Username:     reply.Username,
 			ImageKeys:    reply.ImageKeys,
 			VideoKey:     reply.VideoKey,
+			Poll:         reply.Poll,
 		},
 	)
 	if errors.Is(err, warpnet.ErrNodeIsOffline) {

--- a/core/handler/tweet_test.go
+++ b/core/handler/tweet_test.go
@@ -3,6 +3,7 @@ package handler
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -283,6 +284,55 @@ func TestStreamNewTweetHandler(t *testing.T) {
 		_, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: string(longText)}), nil)
 		if err == nil || err.Error() != "tweet text is too long" {
 			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("poll validation", func(t *testing.T) {
+		expires := time.Now().Add(time.Hour)
+		longOption := strings.Repeat("a", domain.PollOptionRuneLimit+1)
+		for _, tt := range []struct {
+			name string
+			poll *domain.Poll
+			want string
+		}{
+			{"too few options", &domain.Poll{Options: []string{"only"}, ExpiresAt: expires}, "poll: too few options"},
+			{"too many options", &domain.Poll{Options: []string{"a", "b", "c", "d", "e"}, ExpiresAt: expires}, "poll: too many options"},
+			{"no expiration", &domain.Poll{Options: []string{"a", "b"}}, "poll: empty expiration time"},
+			{"blank option", &domain.Poll{Options: []string{"a", "  "}, ExpiresAt: expires}, "poll: empty option"},
+			{"option too long", &domain.Poll{Options: []string{"a", longOption}, ExpiresAt: expires}, "poll: option is too long"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				h := StreamNewTweetHandler(stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}}, stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{}, stubTweetUserRepo{}, stubModerationNotifier{}, stubStreamer{})
+				_, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: "vote", Poll: tt.poll}), nil)
+				if err == nil || err.Error() != tt.want {
+					t.Fatalf("unexpected err: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("poll is broadcast to followers", func(t *testing.T) {
+		poll := &domain.Poll{Options: []string{"yes", "no"}, ExpiresAt: time.Now().Add(time.Hour)}
+		var published []byte
+		broadcaster := stubTweetBroadcaster{publishFn: func(_, _ string, bt []byte) error {
+			published = bt
+			return nil
+		}}
+		repo := stubTweetRepo{createFn: func(_ string, tweet domain.Tweet) (domain.Tweet, error) {
+			tweet.Id = "tweet-1"
+			return tweet, nil
+		}}
+		h := StreamNewTweetHandler(broadcaster, stubAuth{owner: domain.Owner{UserId: owner}}, repo, stubTimelineRepo{}, stubFollowChecker{}, stubTweetUserRepo{}, stubModerationNotifier{}, stubStreamer{})
+
+		if _, err := h(marshal(t, event.NewTweetEvent{UserId: owner, Text: "vote", Poll: poll}), nil); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		var broadcast domain.Tweet
+		if err := json.Unmarshal(published, &broadcast); err != nil {
+			t.Fatalf("unmarshal broadcast: %v", err)
+		}
+		if broadcast.Poll == nil || len(broadcast.Poll.Options) != 2 {
+			t.Fatalf("followers must receive the poll, got: %+v", broadcast.Poll)
 		}
 	})
 

--- a/database/poll-repo.go
+++ b/database/poll-repo.go
@@ -1,0 +1,199 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package database
+
+import (
+	"encoding/binary"
+	"strconv"
+
+	ds "github.com/Warp-net/warpnet/database/datastore"
+	"github.com/Warp-net/warpnet/database/local-store"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	PollRepoName      = "/POLLS"
+	VoterSubNamespace = "VOTER"
+)
+
+var ErrPollAlreadyVoted = local_store.DBError("poll already voted")
+
+type PollStorer interface {
+	Get(key local_store.DatabaseKey) ([]byte, error)
+	NewTxn() (local_store.WarpTransactioner, error)
+}
+
+type PollStatsStorer interface {
+	GetAggregatedStat(key ds.Key) (uint64, error)
+	Increment(key ds.Key) error
+}
+
+type PollRepo struct {
+	db      PollStorer
+	statsDb PollStatsStorer
+}
+
+func NewPollRepo(db PollStorer, statsDb PollStatsStorer) *PollRepo {
+	return &PollRepo{db: db, statsDb: statsDb}
+}
+
+func pollVotesKey(tweetId string, option int) local_store.DatabaseKey {
+	return local_store.NewPrefixBuilder(PollRepoName).
+		AddSubPrefix(IncrSubNamespace).
+		AddRootID(tweetId).
+		AddParentId(strconv.Itoa(option)).
+		Build()
+}
+
+func pollVoterKey(tweetId, userId string) local_store.DatabaseKey {
+	return local_store.NewPrefixBuilder(PollRepoName).
+		AddSubPrefix(VoterSubNamespace).
+		AddRootID(tweetId).
+		AddRange(local_store.NoneRangeKey).
+		AddParentId(userId).
+		Build()
+}
+
+// Vote records userId's choice on the poll attached to tweetId. A vote is
+// final: a second call for the same voter returns ErrPollAlreadyVoted and
+// changes nothing, so a replayed or propagated event can't inflate a count.
+//
+// isTransitive carries the same meaning as in LikeRepo: the network-wide
+// (CRDT) counter is bumped only on the voter's own node, so a vote stored on
+// both the voter's and the author's node is counted once.
+func (repo *PollRepo) Vote(tweetId, userId string, option int, isTransitive bool) error {
+	if tweetId == "" {
+		return local_store.DBError("empty tweet id")
+	}
+	if userId == "" {
+		return local_store.DBError("empty user id")
+	}
+	if option < 0 {
+		return local_store.DBError("negative poll option")
+	}
+
+	votesKey := pollVotesKey(tweetId, option)
+	voterKey := pollVoterKey(tweetId, userId)
+
+	txn, err := repo.db.NewTxn()
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	_, err = txn.Get(voterKey)
+	if !local_store.IsNotFoundError(err) {
+		_ = txn.Commit()
+		return ErrPollAlreadyVoted
+	}
+
+	if err = txn.Set(voterKey, []byte(strconv.Itoa(option))); err != nil {
+		return err
+	}
+	if _, err = txn.Increment(votesKey); err != nil {
+		return err
+	}
+	if err = txn.Commit(); err != nil {
+		return err
+	}
+	if repo.statsDb == nil || !isTransitive {
+		return nil
+	}
+	if err := repo.statsDb.Increment(votesKey.DatastoreKey()); err != nil {
+		log.Warnf("poll: stats db increment: %v", err)
+	}
+	return nil
+}
+
+// Voted returns the option userId picked on tweetId's poll. ok is false when
+// they haven't voted.
+func (repo *PollRepo) Voted(tweetId, userId string) (option int, ok bool, err error) {
+	if tweetId == "" {
+		return 0, false, local_store.DBError("empty tweet id")
+	}
+	if userId == "" {
+		return 0, false, local_store.DBError("empty user id")
+	}
+
+	bt, err := repo.db.Get(pollVoterKey(tweetId, userId))
+	if local_store.IsNotFoundError(err) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	option, err = strconv.Atoi(string(bt))
+	if err != nil {
+		return 0, false, err
+	}
+	return option, true, nil
+}
+
+// Results returns the vote count for each of the poll's optionsNum options,
+// in option order. Like the other engagement counters it prefers the
+// network-wide (CRDT) total and falls back to this node's own counter.
+func (repo *PollRepo) Results(tweetId string, optionsNum int) (votes []uint64, err error) {
+	if tweetId == "" {
+		return nil, local_store.DBError("empty tweet id")
+	}
+	if optionsNum <= 0 {
+		return nil, local_store.DBError("empty poll options")
+	}
+
+	votes = make([]uint64, optionsNum)
+	for i := range votes {
+		votes[i], err = repo.optionVotes(tweetId, i)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return votes, nil
+}
+
+// optionVotes reads one option's counter. A missing counter means nobody
+// picked that option yet, which is zero rather than an error.
+func (repo *PollRepo) optionVotes(tweetId string, option int) (uint64, error) {
+	votesKey := pollVotesKey(tweetId, option)
+
+	if repo.statsDb != nil {
+		total, err := repo.statsDb.GetAggregatedStat(votesKey.DatastoreKey())
+		if err == nil {
+			return total, nil
+		}
+		log.Warnf("crdt poll votes not found for %s option %d - %s", tweetId, option, err)
+	}
+
+	bt, err := repo.db.Get(votesKey)
+	if local_store.IsNotFoundError(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(bt), nil
+}

--- a/database/poll-repo.go
+++ b/database/poll-repo.go
@@ -37,8 +37,16 @@ import (
 )
 
 const (
-	PollRepoName      = "/POLLS"
-	VoterSubNamespace = "VOTER"
+	PollRepoName = "/POLLS"
+
+	// Poll-owned key segments. They deliberately duplicate the values likes
+	// use rather than borrowing LikeRepoName's constants: the two keyspaces
+	// are independent, and sharing a constant would silently move the poll
+	// keys if likes ever renamed theirs.
+	VotesSubNamespace     = "VOTES" // per-option vote counters
+	VotesIncrSubNamespace = "INCR"
+	VotesDecrSubNamespace = "DECR"
+	VoterSubNamespace     = "VOTER" // per-voter record of the option they picked
 )
 
 var ErrPollAlreadyVoted = local_store.DBError("poll already voted")
@@ -62,9 +70,13 @@ func NewPollRepo(db PollStorer, statsDb PollStatsStorer) *PollRepo {
 	return &PollRepo{db: db, statsDb: statsDb}
 }
 
-func pollVotesKey(tweetId string, option int) local_store.DatabaseKey {
+// pollVotesKey addresses one option's counter. direction is
+// VotesIncrSubNamespace or VotesDecrSubNamespace, mirroring the PN-counter
+// split the CRDT stats store uses.
+func pollVotesKey(tweetId string, option int, direction string) local_store.DatabaseKey {
 	return local_store.NewPrefixBuilder(PollRepoName).
-		AddSubPrefix(IncrSubNamespace).
+		AddSubPrefix(VotesSubNamespace).
+		AddSubPrefix(direction).
 		AddRootID(tweetId).
 		AddParentId(strconv.Itoa(option)).
 		Build()
@@ -97,7 +109,7 @@ func (repo *PollRepo) Vote(tweetId, userId string, option int, isTransitive bool
 		return local_store.DBError("negative poll option")
 	}
 
-	votesKey := pollVotesKey(tweetId, option)
+	votesKey := pollVotesKey(tweetId, option, VotesIncrSubNamespace)
 	voterKey := pollVoterKey(tweetId, userId)
 
 	txn, err := repo.db.NewTxn()
@@ -175,20 +187,42 @@ func (repo *PollRepo) Results(tweetId string, optionsNum int) (votes []uint64, e
 	return votes, nil
 }
 
-// optionVotes reads one option's counter. A missing counter means nobody
-// picked that option yet, which is zero rather than an error.
+// optionVotes reads one option's tally. It prefers the network-wide (CRDT)
+// total and falls back to this node's own counters.
+//
+// The CRDT store keeps its own positive/negative split for whichever key it
+// is handed, so only the INCR key goes to it — same as likes, where an
+// unlike decrements that very key. The local fallback is the plain
+// difference of the two counters.
 func (repo *PollRepo) optionVotes(tweetId string, option int) (uint64, error) {
-	votesKey := pollVotesKey(tweetId, option)
+	incrKey := pollVotesKey(tweetId, option, VotesIncrSubNamespace)
 
 	if repo.statsDb != nil {
-		total, err := repo.statsDb.GetAggregatedStat(votesKey.DatastoreKey())
+		total, err := repo.statsDb.GetAggregatedStat(incrKey.DatastoreKey())
 		if err == nil {
 			return total, nil
 		}
 		log.Warnf("crdt poll votes not found for %s option %d - %s", tweetId, option, err)
 	}
 
-	bt, err := repo.db.Get(votesKey)
+	incr, err := repo.localCounter(incrKey)
+	if err != nil {
+		return 0, err
+	}
+	decr, err := repo.localCounter(pollVotesKey(tweetId, option, VotesDecrSubNamespace))
+	if err != nil {
+		return 0, err
+	}
+	if decr >= incr {
+		return 0, nil
+	}
+	return incr - decr, nil
+}
+
+// localCounter reads a counter this node keeps. A missing key means nothing
+// has been counted there yet, which is zero rather than an error.
+func (repo *PollRepo) localCounter(key local_store.DatabaseKey) (uint64, error) {
+	bt, err := repo.db.Get(key)
 	if local_store.IsNotFoundError(err) {
 		return 0, nil
 	}

--- a/database/poll-repo_test.go
+++ b/database/poll-repo_test.go
@@ -1,0 +1,139 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/Warp-net/warpnet/database/local-store"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/suite"
+)
+
+type PollRepoTestSuite struct {
+	suite.Suite
+
+	db   *local_store.DB
+	repo *PollRepo
+}
+
+func (s *PollRepoTestSuite) SetupSuite() {
+	var err error
+	s.db, err = local_store.New("", local_store.DefaultOptions().WithInMemory(true))
+	s.Require().NoError(err)
+
+	authRepo := NewAuthRepo(s.db, "test")
+	err = authRepo.Authenticate("test", "test")
+	s.Require().NoError(err)
+
+	s.repo = NewPollRepo(s.db, nil)
+}
+
+func (s *PollRepoTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func (s *PollRepoTestSuite) TestVoteAndResults() {
+	tweetId := ulid.Make().String()
+	first := ulid.Make().String()
+	second := ulid.Make().String()
+
+	s.Require().NoError(s.repo.Vote(tweetId, first, 1, true))
+	s.Require().NoError(s.repo.Vote(tweetId, second, 1, true))
+
+	votes, err := s.repo.Results(tweetId, 3)
+	s.Require().NoError(err)
+	s.Equal([]uint64{0, 2, 0}, votes)
+
+	option, ok, err := s.repo.Voted(tweetId, first)
+	s.Require().NoError(err)
+	s.True(ok)
+	s.Equal(1, option)
+}
+
+func (s *PollRepoTestSuite) TestVote_IsFinal() {
+	tweetId := ulid.Make().String()
+	userId := ulid.Make().String()
+
+	s.Require().NoError(s.repo.Vote(tweetId, userId, 0, true))
+
+	// A second vote — a replay, or the same event arriving through the
+	// author's node — must not move any counter.
+	err := s.repo.Vote(tweetId, userId, 1, true)
+	s.EqualError(err, ErrPollAlreadyVoted.Error())
+
+	votes, err := s.repo.Results(tweetId, 2)
+	s.Require().NoError(err)
+	s.Equal([]uint64{1, 0}, votes)
+
+	option, ok, err := s.repo.Voted(tweetId, userId)
+	s.Require().NoError(err)
+	s.True(ok)
+	s.Equal(0, option)
+}
+
+func (s *PollRepoTestSuite) TestVoted_NoVote() {
+	option, ok, err := s.repo.Voted(ulid.Make().String(), ulid.Make().String())
+	s.Require().NoError(err)
+	s.False(ok)
+	s.Zero(option)
+}
+
+func (s *PollRepoTestSuite) TestResults_NoVotes() {
+	votes, err := s.repo.Results(ulid.Make().String(), 2)
+	s.Require().NoError(err)
+	s.Equal([]uint64{0, 0}, votes)
+}
+
+func (s *PollRepoTestSuite) TestInvalidParams() {
+	tweetId := ulid.Make().String()
+	userId := ulid.Make().String()
+
+	s.Error(s.repo.Vote("", userId, 0, true))
+	s.Error(s.repo.Vote(tweetId, "", 0, true))
+	s.Error(s.repo.Vote(tweetId, userId, -1, true))
+
+	_, _, err := s.repo.Voted("", userId)
+	s.Error(err)
+	_, _, err = s.repo.Voted(tweetId, "")
+	s.Error(err)
+
+	_, err = s.repo.Results("", 2)
+	s.Error(err)
+	_, err = s.repo.Results(tweetId, 0)
+	s.Error(err)
+}
+
+func TestPollRepoTestSuite(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	suite.Run(t, new(PollRepoTestSuite))
+}

--- a/database/poll-repo_test.go
+++ b/database/poll-repo_test.go
@@ -79,6 +79,25 @@ func (s *PollRepoTestSuite) TestVoteAndResults() {
 	s.Equal(1, option)
 }
 
+func (s *PollRepoTestSuite) TestResults_SubtractsDecrements() {
+	tweetId := ulid.Make().String()
+	s.Require().NoError(s.repo.Vote(tweetId, ulid.Make().String(), 0, true))
+	s.Require().NoError(s.repo.Vote(tweetId, ulid.Make().String(), 0, true))
+
+	// Nothing retracts a vote today, so bump the DECR counter directly: it
+	// proves INCR and DECR address different keys and that the read composes
+	// both halves instead of ignoring one.
+	txn, err := s.db.NewTxn()
+	s.Require().NoError(err)
+	_, err = txn.Increment(pollVotesKey(tweetId, 0, VotesDecrSubNamespace))
+	s.Require().NoError(err)
+	s.Require().NoError(txn.Commit())
+
+	votes, err := s.repo.Results(tweetId, 2)
+	s.Require().NoError(err)
+	s.Equal([]uint64{1, 0}, votes)
+}
+
 func (s *PollRepoTestSuite) TestVote_IsFinal() {
 	tweetId := ulid.Make().String()
 	userId := ulid.Make().String()

--- a/domain/warpnet.go
+++ b/domain/warpnet.go
@@ -187,6 +187,7 @@ type Tweet struct {
 	Pinned        bool             `json:"pinned,omitempty"`
 	QuotedTweetId *string          `json:"quoted_tweet_id,omitempty"`
 	QuotedUserId  *string          `json:"quoted_user_id,omitempty"`
+	Poll          *Poll            `json:"poll,omitempty"`
 }
 
 // IsReply reports whether the tweet is a reply, i.e. it hangs off a parent
@@ -197,6 +198,27 @@ func (t *Tweet) IsReply() bool {
 
 func (t *Tweet) IsModerated() bool {
 	return t.Moderation != nil
+}
+
+const (
+	PollMinOptions      = 2
+	PollMaxOptions      = 4
+	PollOptionRuneLimit = 25
+)
+
+// Poll is an optional single-choice poll carried by a tweet. Only the
+// immutable definition lives here, so it travels with the tweet through
+// every existing distribution path (storage, gossip, timeline snapshots).
+// The votes themselves are held per node by the poll repo, keyed by tweet
+// id, and aggregated across the network the same way likes are.
+type Poll struct {
+	Options   []string  `json:"options"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// IsClosed reports whether the poll has stopped accepting votes.
+func (p *Poll) IsClosed() bool {
+	return p != nil && !p.ExpiresAt.IsZero() && time.Now().After(p.ExpiresAt)
 }
 
 type ModelType string

--- a/event/event.go
+++ b/event/event.go
@@ -332,6 +332,48 @@ type NewUserEvent = domain.User
 // Owner defines model for Owner.
 type Owner = domain.Owner
 
+// PollVoteEvent defines model for PollVoteEvent.
+//
+// Same actor/target convention as LikeEvent: UserId is the tweet author
+// (the routing key), OwnerId is the voter. Option is the zero-based index
+// into the tweet's poll options.
+type PollVoteEvent struct {
+	TweetId domain.ID `json:"tweet_id"`
+	UserId  domain.ID `json:"user_id"`
+	OwnerId domain.ID `json:"owner_id"`
+	Option  int       `json:"option"`
+
+	// OptionsNum is how many options the voter's copy of the tweet shows.
+	// The counters are stored per option index, so it sizes the results the
+	// vote replies with on a node that doesn't hold the tweet itself.
+	OptionsNum int `json:"options_num"`
+}
+
+// GetPollEvent defines model for GetPollEvent.
+type GetPollEvent struct {
+	TweetId domain.ID `json:"tweet_id"`
+	UserId  domain.ID `json:"user_id"`
+	OwnerId domain.ID `json:"owner_id"`
+
+	// OptionsNum is how many options the caller's copy of the tweet shows.
+	// The vote counters are stored per option index, so the reader needs it
+	// to know how many to fetch.
+	OptionsNum int `json:"options_num"`
+}
+
+// PollResultsResponse defines model for PollResultsResponse.
+type PollResultsResponse struct {
+	TweetId domain.ID `json:"tweet_id"`
+
+	// Votes holds the vote count per option, in option order.
+	Votes      []uint64 `json:"votes"`
+	TotalVotes uint64   `json:"total_votes"`
+
+	// VotedOption is the option the requesting user picked, nil if they
+	// haven't voted.
+	VotedOption *int `json:"voted_option,omitempty"`
+}
+
 // ReTweetsCountResponse defines model for ReTweetsCountResponse.
 type ReTweetsCountResponse = LikesCountResponse
 

--- a/event/paths.go
+++ b/event/paths.go
@@ -99,6 +99,9 @@ const (
 	PUBLIC_GET_TWEET_RETWEETERS = "/public/get/tweet/retweeters/0.0.0"
 	PRIVATE_GET_LIKES           = "/private/get/likes/0.0.0"
 
+	PUBLIC_POST_POLL_VOTE = "/public/post/poll/vote/0.0.0"
+	PUBLIC_GET_POLL       = "/public/get/poll/0.0.0"
+
 	PRIVATE_POST_SUBSCRIBE_USER   = "/private/post/subscribe/user/0.0.0"
 	PRIVATE_POST_UNSUBSCRIBE_USER = "/private/post/unsubscribe/user/0.0.0"
 

--- a/frontend/src/components/PollWidget.vue
+++ b/frontend/src/components/PollWidget.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="mt-1 mb-2">
+    <div v-for="(option, index) in options" :key="index" class="mb-2">
+      <button
+          v-if="!showResults"
+          @click.stop="vote(index)"
+          type="button"
+          class="w-full text-left px-4 py-2 rounded-full border border-blue text-blue font-semibold text-sm hover:bg-lightblue transition-colors flat-btn"
+          :class="voting ? 'opacity-50 cursor-not-allowed' : ''"
+          :disabled="voting"
+      >
+        {{ option }}
+      </button>
+      <div v-else class="relative rounded border border-lighter overflow-hidden">
+        <!-- A translucent brand tint, not a solid light fill: the themed
+             surface shows through, so the label keeps its contrast in the
+             dark and mastodon themes as well as the light one. -->
+        <div class="absolute inset-y-0 left-0 bg-blue bg-opacity-25" :style="{width: percent(index) + '%'}"></div>
+        <div class="relative flex items-center justify-between px-3 py-2 text-sm">
+          <span :class="votedOption === index ? 'font-semibold' : ''">
+            <i v-if="votedOption === index" class="fas fa-check-circle text-blue mr-1" aria-hidden="true"></i>
+            {{ option }}
+          </span>
+          <span class="text-dark ml-2">{{ percent(index) }}%</span>
+        </div>
+      </div>
+    </div>
+    <p class="text-xs text-dark">
+      {{ totalVotes }} {{ totalVotes === 1 ? 'vote' : 'votes' }} · {{ statusLabel }}
+    </p>
+  </div>
+</template>
+
+<script>
+import {warpnetService} from "@/service/service";
+import {toast} from "@/lib/toast";
+
+export default {
+  name: "PollWidget",
+  props: {
+    tweet: {type: Object, required: true},
+  },
+  data() {
+    return {
+      votes: [],
+      totalVotes: 0,
+      votedOption: null,
+      voting: false,
+    };
+  },
+  computed: {
+    options() {
+      return (this.tweet.poll && this.tweet.poll.options) || [];
+    },
+    closed() {
+      const expiresAt = this.tweet.poll && this.tweet.poll.expires_at;
+      if (!expiresAt) return false;
+      return new Date(expiresAt).getTime() <= Date.now();
+    },
+    // Same rule as Twitter: the tally stays hidden until you've had your say
+    // or the poll has closed, so early results can't steer later voters.
+    showResults() {
+      return this.closed || this.votedOption !== null;
+    },
+    statusLabel() {
+      if (this.closed) return 'Final results';
+      const remaining = new Date(this.tweet.poll.expires_at).getTime() - Date.now();
+      const hours = Math.floor(remaining / 3600000);
+      if (hours >= 24) return `${Math.floor(hours / 24)}d left`;
+      if (hours >= 1) return `${hours}h left`;
+      return `${Math.max(1, Math.round(remaining / 60000))}m left`;
+    },
+  },
+  mounted() {
+    this.loadResults();
+  },
+  methods: {
+    percent(index) {
+      if (!this.totalVotes) return 0;
+      return Math.round(((this.votes[index] || 0) / this.totalVotes) * 100);
+    },
+    applyResults(results) {
+      if (!results || !Array.isArray(results.votes)) return false;
+      this.votes = results.votes;
+      this.totalVotes = results.total_votes || 0;
+      this.votedOption = Number.isInteger(results.voted_option) ? results.voted_option : null;
+      return true;
+    },
+    async loadResults() {
+      if (this.options.length === 0) return;
+      try {
+        const results = await warpnetService.getPollResults(
+            this.tweet.id, this.tweet.user_id, this.options.length,
+        );
+        this.applyResults(results);
+      } catch (err) {
+        console.error(`failed to load poll results [${this.tweet.id}]`, err);
+      }
+    },
+    async vote(index) {
+      if (this.voting || this.showResults) return;
+      this.voting = true;
+      try {
+        const results = await warpnetService.voteInPoll(
+            this.tweet.id, this.tweet.user_id, index, this.options.length,
+        );
+        // The transport turns a node-side failure into an empty body, so an
+        // unusable answer must leave the choices clickable rather than
+        // showing an empty tally as if the vote had landed.
+        if (!this.applyResults(results)) {
+          toast.error("Couldn't cast your vote. Please try again.");
+          return;
+        }
+        // A vote is final, so reveal the results even if the node answered
+        // without echoing our choice back.
+        if (this.votedOption === null) this.votedOption = index;
+      } catch (err) {
+        console.error(`failed to vote in poll [${this.tweet.id}]`, err);
+        toast.error(err?.message || "Couldn't cast your vote. Please try again.");
+      } finally {
+        this.voting = false;
+      }
+    },
+  },
+};
+</script>

--- a/frontend/src/components/TweetBlock.vue
+++ b/frontend/src/components/TweetBlock.vue
@@ -104,6 +104,7 @@ resulting from the use or misuse of this software.
       <p v-else class="pb-2 bg-red-300">
         Moderated: {{ tweet.moderation.reason }}.
       </p>
+      <PollWidget v-if="hasPoll" :tweet="tweet" />
       <div
         v-if="tweet.quoted_tweet_id"
         class="mb-2 border border-lighter rounded p-3 bg-lightest text-sm"
@@ -345,6 +346,7 @@ export default {
     ReportDialog: defineAsyncComponent(() => import('./ReportDialog.vue')),
     ConfirmDialog: defineAsyncComponent(() => import('./ConfirmDialog.vue')),
     YoutubeEmbed: defineAsyncComponent(() => import('./YoutubeEmbed.vue')),
+    PollWidget: defineAsyncComponent(() => import('./PollWidget.vue')),
   },
   data() {
     return {
@@ -388,6 +390,9 @@ export default {
     },
     hasVideo() {
       return !!(this.tweet && this.tweet.video_key);
+    },
+    hasPoll() {
+      return !!(this.tweet && this.tweet.poll && this.tweet.poll.options && this.tweet.poll.options.length > 0);
     },
     // A video post carries its first frame as the first image key (see the
     // composer in Home.vue), so it stands in as the poster rather than being

--- a/frontend/src/lib/backend-mock.js
+++ b/frontend/src/lib/backend-mock.js
@@ -56,7 +56,9 @@ import {
     PUBLIC_POST_UNFOLLOW,
     PUBLIC_POST_UNLIKE,
     PUBLIC_POST_UNRETWEET,
-    PUBLIC_POST_VIEW
+    PUBLIC_POST_VIEW,
+    PUBLIC_POST_POLL_VOTE,
+    PUBLIC_GET_POLL
 } from "@/service/service";
 import {generateUUID} from "@/lib/uuid";
 
@@ -130,6 +132,7 @@ function generateResponse(arg) {
                 image_key : arg.body.image_key || "",
                 image_keys : arg.body.image_keys || [],
                 video_key : arg.body.video_key || undefined,
+                poll : arg.body.poll || undefined,
                 created_at : arg.body.created_at || Date.now().toString(),
                 parent_id: null,
                 retweeted_by: null,
@@ -335,6 +338,23 @@ function generateResponse(arg) {
             mockMap.set("stats:"+arg.body.tweet_id, unlikeStats)
             return {count: unlikeStats.likes_count};
 
+        case PUBLIC_POST_POLL_VOTE: {
+            const pollKey = "poll:"+arg.body.tweet_id
+            const tally = mockMap.get(pollKey) || {votes: new Array(arg.body.options_num || 0).fill(0), voters: {}}
+            if (!(arg.body.owner_id in tally.voters)) {
+                tally.voters[arg.body.owner_id] = arg.body.option
+                tally.votes[arg.body.option] = (tally.votes[arg.body.option] || 0) + 1
+                mockMap.set(pollKey, tally)
+            }
+            return pollResults(tally, arg.body.owner_id);
+        }
+
+        case PUBLIC_GET_POLL: {
+            const tally = mockMap.get("poll:"+arg.body.tweet_id)
+            if (!tally) return {tweet_id: arg.body.tweet_id, votes: new Array(arg.body.options_num || 0).fill(0), total_votes: 0};
+            return pollResults(tally, arg.body.owner_id);
+        }
+
         case PUBLIC_POST_VIEW: {
             // NOTE: this mock uses an "infinite" dedup window — once a viewer
             // has been seen for a tweet, the count never re-increments for
@@ -484,6 +504,15 @@ function newUser() {
         latency: 0,
         tweets_count: 0,
         metadata: {},
+    }
+}
+
+function pollResults(tally, ownerId) {
+    const voted = tally.voters[ownerId];
+    return {
+        votes: tally.votes,
+        total_votes: tally.votes.reduce((sum, n) => sum + n, 0),
+        voted_option: voted === undefined ? undefined : voted,
     }
 }
 

--- a/frontend/src/service/service.js
+++ b/frontend/src/service/service.js
@@ -104,6 +104,8 @@ export const PUBLIC_POST_IS_FOLLOWING  = "/public/post/isfollowing/0.0.0"
 export const PUBLIC_POST_IS_FOLLOWER   = "/public/post/isfollower/0.0.0"
 export const PUBLIC_POST_VIEW          = "/public/post/view/0.0.0"
 export const PUBLIC_POST_REPORT        = "/public/post/report/0.0.0"
+export const PUBLIC_POST_POLL_VOTE     = "/public/post/poll/vote/0.0.0"
+export const PUBLIC_GET_POLL           = "/public/get/poll/0.0.0"
 
 const stateMap = new Map();
 // localStorage key for the owner profile; persisted on login so reopening the
@@ -1492,7 +1494,7 @@ export const warpnetService = {
         return tweetsResp.tweets;
     },
 
-    async createTweet({text, imageKeys, videoKey}) {
+    async createTweet({text, imageKeys, videoKey, poll}) {
         const owner = this.getOwnerProfile()
 
         const request ={
@@ -1507,6 +1509,12 @@ export const warpnetService = {
         }
         if (videoKey) {
             request.body.video_key = videoKey;
+        }
+        if (poll) {
+            request.body.poll = {
+                options: poll.options,
+                expires_at: poll.expiresAt,
+            };
         }
 
         return await this.sendToNode(request);
@@ -1799,6 +1807,44 @@ export const warpnetService = {
 
         const unlikeResp = await this.sendToNode(request);
         return unlikeResp.count;
+    },
+
+    // voteInPoll casts a final vote on a tweet's poll and returns the tally
+    // the node knows about, in the same shape as getPollResults.
+    async voteInPoll(tweetId, userId, option, optionsNum) {
+        const owner = this.getOwnerProfile()
+
+        const request = {
+            path: PUBLIC_POST_POLL_VOTE,
+            body: {
+                user_id: userId,
+                tweet_id: tweetId,
+                owner_id: owner.user_id,
+                option: option,
+                options_num: optionsNum,
+            },
+        }
+
+        return await this.sendToNode(request);
+    },
+
+    // getPollResults returns {votes, total_votes, voted_option}. votes is the
+    // per-option tally in option order; voted_option is null until this user
+    // has voted.
+    async getPollResults(tweetId, userId, optionsNum) {
+        const owner = this.getOwnerProfile()
+
+        const request = {
+            path: PUBLIC_GET_POLL,
+            body: {
+                user_id: userId,
+                tweet_id: tweetId,
+                owner_id: owner.user_id,
+                options_num: optionsNum,
+            },
+        }
+
+        return await this.sendToNode(request);
     },
 
     // viewTweet returns the new view count on success, or `null` if

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -111,6 +111,49 @@ resulting from the use or misuse of this software.
             </button>
             <div v-if="!videoKey" class="text-xs text-dark mt-1">Uploading video…</div>
           </div>
+          <div v-if="poll" class="mt-2 mb-2 border border-lighter rounded p-3">
+            <div v-for="(option, index) in poll.options" :key="index" class="flex items-center mb-2">
+              <label :for="`poll-option-${index}`" class="sr-only">Choice {{ index + 1 }}</label>
+              <input
+                  :id="`poll-option-${index}`"
+                  v-model="poll.options[index]"
+                  type="text"
+                  :placeholder="`Choice ${index + 1}`"
+                  :maxlength="pollOptionCharLimit"
+                  class="w-full px-3 py-2 border border-lighter rounded focus:outline-none"
+              />
+              <button
+                  v-if="poll.options.length > pollMinOptions"
+                  @click="removePollOption(index)"
+                  type="button"
+                  class="ml-2 rounded-full w-9 h-9 flex-none flex items-center justify-center hover:bg-lighter"
+                  :aria-label="`Remove choice ${index + 1}`"
+                  title="Remove choice"
+              >
+                <i class="fas fa-times text-dark" aria-hidden="true"></i>
+              </button>
+            </div>
+            <div class="flex items-center justify-between">
+              <button
+                  v-if="poll.options.length < pollMaxOptions"
+                  @click="addPollOption"
+                  type="button"
+                  class="text-sm text-blue hover:underline"
+              >
+                <i class="fas fa-plus mr-1" aria-hidden="true"></i>Add a choice
+              </button>
+              <span v-else></span>
+              <div class="flex items-center text-sm">
+                <label for="poll-length" class="text-dark mr-2">Poll length</label>
+                <!-- bg-white, not the UA default: the global CSS themes input
+                     and textarea but not select, so without a mapped surface
+                     the themed text lands on light grey in dark mode. -->
+                <select id="poll-length" v-model="poll.durationHours" class="bg-white border border-lighter rounded px-2 py-1">
+                  <option v-for="d in pollDurations" :key="d.hours" :value="d.hours">{{ d.label }}</option>
+                </select>
+              </div>
+            </div>
+          </div>
           <div class="flex items-center justify-between border-t border-lighter pt-2">
             <div class="flex items-center">
               <button
@@ -150,7 +193,15 @@ resulting from the use or misuse of this software.
                   type="file"
                   class="hidden"
               />
-              <button type="button" disabled class="text-lg text-blue mr-3 rounded-full w-9 h-9 flex items-center justify-center opacity-50 cursor-not-allowed" aria-label="Add poll (coming soon)" title="Coming soon">
+              <button
+                  @click="togglePoll"
+                  class="text-lg mr-3 rounded-full w-9 h-9 flex items-center justify-center hover:bg-lightblue"
+                  :class="poll ? 'text-white bg-blue' : 'text-blue'"
+                  type="button"
+                  aria-label="Add poll"
+                  :aria-pressed="!!poll"
+                  :title="poll ? 'Remove poll' : 'Add poll'"
+              >
                 <i class="far fa-chart-bar" aria-hidden="true"></i>
               </button>
               <div class="relative mr-3" data-emoji-anchor>
@@ -175,9 +226,9 @@ resulting from the use or misuse of this software.
               @click="addNewTweet"
               type="button"
               class="h-10 px-4 text-white font-semibold bg-blue hover:bg-darkblue rounded-full"
-              :class="(tweet.text.trim() && pendingReads === 0 && !posting && !videoUploading) ? '' : 'opacity-50 cursor-not-allowed'"
-              :disabled="!tweet.text.trim() || pendingReads > 0 || posting || videoUploading"
-              :title="videoUploading ? 'Uploading video…' : (pendingReads > 0 ? 'Uploading image…' : '')"
+              :class="(tweet.text.trim() && pendingReads === 0 && !posting && !videoUploading && pollReady) ? '' : 'opacity-50 cursor-not-allowed'"
+              :disabled="!tweet.text.trim() || pendingReads > 0 || posting || videoUploading || !pollReady"
+              :title="videoUploading ? 'Uploading video…' : (pendingReads > 0 ? 'Uploading image…' : (!pollReady ? 'Fill in every poll choice' : ''))"
             >
               <span v-if="!posting">Tweet</span>
               <span v-else><i class="fas fa-circle-notch fa-spin mr-1" aria-hidden="true"></i>Posting…</span>
@@ -248,6 +299,18 @@ import {acceptedVideoAccept, captureVideoPoster, normalizeVideoDataUrl, validate
 import {clampRunes, focusCaret, insertEmoji, runeLength} from "@/lib/emoji";
 
 const tweetCharLimit = 280;
+// Mirrors domain.PollMinOptions / PollMaxOptions / PollOptionRuneLimit — the
+// node rejects a poll outside these bounds.
+const pollMinOptions = 2;
+const pollMaxOptions = 4;
+const pollOptionCharLimit = 25;
+const pollDurations = [
+  {hours: 1, label: '1 hour'},
+  {hours: 6, label: '6 hours'},
+  {hours: 24, label: '1 day'},
+  {hours: 72, label: '3 days'},
+  {hours: 168, label: '7 days'},
+];
 
 export default {
   name: "Home",
@@ -286,6 +349,7 @@ export default {
       loadingMore: false,
       endOfFeed: false,
       showEmojiPicker: false,
+      poll: null,
     };
   },
   watch: {
@@ -318,6 +382,24 @@ export default {
       if (this.videoAttachment) return 'Only one video per post';
       if (this.imageAttachments.length > 0) return 'Remove images to attach a video';
       return 'Attach video (MP4 or MOV)';
+    },
+    pollMinOptions() {
+      return pollMinOptions;
+    },
+    pollMaxOptions() {
+      return pollMaxOptions;
+    },
+    pollOptionCharLimit() {
+      return pollOptionCharLimit;
+    },
+    pollDurations() {
+      return pollDurations;
+    },
+    // A half-filled poll would be rejected by the node, so hold the post
+    // button until every choice has text.
+    pollReady() {
+      if (!this.poll) return true;
+      return this.poll.options.every(o => o.trim());
     },
   },
   methods: {
@@ -467,8 +549,29 @@ export default {
     openAltModal(index) {
       this.altModalIndex = index;
     },
+    togglePoll() {
+      this.poll = this.poll ? null : {options: ['', ''], durationHours: 24};
+    },
+    addPollOption() {
+      if (this.poll.options.length >= pollMaxOptions) return;
+      this.poll.options.push('');
+    },
+    removePollOption(index) {
+      if (this.poll.options.length <= pollMinOptions) return;
+      this.poll.options.splice(index, 1);
+    },
+    // The wire carries an absolute deadline, not a duration, so every node
+    // reading the tweet closes the poll at the same moment.
+    pollPayload() {
+      if (!this.poll) return null;
+      const expiresAt = new Date(Date.now() + this.poll.durationHours * 3600000);
+      return {
+        options: this.poll.options.map(o => o.trim()),
+        expiresAt: expiresAt.toISOString(),
+      };
+    },
     async addNewTweet() {
-      if (this.posting || !this.tweet.text.trim()) return;
+      if (this.posting || !this.tweet.text.trim() || !this.pollReady) return;
       const draftText = this.tweet.text;
       const draftImages = this.imageAttachments;
       this.posting = true;
@@ -488,11 +591,14 @@ export default {
           // images and video, so it stays unambiguous on the other side.
           imageKeys = [this.videoPosterKey, ...imageKeys];
         }
-        await warpnetService.createTweet({text: draftText, imageKeys, videoKey: this.videoKey});
+        await warpnetService.createTweet({
+          text: draftText, imageKeys, videoKey: this.videoKey, poll: this.pollPayload(),
+        });
 
         this.tweet.text = "";
         this.imageAttachments = [];
         this.imageKeys = [];
+        this.poll = null;
         this.removeVideoAttachment();
         this.endOfFeed = false;
 

--- a/frontend/tests/components/PollWidget.spec.js
+++ b/frontend/tests/components/PollWidget.spec.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/vue';
+
+vi.mock('@/service/service', () => ({
+  warpnetService: {
+    getPollResults: vi.fn(),
+    voteInPoll: vi.fn(),
+    getOwnerProfile: vi.fn(),
+  },
+}));
+
+import PollWidget from '@/components/PollWidget.vue';
+import { warpnetService } from '@/service/service';
+
+let errSpy;
+beforeAll(() => {
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterAll(() => {
+  errSpy.mockRestore();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  warpnetService.getOwnerProfile.mockReturnValue({user_id: 'viewer1'});
+  warpnetService.getPollResults.mockResolvedValue({
+    tweet_id: 't1', votes: [0, 0], total_votes: 0,
+  });
+});
+
+const pollTweet = (poll) => ({
+  id: 't1',
+  user_id: 'author1',
+  username: 'author',
+  text: 'pick one',
+  created_at: '2026-05-04T00:00:00Z',
+  poll,
+});
+
+const openPoll = () => pollTweet({
+  options: ['Cats', 'Dogs'],
+  expires_at: new Date(Date.now() + 3600000).toISOString(),
+});
+
+const closedPoll = () => pollTweet({
+  options: ['Cats', 'Dogs'],
+  expires_at: new Date(Date.now() - 3600000).toISOString(),
+});
+
+const renderPoll = (tweet) => render(PollWidget, {props: {tweet}});
+
+describe('PollWidget', () => {
+  it('offers the choices as buttons while the poll is open and unanswered', async () => {
+    const {getByText} = renderPoll(openPoll());
+
+    await waitFor(() => expect(warpnetService.getPollResults).toHaveBeenCalledWith('t1', 'author1', 2));
+    expect(getByText('Cats').tagName).toBe('BUTTON');
+    expect(getByText('Dogs').tagName).toBe('BUTTON');
+  });
+
+  it('hides the tally until the reader has voted', async () => {
+    warpnetService.getPollResults.mockResolvedValue({
+      tweet_id: 't1', votes: [7, 3], total_votes: 10,
+    });
+    const {container} = renderPoll(openPoll());
+
+    // The total is public — which option is winning is not.
+    await waitFor(() => expect(container.textContent).toContain('10 votes'));
+    expect(container.textContent).not.toContain('%');
+  });
+
+  it('reveals the tally and marks the choice after voting', async () => {
+    warpnetService.voteInPoll.mockResolvedValue({
+      tweet_id: 't1', votes: [1, 0], total_votes: 1, voted_option: 0,
+    });
+    const {getByText, container} = renderPoll(openPoll());
+
+    await waitFor(() => expect(warpnetService.getPollResults).toHaveBeenCalled());
+    await fireEvent.click(getByText('Cats'));
+
+    await waitFor(() => expect(container.textContent).toContain('100%'));
+    expect(warpnetService.voteInPoll).toHaveBeenCalledWith('t1', 'author1', 0, 2);
+    expect(container.textContent).toContain('1 vote ·');
+    expect(container.querySelector('.fa-check-circle')).not.toBeNull();
+  });
+
+  it('shows the final results without vote buttons once the poll has closed', async () => {
+    warpnetService.getPollResults.mockResolvedValue({
+      tweet_id: 't1', votes: [1, 3], total_votes: 4,
+    });
+    const {getByText, container} = renderPoll(closedPoll());
+
+    await waitFor(() => expect(container.textContent).toContain('4 votes'));
+    expect(container.textContent).toContain('Final results');
+    expect(getByText('Cats').tagName).not.toBe('BUTTON');
+    expect(container.textContent).toContain('25%');
+    expect(container.textContent).toContain('75%');
+  });
+
+  it('keeps the choices clickable when the vote fails', async () => {
+    warpnetService.voteInPoll.mockRejectedValue(new Error('node offline'));
+    const {getByText} = renderPoll(openPoll());
+
+    await waitFor(() => expect(warpnetService.getPollResults).toHaveBeenCalled());
+    await fireEvent.click(getByText('Cats'));
+
+    await waitFor(() => expect(warpnetService.voteInPoll).toHaveBeenCalled());
+    expect(getByText('Cats').tagName).toBe('BUTTON');
+  });
+
+  it('does not pretend the vote landed when the node answers with an empty body', async () => {
+    // sendToNode turns a node-side error into `{}` rather than throwing.
+    warpnetService.voteInPoll.mockResolvedValue({});
+    const {getByText, container} = renderPoll(openPoll());
+
+    await waitFor(() => expect(warpnetService.getPollResults).toHaveBeenCalled());
+    await fireEvent.click(getByText('Cats'));
+
+    await waitFor(() => expect(warpnetService.voteInPoll).toHaveBeenCalled());
+    expect(getByText('Cats').tagName).toBe('BUTTON');
+    expect(container.textContent).not.toContain('%');
+  });
+});


### PR DESCRIPTION
A tweet can carry an optional single-choice poll: 2-4 options and a deadline. The definition lives on domain.Tweet, so it travels with the tweet through every existing distribution path (storage, gossip, timeline snapshots) and needs no separate fetch to render.

Votes are held per node by a new PollRepo keyed by tweet id, mirroring LikeRepo: the network-wide (CRDT) counter is bumped only on the voter's own node, so a vote stored on both the voter's and the author's node is counted once. A vote is final — a replayed or twice-delivered event returns ErrPollAlreadyVoted and moves no counter.

Two routes:
  /public/post/poll/vote/0.0.0 - bounds the vote against the poll
      definition and forwards it to the author's node
  /public/get/poll/0.0.0       - forwards the tally to the author's node
      (it sees every vote) while answering "did I vote" locally, so
      results still resolve when the author is offline

The Vue composer enables the poll button that was sitting there disabled, and PollWidget hides the tally until the reader has voted or the poll closes, as Twitter does.

Two theme fixes the browser check turned up: select gets no themed background from the global CSS (only input/textarea do), and a bg-lightblue fill has no dark override - both left light text on a light surface in the dark theme.