### PR TITLE
Finish the profile Media and Tweets and threads tabs

### DIFF
--- a/frontend/src/views/Profile.vue
+++ b/frontend/src/views/Profile.vue
@@ -244,19 +244,17 @@ resulting from the use or misuse of this software.
             </button>
             <button
               type="button"
-              disabled
-              title="Coming soon"
-              aria-label="Tweets & replies (coming soon)"
-              class="cursor-not-allowed opacity-50 flex-grow text-dark font-bold border-b-2 p-1 md:px-2 md:py-4"
+              @click="selectTab('replies')"
+              class="flex-grow text-dark font-bold border-b-2 p-1 md:px-2 md:py-4 hover:bg-lightblue"
+              :class="activeTab === 'replies' ? 'border-blue' : ''"
             >
-              Tweets & replies
+              Tweets and threads
             </button>
             <button
               type="button"
-              disabled
-              title="Coming soon"
-              aria-label="Media (coming soon)"
-              class="cursor-not-allowed opacity-50 flex-grow text-dark font-bold border-b-2 p-1 md:px-2 md:py-4"
+              @click="selectTab('media')"
+              class="flex-grow text-dark font-bold border-b-2 p-1 md:px-2 md:py-4 hover:bg-lightblue"
+              :class="activeTab === 'media' ? 'border-blue' : ''"
             >
               Media
             </button>
@@ -315,6 +313,37 @@ resulting from the use or misuse of this software.
             <p class="mt-1">Their tweets are hidden. Use the menu above to unblock if you change your mind.</p>
           </div>
           <Tweets v-if="!noUser && !isBlocked" :tweets="sortedTweets" />
+        </template>
+
+        <!-- tweets and threads -->
+        <template v-else-if="activeTab === 'replies'">
+          <Loader :loading="repliesLoading" />
+          <div
+            v-if="!repliesLoading && tweetsAndReplies.length === 0"
+            class="flex flex-col items-center justify-center w-full pt-10 px-5"
+          >
+            <p class="font-bold text-lg">Nothing here yet</p>
+            <p class="text-sm text-dark text-center">
+              Tweets and the replies continuing their threads will show up here.
+            </p>
+          </div>
+          <Tweets v-if="!noUser && !isBlocked" :tweets="tweetsAndReplies" />
+        </template>
+
+        <!-- media -->
+        <template v-else-if="activeTab === 'media'">
+          <Loader :loading="mediaLoading" />
+          <div
+            v-if="!mediaLoading && mediaTweets.length === 0"
+            class="flex flex-col items-center justify-center w-full pt-10 px-5"
+          >
+            <p class="font-bold text-lg">No photos or videos yet</p>
+            <p class="text-sm text-dark text-center">
+              <span>{{ isSelf ? "Tweets you post" : `Tweets ${profile.username || "this user"} posts` }}</span>
+              with a photo or a video will show up here.
+            </p>
+          </div>
+          <Tweets v-if="!noUser && !isBlocked" :tweets="mediaTweets" />
         </template>
 
         <!-- likes -->
@@ -409,6 +438,10 @@ export default {
       likes: [],
       likesLoading: false,
       likesLoaded: false,
+      replies: [],
+      repliesLoading: false,
+      repliesScanned: 0,
+      mediaLoading: false,
     };
   },
   computed: {
@@ -420,6 +453,17 @@ export default {
     },
     likedTweets() {
       return this.likes.map(l => l.tweet);
+    },
+    // Tweets and the profile owner's replies in one chronological feed.
+    tweetsAndReplies() {
+      return this.tweets.concat(this.replies).sort(
+        (a, b) => new Date(b.created_at) - new Date(a.created_at)
+      );
+    },
+    mediaTweets() {
+      return this.tweets.filter(
+        t => t && ((t.image_keys && t.image_keys.length > 0) || t.video_key)
+      );
     },
     lastSeenText() {
       if (this.isSelf || !this.profile || !this.profile.last_seen) return "";
@@ -646,12 +690,29 @@ export default {
         this.likes = this.likes.concat(items);
         return;
       }
+      await this.loadMoreTweets();
+      if (this.activeTab === 'replies') {
+        await this.loadReplies();
+      }
+    },
+    // Returns only the tweets this page actually added: the media and replies
+    // tabs page through the profile until they find something, and a repeated
+    // page would both duplicate keys and loop forever.
+    async loadMoreTweets() {
       const tweets = await warpnetService.getTweets({userId:this.profile.id, cursorReset:false});
-      this.tweets = this.tweets.concat(tweets);
+      const known = new Set(this.tweets.map(t => t && t.id));
+      const fresh = tweets.filter(t => t && t.id && !known.has(t.id));
+      this.tweets = this.tweets.concat(fresh);
+      return fresh;
     },
     async selectTab(tab) {
       this.activeTab = tab;
-      if (tab !== 'likes' || this.likesLoaded) return;
+      if (tab === 'likes') return this.loadLikes();
+      if (tab === 'replies') return this.loadReplies();
+      if (tab === 'media') return this.fillMediaTab();
+    },
+    async loadLikes() {
+      if (this.likesLoaded || this.likesLoading) return;
       this.likesLoading = true;
       try {
         const resp = await warpnetService.getLikes(true);
@@ -661,6 +722,75 @@ export default {
         console.error('Failed to load likes:', err);
       } finally {
         this.likesLoading = false;
+      }
+    },
+    // A reply is stored under the tweet it answers, not under its author, so
+    // the replies a profile can reach are the ones its owner left in their
+    // own threads: walk the loaded tweets and keep those.
+    async loadReplies() {
+      if (this.repliesLoading) return;
+      // Tweets loaded while another tab was open still need a scan.
+      const pending = this.tweets.slice(this.repliesScanned);
+      if (pending.length === 0) return;
+      this.repliesLoading = true;
+      this.repliesScanned = this.tweets.length;
+      try {
+        await this.collectReplies(pending);
+      } catch (err) {
+        console.error('Failed to load replies:', err);
+      } finally {
+        this.repliesLoading = false;
+      }
+    },
+    async collectReplies(tweets) {
+      const known = new Set(this.replies.map(r => r.id));
+      const batchSize = 4; // one request per tweet, but not all at once
+      for (let i = 0; i < tweets.length; i += batchSize) {
+        const pages = await Promise.all(
+          tweets.slice(i, i + batchSize).map(t => this.threadReplies(t))
+        );
+        const own = [];
+        for (const reply of pages.flat()) {
+          if (!reply || !reply.id || reply.user_id !== this.profile.id) continue;
+          if (known.has(reply.id)) continue;
+          known.add(reply.id);
+          own.push(reply);
+        }
+        if (own.length !== 0) this.replies = this.replies.concat(own);
+      }
+    },
+    async threadReplies(tweet) {
+      if (!tweet || !tweet.id) return [];
+      const root = tweet.root_id || tweet.id;
+      try {
+        const page = await warpnetService.getReplies({
+          rootId: root,
+          parentId: tweet.id,
+          // user_id is the root author only when this tweet is the root itself.
+          rootUserId: root === tweet.id ? tweet.user_id : undefined,
+          cursorReset: true,
+        });
+        return Array.isArray(page) ? page : [];
+      } catch (err) {
+        console.warn(`failed to load replies of ${tweet.id}:`, err);
+        return [];
+      }
+    },
+    // The media tab filters the tweets already loaded, so a page carrying no
+    // photo or video leaves it empty with nothing to scroll: pull further
+    // pages until something shows up or the profile runs out of tweets.
+    async fillMediaTab() {
+      if (this.mediaLoading) return;
+      this.mediaLoading = true;
+      try {
+        for (let i = 0; i < 5 && this.mediaTweets.length === 0; i++) {
+          const tweets = await this.loadMoreTweets();
+          if (tweets.length === 0) break;
+        }
+      } catch (err) {
+        console.error('Failed to load media:', err);
+      } finally {
+        this.mediaLoading = false;
       }
     },
     closeProfileMenu() {

--- a/frontend/tests/views/Profile.spec.js
+++ b/frontend/tests/views/Profile.spec.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
+
+vi.mock('@/service/service', () => ({
+  warpnetService: {
+    getOwnerProfile: vi.fn(),
+    getProfile: vi.fn(),
+    getImage: vi.fn(),
+    getUsers: vi.fn(),
+    getTweets: vi.fn(),
+    getReplies: vi.fn(),
+    getLikes: vi.fn(),
+    getFollowers: vi.fn(),
+    getFollowings: vi.fn(),
+    isFollowing: vi.fn(),
+    isFollower: vi.fn(),
+    isUserBlocked: vi.fn(),
+    isUserMuted: vi.fn(),
+  },
+}));
+
+import Profile from '@/views/Profile.vue';
+import { warpnetService } from '@/service/service';
+
+const scrollDirective = { mounted() {}, updated() {}, unmounted() {} };
+const linkifyDirective = { mounted() {}, updated() {}, unmounted() {} };
+
+const tweetsStub = {
+  props: ['tweets'],
+  template: '<div><article v-for="t in tweets" :key="t.id">{{ t.text }}</article></div>',
+};
+
+const renderProfile = () =>
+  render(Profile, {
+    global: {
+      mocks: {
+        $router: { push: vi.fn() },
+        $route: { params: { id: 'alice' } },
+      },
+      directives: { scroll: scrollDirective, linkify: linkifyDirective },
+      stubs: {
+        SideNav: true,
+        DefaultRightBar: true,
+        Loader: true,
+        ConfirmDialog: true,
+        ReportDialog: true,
+        EditProfileOverlay: true,
+        SetUpProfileOverlay: true,
+        Tweets: tweetsStub,
+      },
+    },
+  });
+
+const textTweet = { id: 't1', user_id: 'alice', text: 'plain tweet', created_at: '2026-01-01T10:00:00Z' };
+const photoTweet = {
+  id: 't2',
+  user_id: 'alice',
+  text: 'tweet with a photo',
+  image_keys: ['img-1'],
+  created_at: '2026-01-02T10:00:00Z',
+};
+
+let logSpy, errSpy, warnSpy;
+beforeAll(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterAll(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  warpnetService.getOwnerProfile.mockReturnValue({ user_id: 'alice', username: 'Alice' });
+  warpnetService.getProfile.mockResolvedValue({
+    id: 'alice',
+    user_id: 'alice',
+    username: 'Alice',
+    created_at: '2025-12-01T10:00:00Z',
+  });
+  warpnetService.getImage.mockResolvedValue('');
+  warpnetService.getUsers.mockResolvedValue([]);
+  warpnetService.getFollowers.mockResolvedValue([]);
+  warpnetService.getFollowings.mockResolvedValue([]);
+  warpnetService.isFollowing.mockResolvedValue(false);
+  warpnetService.isFollower.mockResolvedValue(false);
+  warpnetService.isUserBlocked.mockResolvedValue(false);
+  warpnetService.isUserMuted.mockResolvedValue(false);
+  warpnetService.getReplies.mockResolvedValue([]);
+  warpnetService.getLikes.mockResolvedValue({ items: [] });
+  warpnetService.getTweets.mockImplementation(({ cursorReset }) =>
+    Promise.resolve(cursorReset ? [photoTweet, textTweet] : [])
+  );
+});
+
+describe('Profile.vue tabs', () => {
+  it('keeps only tweets carrying a photo or a video in the media tab', async () => {
+    renderProfile();
+    await waitFor(() => expect(screen.getByText('plain tweet')).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Media' }));
+
+    await waitFor(() => expect(screen.queryByText('plain tweet')).not.toBeInTheDocument());
+    expect(screen.getByText('tweet with a photo')).toBeInTheDocument();
+  });
+
+  it('pages further into the profile when the first page holds no media', async () => {
+    const videoTweet = {
+      id: 't3',
+      user_id: 'alice',
+      text: 'tweet with a video',
+      video_key: 'vid-1',
+      created_at: '2026-01-03T10:00:00Z',
+    };
+    warpnetService.getTweets.mockImplementation(({ cursorReset }) =>
+      Promise.resolve(cursorReset ? [textTweet] : [videoTweet])
+    );
+
+    renderProfile();
+    await waitFor(() => expect(screen.getByText('plain tweet')).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Media' }));
+
+    await waitFor(() => expect(screen.getByText('tweet with a video')).toBeInTheDocument());
+  });
+
+  it('shows the owner replies from their own threads next to their tweets', async () => {
+    warpnetService.getReplies.mockImplementation(({ parentId }) =>
+      Promise.resolve(
+        parentId === 't1'
+          ? [
+              { id: 'r1', user_id: 'alice', parent_id: 't1', text: 'my own follow-up', created_at: '2026-01-01T11:00:00Z' },
+              { id: 'r2', user_id: 'bob', parent_id: 't1', text: 'someone else answer', created_at: '2026-01-01T12:00:00Z' },
+            ]
+          : []
+      )
+    );
+
+    renderProfile();
+    await waitFor(() => expect(screen.getByText('plain tweet')).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tweets and threads' }));
+
+    await waitFor(() => expect(screen.getByText('my own follow-up')).toBeInTheDocument());
+    expect(screen.getByText('plain tweet')).toBeInTheDocument();
+    expect(screen.queryByText('someone else answer')).not.toBeInTheDocument();
+  });
+
+  it('leaves the tweets tab free of replies', async () => {
+    warpnetService.getReplies.mockResolvedValue([
+      { id: 'r1', user_id: 'alice', parent_id: 't1', text: 'my own follow-up', created_at: '2026-01-01T11:00:00Z' },
+    ]);
+
+    renderProfile();
+    await waitFor(() => expect(screen.getByText('plain tweet')).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tweets and threads' }));
+    await waitFor(() => expect(screen.getByText('my own follow-up')).toBeInTheDocument());
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tweets' }));
+
+    await waitFor(() => expect(screen.queryByText('my own follow-up')).not.toBeInTheDocument());
+    expect(screen.getByText('plain tweet')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Both tabs were dead buttons labelled "Coming soon". They are now built entirely on the client, with no backend change.

Media filters the profile's tweets by attachment, and pages further into the profile when a page carries none — the tab would otherwise sit empty with nothing to scroll, so infinite scroll could never kick in.

Tweets and threads merges the profile's tweets with the replies its owner left in their own threads, fetched through the existing thread route. A reply is stored under the tweet it answers rather than under its author, so those are the only replies a profile can reach: replies to other people's tweets stay out until an index by author exists.

Paging now drops tweets already loaded — a repeated page would duplicate keys and spin the media tab's page-until-found loop forever.