### PR TITLE
fix(ui): stop the chat list from hiding chats and hanging on the loader

### DIFF
--- a/frontend/src/views/Conversations.vue
+++ b/frontend/src/views/Conversations.vue
@@ -211,7 +211,14 @@ export default {
       if (isMastodonUser(u)) {
         return
       }
-      u.avatar = await warpnetService.getImage({userId: u.id, key: u.avatar_key})
+      // A failed avatar fetch must not reject loadChatUser: normalizeChats
+      // awaits these in a Promise.all, so one broken avatar would hide the
+      // whole list. The row falls back to the default profile image.
+      try {
+        u.avatar = await warpnetService.getImage({userId: u.id, key: u.avatar_key})
+      } catch (err) {
+        console.warn('conversations: failed to load avatar for', u.id, err)
+      }
       this.usersMap.set(u.id, u)
     },
     // The row shows the participant who is not the owner, so the ids are

--- a/frontend/src/views/Conversations.vue
+++ b/frontend/src/views/Conversations.vue
@@ -183,8 +183,6 @@ export default {
       if (!userId || userId.length === 0) {
         return
       }
-      // A resolved profile is kept; a placeholder is retried by the next poll,
-      // so a peer that was unreachable at load time fills in when it returns.
       const known = this.usersMap.get(userId)
       if (known && known.username) {
         return
@@ -196,9 +194,6 @@ export default {
       } catch (err) {
         console.error('conversations: failed to load chat user', userId, err)
       }
-      // An unresolved profile (peer offline, user unknown to the node, request
-      // failed) carries no id. It still has to land in the map, or the chat row
-      // is filtered out and the whole list reads as empty.
       if (!u || !u.id) {
         console.warn('conversations: unresolved chat user, showing placeholder', userId)
         if (!isMastodonUser({id: userId})) {
@@ -211,9 +206,6 @@ export default {
       if (isMastodonUser(u)) {
         return
       }
-      // A failed avatar fetch must not reject loadChatUser: normalizeChats
-      // awaits these in a Promise.all, so one broken avatar would hide the
-      // whole list. The row falls back to the default profile image.
       try {
         u.avatar = await warpnetService.getImage({userId: u.id, key: u.avatar_key})
       } catch (err) {
@@ -221,16 +213,12 @@ export default {
       }
       this.usersMap.set(u.id, u)
     },
-    // The row shows the participant who is not the owner, so the ids are
-    // normalized before their profiles are fetched.
     normalizeChats(chats) {
       for (const chat of chats) {
         if (chat.owner_id !== this.profileId) {
           [chat.owner_id, chat.other_user_id] = [chat.other_user_id, chat.owner_id];
         }
       }
-      // In parallel: one round trip per chat awaited in sequence held the
-      // spinner for the sum of them.
       return Promise.all(chats.map((chat) => this.loadChatUser(chat.other_user_id)));
     },
     async loadMore() {
@@ -279,9 +267,6 @@ export default {
         await this.normalizeChats(chats);
         this.chats = chats;
       } catch (err) {
-        // Without this the view is stuck on the spinner for good: loading was
-        // cleared on the success path only, and the poll timer below was never
-        // reached, so nothing retried once the node answered again.
         console.error('Failed to load chats:', err);
       } finally {
         this.loading = false;

--- a/frontend/src/views/Conversations.vue
+++ b/frontend/src/views/Conversations.vue
@@ -183,24 +183,58 @@ export default {
       if (!userId || userId.length === 0) {
         return
       }
+      // A resolved profile is kept; a placeholder is retried by the next poll,
+      // so a peer that was unreachable at load time fills in when it returns.
+      const known = this.usersMap.get(userId)
+      if (known && known.username) {
+        return
+      }
 
-      const u = await warpnetService.getProfile(userId)
-      u.avatar = await warpnetService.getImage({userId:u.id, key:u.avatar_key})
+      let u
+      try {
+        u = await warpnetService.getProfile(userId)
+      } catch (err) {
+        console.error('conversations: failed to load chat user', userId, err)
+      }
+      // An unresolved profile (peer offline, user unknown to the node, request
+      // failed) carries no id. It still has to land in the map, or the chat row
+      // is filtered out and the whole list reads as empty.
+      if (!u || !u.id) {
+        console.warn('conversations: unresolved chat user, showing placeholder', userId)
+        if (!isMastodonUser({id: userId})) {
+          this.usersMap.set(userId, {id: userId})
+        }
+        return
+      }
       // Leaving a bridged user out of the map hides the whole chat row:
       // the list only renders chats whose other user resolved.
       if (isMastodonUser(u)) {
         return
       }
+      u.avatar = await warpnetService.getImage({userId: u.id, key: u.avatar_key})
       this.usersMap.set(u.id, u)
     },
-    async loadMore() {
-      const chats = await warpnetService.getChats(false);
+    // The row shows the participant who is not the owner, so the ids are
+    // normalized before their profiles are fetched.
+    normalizeChats(chats) {
       for (const chat of chats) {
-        await this.loadChatUser(chat.other_user_id)
-        await this.loadChatUser(chat.owner_id)
+        if (chat.owner_id !== this.profileId) {
+          [chat.owner_id, chat.other_user_id] = [chat.other_user_id, chat.owner_id];
+        }
       }
-      const known = new Set(this.chats.map((c) => c.id));
-      this.chats = [...this.chats, ...chats.filter((c) => !known.has(c.id))];
+      // In parallel: one round trip per chat awaited in sequence held the
+      // spinner for the sum of them.
+      return Promise.all(chats.map((chat) => this.loadChatUser(chat.other_user_id)));
+    },
+    async loadMore() {
+      try {
+        const chats = await warpnetService.getChats(false);
+        await this.normalizeChats(chats);
+        const known = new Set(this.chats.map((c) => c.id));
+        this.chats = [...this.chats, ...chats.filter((c) => !known.has(c.id))];
+      } catch (err) {
+        console.error('Failed to load more chats:', err);
+      }
     },
     // Poll-driven live updates (no server push on the bridge): re-fetch
     // page 1 of the chat list and merge by id so new incoming chats and
@@ -214,13 +248,7 @@ export default {
         const savedCursor = warpnetService.getCursor('chats');
         const chats = await warpnetService.getChats(true);
         warpnetService.setCursor('chats', savedCursor);
-        for (const chat of chats) {
-          if (!this.usersMap.has(chat.owner_id)) await this.loadChatUser(chat.owner_id);
-          if (!this.usersMap.has(chat.other_user_id)) await this.loadChatUser(chat.other_user_id);
-          if (chat.owner_id !== this.profileId) {
-            [chat.owner_id, chat.other_user_id] = [chat.other_user_id, chat.owner_id];
-          }
-        }
+        await this.normalizeChats(chats);
         if (chats.length > 0) {
           const freshIds = new Set(chats.map((c) => c.id));
           this.chats = [...chats, ...this.chats.filter((c) => !freshIds.has(c.id))];
@@ -236,21 +264,21 @@ export default {
   async created() {
       console.log("loading component:", this.$options.name);
       this.profileId = this.$route.params.id
-      warpnetService.markMessageNotificationsRead().catch(() => {});
-      await this.loadChatUser(this.profileId)
+      try {
+        warpnetService.markMessageNotificationsRead().catch(() => {});
+        await this.loadChatUser(this.profileId)
 
-      const chats = await warpnetService.getChats(true);
-
-      for (const chat of chats) {
-        await this.loadChatUser(chat.owner_id)
-        await this.loadChatUser(chat.other_user_id)
-
-        if (chat.owner_id !== this.profileId) {
-          [chat.owner_id, chat.other_user_id] = [chat.other_user_id, chat.owner_id];
-        }
+        const chats = await warpnetService.getChats(true);
+        await this.normalizeChats(chats);
+        this.chats = chats;
+      } catch (err) {
+        // Without this the view is stuck on the spinner for good: loading was
+        // cleared on the success path only, and the poll timer below was never
+        // reached, so nothing retried once the node answered again.
+        console.error('Failed to load chats:', err);
+      } finally {
+        this.loading = false;
       }
-      this.chats = chats;
-      this.loading = false;
 
       this.refreshTimer = setInterval(() => this.refreshChats(), 3000);
     },

--- a/frontend/tests/views/Conversations.spec.js
+++ b/frontend/tests/views/Conversations.spec.js
@@ -58,8 +58,6 @@ afterAll(() => {
   warnSpy.mockRestore();
 });
 
-// Warpnet user ids are ULIDs; the view hides bridged (non-ULID) accounts, so
-// the fixtures have to look like real ids.
 const ALICE = '01KY0357FD1DS8X2E6HHHVXJBG';
 const BOB = '01KTRA1Q83VBTES33BRQV79JN6';
 const CAROL = '01KSGHBHKG0N77T6A3RZV8WSH5';
@@ -181,9 +179,6 @@ describe('Conversations.vue', () => {
     expect(warpnetService.createChat).not.toHaveBeenCalled();
   });
 
-  // The node keeps chats whose peer it cannot resolve (an offline node, a user
-  // record without a node id): the row has to stay, or the list reads as empty
-  // while the node is returning chats.
   it('still lists a chat whose other user could not be resolved', async () => {
     warpnetService.getChats.mockResolvedValue([
       {
@@ -204,8 +199,6 @@ describe('Conversations.vue', () => {
     expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
   });
 
-  // The avatar fetch runs inside the same Promise.all as the profile
-  // fetches; a rejection there must not sink the whole list.
   it('keeps the chat row when the avatar fetch fails', async () => {
     warpnetService.getChats.mockResolvedValue([
       {
@@ -233,8 +226,6 @@ describe('Conversations.vue', () => {
 
     renderConversations();
 
-    // The empty state only renders once loading is false; before the fix a
-    // failed request left the spinner up until the page was reloaded.
     expect(await screen.findByText(/No messages yet/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/views/Conversations.spec.js
+++ b/frontend/tests/views/Conversations.spec.js
@@ -7,6 +7,9 @@ vi.mock('@/service/service', () => ({
     getProfile: vi.fn(),
     getImage: vi.fn(),
     createChat: vi.fn(),
+    markMessageNotificationsRead: vi.fn(),
+    getCursor: vi.fn(),
+    setCursor: vi.fn(),
   },
 }));
 
@@ -21,7 +24,7 @@ const scrollDirective = {
 
 const routerPush = vi.fn();
 
-const renderConversations = ({ id = 'alice' } = {}) =>
+const renderConversations = ({ id = ALICE } = {}) =>
   render(Conversations, {
     global: {
       mocks: {
@@ -35,22 +38,31 @@ const renderConversations = ({ id = 'alice' } = {}) =>
         Loader: true,
         NewMessageOverlay: {
           template:
-            '<div data-testid="new-message-overlay"><button @click="$emit(\'selected\', { id: \'carol\' })">pick-user</button></div>',
+            '<div data-testid="new-message-overlay"><button @click="$emit(\'selected\', { id: CAROL })">pick-user</button></div>',
+          data: () => ({ CAROL }),
           emits: ['selected', 'update:showNewMessageModal'],
         },
       },
     },
   });
 
-let logSpy, errSpy;
+let logSpy, errSpy, warnSpy;
 beforeAll(() => {
   logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 afterAll(() => {
   logSpy.mockRestore();
   errSpy.mockRestore();
+  warnSpy.mockRestore();
 });
+
+// Warpnet user ids are ULIDs; the view hides bridged (non-ULID) accounts, so
+// the fixtures have to look like real ids.
+const ALICE = '01KY0357FD1DS8X2E6HHHVXJBG';
+const BOB = '01KTRA1Q83VBTES33BRQV79JN6';
+const CAROL = '01KSGHBHKG0N77T6A3RZV8WSH5';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -63,6 +75,8 @@ beforeEach(() => {
   }));
   warpnetService.getImage.mockResolvedValue(null);
   warpnetService.createChat.mockResolvedValue({ id: 'new-chat-id' });
+  warpnetService.markMessageNotificationsRead.mockResolvedValue(undefined);
+  warpnetService.getCursor.mockReturnValue('');
 });
 
 describe('Conversations.vue', () => {
@@ -73,54 +87,54 @@ describe('Conversations.vue', () => {
 
   it('shows the empty-state message when there are no chats', async () => {
     renderConversations();
-    expect(await screen.findByText(/No chats yet/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No messages yet/i)).toBeInTheDocument();
   });
 
   it('renders a chat list entry with the other user and last message', async () => {
     warpnetService.getChats.mockResolvedValue([
       {
         id: 'chat-1',
-        owner_id: 'alice',
-        other_user_id: 'bob',
+        owner_id: ALICE,
+        other_user_id: BOB,
         last_message: 'see you tomorrow',
       },
     ]);
 
     renderConversations();
 
-    expect(await screen.findByText('bob')).toBeInTheDocument();
+    expect(await screen.findByText(BOB)).toBeInTheDocument();
     expect(screen.getByText('see you tomorrow')).toBeInTheDocument();
-    expect(screen.queryByText(/No chats yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
   });
 
   it('navigates to Messages when a chat row is clicked', async () => {
     warpnetService.getChats.mockResolvedValue([
       {
         id: 'chat-1',
-        owner_id: 'alice',
-        other_user_id: 'bob',
+        owner_id: ALICE,
+        other_user_id: BOB,
         last_message: 'hi',
       },
     ]);
 
     renderConversations();
 
-    const row = await screen.findByText('bob');
+    const row = await screen.findByText(BOB);
     await fireEvent.click(row);
 
     await waitFor(() => {
       expect(routerPush).toHaveBeenCalledWith({
         name: 'Messages',
-        params: { id: 'alice', chatId: 'chat-1' },
+        params: { id: ALICE, chatId: 'chat-1' },
       });
     });
   });
 
   it('opens the new message overlay when the "New message" button is clicked', async () => {
     renderConversations();
-    await screen.findByText(/No chats yet/i);
+    await screen.findByText(/No messages yet/i);
 
-    const newMsgBtn = screen.getByRole('button', { name: /New message/i });
+    const newMsgBtn = screen.getByRole('button', { name: 'New message' });
     await fireEvent.click(newMsgBtn);
 
     expect(await screen.findByTestId('new-message-overlay')).toBeInTheDocument();
@@ -128,16 +142,16 @@ describe('Conversations.vue', () => {
 
   it('creates a new chat and navigates when selecting a user without an existing chat', async () => {
     renderConversations();
-    await screen.findByText(/No chats yet/i);
+    await screen.findByText(/No messages yet/i);
 
-    await fireEvent.click(screen.getByRole('button', { name: /New message/i }));
+    await fireEvent.click(screen.getByRole('button', { name: 'New message' }));
     await fireEvent.click(await screen.findByText('pick-user'));
 
     await waitFor(() => {
-      expect(warpnetService.createChat).toHaveBeenCalledWith('carol');
+      expect(warpnetService.createChat).toHaveBeenCalledWith(CAROL);
       expect(routerPush).toHaveBeenCalledWith({
         name: 'Messages',
-        params: { id: 'alice', chatId: 'new-chat-id' },
+        params: { id: ALICE, chatId: 'new-chat-id' },
       });
     });
   });
@@ -146,24 +160,57 @@ describe('Conversations.vue', () => {
     warpnetService.getChats.mockResolvedValue([
       {
         id: 'chat-existing',
-        owner_id: 'alice',
-        other_user_id: 'carol',
+        owner_id: ALICE,
+        other_user_id: CAROL,
         last_message: '',
       },
     ]);
 
     renderConversations();
-    await screen.findByText('carol');
+    await screen.findByText(CAROL);
 
-    await fireEvent.click(screen.getByRole('button', { name: /New message/i }));
+    await fireEvent.click(screen.getByRole('button', { name: 'New message' }));
     await fireEvent.click(await screen.findByText('pick-user'));
 
     await waitFor(() => {
       expect(routerPush).toHaveBeenCalledWith({
         name: 'Messages',
-        params: { id: 'alice', chatId: 'chat-existing' },
+        params: { id: ALICE, chatId: 'chat-existing' },
       });
     });
     expect(warpnetService.createChat).not.toHaveBeenCalled();
+  });
+
+  // The node keeps chats whose peer it cannot resolve (an offline node, a user
+  // record without a node id): the row has to stay, or the list reads as empty
+  // while the node is returning chats.
+  it('still lists a chat whose other user could not be resolved', async () => {
+    warpnetService.getChats.mockResolvedValue([
+      {
+        id: 'chat-unresolved',
+        owner_id: ALICE,
+        other_user_id: BOB,
+        last_message: 'ping',
+      },
+    ]);
+    warpnetService.getProfile.mockImplementation(async (id) =>
+      id === BOB ? { code: 5000, message: 'get user: other user user not found' } : { id, username: id }
+    );
+
+    renderConversations();
+
+    expect(await screen.findByText('ping')).toBeInTheDocument();
+    expect(screen.getByText('Anonymous')).toBeInTheDocument();
+    expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
+  });
+
+  it('clears the loader when the chat list request fails', async () => {
+    warpnetService.getChats.mockRejectedValue(new Error('node unreachable'));
+
+    renderConversations();
+
+    // The empty state only renders once loading is false; before the fix a
+    // failed request left the spinner up until the page was reloaded.
+    expect(await screen.findByText(/No messages yet/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/views/Conversations.spec.js
+++ b/frontend/tests/views/Conversations.spec.js
@@ -204,6 +204,30 @@ describe('Conversations.vue', () => {
     expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
   });
 
+  // The avatar fetch runs inside the same Promise.all as the profile
+  // fetches; a rejection there must not sink the whole list.
+  it('keeps the chat row when the avatar fetch fails', async () => {
+    warpnetService.getChats.mockResolvedValue([
+      {
+        id: 'chat-avatar',
+        owner_id: ALICE,
+        other_user_id: BOB,
+        last_message: 'yo',
+      },
+    ]);
+    warpnetService.getProfile.mockImplementation(async (id) => ({
+      id,
+      username: id,
+      avatar_key: 'some-key',
+    }));
+    warpnetService.getImage.mockRejectedValue(new Error('ERR_TIMEOUT'));
+
+    renderConversations();
+
+    expect(await screen.findByText(BOB)).toBeInTheDocument();
+    expect(screen.getByText('yo')).toBeInTheDocument();
+  });
+
   it('clears the loader when the chat list request fails', async () => {
     warpnetService.getChats.mockRejectedValue(new Error('node unreachable'));
 


### PR DESCRIPTION
Two independent faults made the chat list read as empty while the node was returning chats.

A chat whose other participant could not be resolved was dropped from the list: getProfile answers an unreachable peer (offline node, user record without a node id, unknown user) with an error body carrying no id, and isMastodonUser() then classified it as a bridged account because the id is not a ULID. The row was filtered out by visibleChats. Such a chat now gets a placeholder and renders as Anonymous, and the poll upgrades it once the peer answers; genuinely bridged accounts stay hidden.

created() had no error handling, so a single failed request (a transport timeout, a dropped socket) left loading true and never reached the poll timer: the view sat on the spinner until the page was reloaded, even after the node was reachable again.

Participants are also fetched in parallel now instead of one await per chat, and the owner/other id normalization is shared, which fixes loadMore() rendering the signed-in user on paginated rows.

The spec was stale (expected copy that no longer exists, mock missing markMessageNotificationsRead) and could not run the component; it is fixed and covers both faults.