### PR TITLE
Open the reaction picker on a full category, and away from the header

### DIFF
--- a/frontend/src/components/EmojiPicker.vue
+++ b/frontend/src/components/EmojiPicker.vue
@@ -119,6 +119,10 @@ export default {
     // Composers pinned to the bottom of the viewport (the DM input) need the
     // panel above the button; anything higher up on the page opens downwards.
     dropUp: {type: Boolean, default: false},
+    // Which tab opens first. The composer wants the emoji you reuse most,
+    // but a reaction row opens on a full category: with one or two recents
+    // the panel is a mostly empty box.
+    initialCategory: {type: String, default: ""},
   },
   emits: ["select", "close"],
   data() {
@@ -128,7 +132,8 @@ export default {
       tone: loadTone(),
       toneOpen: false,
       recent,
-      active: recent.length > 0 ? RECENT_TAB : EMOJI_CATEGORIES[0].id,
+      active: this.initialCategory ||
+        (recent.length > 0 ? RECENT_TAB : EMOJI_CATEGORIES[0].id),
       tones: SKIN_TONES,
     };
   },

--- a/frontend/src/components/ReactionBar.vue
+++ b/frontend/src/components/ReactionBar.vue
@@ -57,12 +57,13 @@ resulting from the use or misuse of this software.
         aria-label="More emoji"
         title="More emoji"
         :aria-expanded="showPicker"
-        @click.stop="showPicker = !showPicker"
+        @click.stop="togglePicker"
       >+</button>
     </div>
     <EmojiPicker
       v-if="showPicker"
-      drop-up
+      :drop-up="pickerDropUp"
+      initial-category="smileys"
       @select="pick"
       @close="showPicker = false"
     />
@@ -73,6 +74,10 @@ resulting from the use or misuse of this software.
 import {defineAsyncComponent} from "vue";
 import {QUICK_REACTIONS} from "@/lib/emoji";
 import {dismissable} from "@/lib/modal.mixin";
+
+// What EmojiPicker occupies (search row, category tabs, h-56 grid) plus the
+// sticky header it must not slide under.
+const spaceNeededAbove = 430;
 
 export default {
   name: "ReactionBar",
@@ -90,6 +95,7 @@ export default {
     return {
       quickReactions: QUICK_REACTIONS,
       showPicker: false,
+      pickerDropUp: true,
     };
   },
   mounted() {
@@ -105,6 +111,14 @@ export default {
     document.removeEventListener("mousedown", this.__outsideHandler);
   },
   methods: {
+    // Upwards by default, but a row near the top of the viewport has to
+    // open downwards or the panel's head ends up under the header.
+    togglePicker() {
+      if (!this.showPicker) {
+        this.pickerDropUp = this.$el.getBoundingClientRect().top > spaceNeededAbove;
+      }
+      this.showPicker = !this.showPicker;
+    },
     pick(emoji) {
       this.showPicker = false;
       this.$emit("select", emoji);


### PR DESCRIPTION
The picker defaults to "Recently used", which is right for the composer — you reuse what you type — but a reaction row opened onto whatever one or two glyphs happened to be there, so the panel read as "almost no emoji" while all 1069 sat behind the category tabs. It now opens on Smileys & Emotion: 153 in the visible grid, the rest a scroll away.

The panel also always dropped upwards, which put its search row under the sticky header for any row in the upper half of the page. The direction now follows the space available.

Verified in the reporter's browser: a row at 399 px opens downwards (471-847), one at 765 px upwards (378-755), both clear of the header and fully on screen, 153 glyphs either way.