### PR TITLE
fix(ui): stop chat list and bookmarks blocking on peers that are offline

### DIFF
--- a/frontend/src/service/service.js
+++ b/frontend/src/service/service.js
@@ -1290,23 +1290,9 @@ export const warpnetService = {
         this.setCursor('bookmarks', resp.cursor || 'end')
 
         // Backend returns the bookmark index entries (tweet_id +
-        // owner_user_id). Hydrate each into the full Tweet so the view
-        // can render it inline like a timeline tweet.
-        const rawItems = resp.items || [];
-        const hydrated = await Promise.all(rawItems.map(async (b) => {
-            if (!b || !b.tweet_id) return null;
-            try {
-                const tweet = await this.getTweet({
-                    userId: b.owner_user_id || owner.user_id,
-                    tweetId: b.tweet_id,
-                });
-                return tweet ? { ...b, tweet } : null;
-            } catch (e) {
-                console.warn('bookmark hydrate failed:', b, e);
-                return null;
-            }
-        }));
-        return { items: hydrated.filter(Boolean), cursor: resp.cursor || 'end' };
+        // owner_user_id); the view hydrates each into a full Tweet.
+        const items = (resp.items || []).filter((b) => b && b.tweet_id);
+        return { items, cursor: resp.cursor || 'end' };
     },
 
     async primeBookmarks() {

--- a/frontend/src/views/Bookmarks.vue
+++ b/frontend/src/views/Bookmarks.vue
@@ -62,12 +62,26 @@ export default {
       if (window.history.length > 1) this.$router.back();
       else this.$router.push({ name: "Home" });
     },
+    async hydrateBookmarks(items) {
+      await Promise.all(items.map(async (b) => {
+        try {
+          const tweet = await warpnetService.getTweet({
+            userId: b.owner_user_id || this.ownerProfile.user_id,
+            tweetId: b.tweet_id,
+          });
+          if (tweet && tweet.id) b.tweet = tweet;
+        } catch (e) {
+          console.warn('bookmark hydrate failed:', b, e);
+        }
+      }));
+    },
     async loadMore() {
       if (this.done || this.loading) return;
       const resp = await warpnetService.getBookmarks(false);
       const items = resp?.items || [];
       if (items.length === 0) { this.done = true; return; }
       this.bookmarks = this.bookmarks.concat(items);
+      this.hydrateBookmarks(this.bookmarks.slice(-items.length));
     },
   },
   async created() {
@@ -77,6 +91,10 @@ export default {
       const resp = await warpnetService.getBookmarks(true);
       this.bookmarks = resp?.items || [];
       if (this.bookmarks.length === 0 && (resp?.cursor === 'end')) this.done = true;
+      await Promise.race([
+        this.hydrateBookmarks(this.bookmarks),
+        new Promise((resolve) => setTimeout(resolve, 1000)),
+      ]);
     } catch (err) {
       console.error('Failed to load bookmarks:', err);
     } finally {

--- a/frontend/src/views/Conversations.vue
+++ b/frontend/src/views/Conversations.vue
@@ -118,6 +118,7 @@ export default {
       chats: [],
       profileId: "",
       usersMap: new Map(),
+      pendingUsers: new Set(),
       otherUser: undefined,
       refreshTimer: null,
       refreshInFlight: false,
@@ -187,36 +188,51 @@ export default {
       if (known && known.username) {
         return
       }
-
-      let u
-      try {
-        u = await warpnetService.getProfile(userId)
-      } catch (err) {
-        console.error('conversations: failed to load chat user', userId, err)
+      if (this.pendingUsers.has(userId)) {
+        return
       }
-      if (!u || !u.id) {
-        console.warn('conversations: unresolved chat user, showing placeholder', userId)
-        if (!isMastodonUser({id: userId})) {
-          this.usersMap.set(userId, {id: userId})
+      this.pendingUsers.add(userId)
+      try {
+        let u
+        try {
+          u = await warpnetService.getProfile(userId)
+        } catch (err) {
+          console.error('conversations: failed to load chat user', userId, err)
         }
-        return
+        if (!u || !u.id) {
+          console.warn('conversations: unresolved chat user, showing placeholder', userId)
+          if (!isMastodonUser({id: userId})) {
+            this.usersMap.set(userId, {id: userId})
+          }
+          return
+        }
+        // Leaving a bridged user out of the map hides the whole chat row:
+        // the list only renders chats whose other user resolved.
+        if (isMastodonUser(u)) {
+          this.usersMap.delete(userId)
+          return
+        }
+        this.usersMap.set(userId, u)
+        try {
+          const avatar = await warpnetService.getImage({userId: userId, key: u.avatar_key})
+          if (avatar) {
+            this.usersMap.set(userId, {...u, avatar})
+          }
+        } catch (err) {
+          console.warn('conversations: failed to load avatar for', userId, err)
+        }
+      } finally {
+        this.pendingUsers.delete(userId)
       }
-      // Leaving a bridged user out of the map hides the whole chat row:
-      // the list only renders chats whose other user resolved.
-      if (isMastodonUser(u)) {
-        return
-      }
-      try {
-        u.avatar = await warpnetService.getImage({userId: u.id, key: u.avatar_key})
-      } catch (err) {
-        console.warn('conversations: failed to load avatar for', u.id, err)
-      }
-      this.usersMap.set(u.id, u)
     },
     normalizeChats(chats) {
       for (const chat of chats) {
         if (chat.owner_id !== this.profileId) {
           [chat.owner_id, chat.other_user_id] = [chat.other_user_id, chat.owner_id];
+        }
+        const uid = chat.other_user_id;
+        if (uid && !this.usersMap.has(uid) && !isMastodonUser({id: uid})) {
+          this.usersMap.set(uid, {id: uid});
         }
       }
       return Promise.all(chats.map((chat) => this.loadChatUser(chat.other_user_id)));
@@ -224,7 +240,7 @@ export default {
     async loadMore() {
       try {
         const chats = await warpnetService.getChats(false);
-        await this.normalizeChats(chats);
+        this.normalizeChats(chats);
         const known = new Set(this.chats.map((c) => c.id));
         this.chats = [...this.chats, ...chats.filter((c) => !known.has(c.id))];
       } catch (err) {
@@ -243,7 +259,7 @@ export default {
         const savedCursor = warpnetService.getCursor('chats');
         const chats = await warpnetService.getChats(true);
         warpnetService.setCursor('chats', savedCursor);
-        await this.normalizeChats(chats);
+        this.normalizeChats(chats);
         if (chats.length > 0) {
           const freshIds = new Set(chats.map((c) => c.id));
           this.chats = [...chats, ...this.chats.filter((c) => !freshIds.has(c.id))];
@@ -261,11 +277,15 @@ export default {
       this.profileId = this.$route.params.id
       try {
         warpnetService.markMessageNotificationsRead().catch(() => {});
-        await this.loadChatUser(this.profileId)
+        this.loadChatUser(this.profileId)
 
         const chats = await warpnetService.getChats(true);
-        await this.normalizeChats(chats);
+        const hydration = this.normalizeChats(chats);
         this.chats = chats;
+        await Promise.race([
+          hydration,
+          new Promise((resolve) => setTimeout(resolve, 1000)),
+        ]);
       } catch (err) {
         console.error('Failed to load chats:', err);
       } finally {

--- a/frontend/tests/views/Bookmarks.spec.js
+++ b/frontend/tests/views/Bookmarks.spec.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/vue';
+
+vi.mock('@/service/service', () => ({
+  warpnetService: {
+    getBookmarks: vi.fn(),
+    getTweet: vi.fn(),
+    getOwnerProfile: vi.fn(),
+  },
+}));
+
+import Bookmarks from '@/views/Bookmarks.vue';
+import { warpnetService } from '@/service/service';
+
+const scrollDirective = {
+  mounted() {},
+  updated() {},
+  unmounted() {},
+};
+
+const renderBookmarks = () =>
+  render(Bookmarks, {
+    global: {
+      mocks: {
+        $router: { back: vi.fn(), push: vi.fn() },
+      },
+      directives: { scroll: scrollDirective },
+      stubs: {
+        SideNav: true,
+        DefaultRightBar: true,
+        Loader: {
+          props: ['loading'],
+          template: '<div v-if="loading" data-testid="loader" />',
+        },
+        TweetBlock: {
+          props: ['tweet'],
+          template: '<div>{{ tweet.text }}</div>',
+        },
+      },
+    },
+  });
+
+let logSpy, errSpy, warnSpy;
+beforeAll(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterAll(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  warpnetService.getOwnerProfile.mockReturnValue({ user_id: 'me' });
+  warpnetService.getBookmarks.mockResolvedValue({ items: [], cursor: 'end' });
+  warpnetService.getTweet.mockResolvedValue(null);
+});
+
+describe('Bookmarks.vue', () => {
+  it('shows the empty state when there are no bookmarks', async () => {
+    renderBookmarks();
+    expect(await screen.findByText(/Save tweets for later/i)).toBeInTheDocument();
+  });
+
+  it('renders a bookmarked tweet once hydrated', async () => {
+    warpnetService.getBookmarks.mockResolvedValue({
+      items: [{ tweet_id: 't1', owner_user_id: 'u1' }],
+      cursor: 'end',
+    });
+    warpnetService.getTweet.mockResolvedValue({ id: 't1', text: 'saved tweet' });
+
+    renderBookmarks();
+
+    expect(await screen.findByText('saved tweet')).toBeInTheDocument();
+    expect(warpnetService.getTweet).toHaveBeenCalledWith({ userId: 'u1', tweetId: 't1' });
+  });
+
+  it('clears the loader even when tweet hydration hangs', async () => {
+    warpnetService.getBookmarks.mockResolvedValue({
+      items: [{ tweet_id: 't1', owner_user_id: 'u1' }],
+      cursor: 'end',
+    });
+    warpnetService.getTweet.mockImplementation(() => new Promise(() => {}));
+
+    renderBookmarks();
+
+    await waitFor(
+      () => expect(screen.queryByTestId('loader')).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it('fills the tweet in place when hydration resolves late', async () => {
+    warpnetService.getBookmarks.mockResolvedValue({
+      items: [{ tweet_id: 't1', owner_user_id: 'u1' }],
+      cursor: 'end',
+    });
+    let resolveTweet;
+    warpnetService.getTweet.mockImplementation(
+      () => new Promise((resolve) => { resolveTweet = resolve; }),
+    );
+
+    renderBookmarks();
+
+    await waitFor(
+      () => expect(screen.queryByTestId('loader')).not.toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.queryByText('late tweet')).not.toBeInTheDocument();
+
+    resolveTweet({ id: 't1', text: 'late tweet' });
+
+    expect(await screen.findByText('late tweet')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/views/Conversations.spec.js
+++ b/frontend/tests/views/Conversations.spec.js
@@ -221,6 +221,28 @@ describe('Conversations.vue', () => {
     expect(screen.getByText('yo')).toBeInTheDocument();
   });
 
+  it('renders the list without waiting for a slow avatar', async () => {
+    warpnetService.getChats.mockResolvedValue([
+      {
+        id: 'chat-slow',
+        owner_id: ALICE,
+        other_user_id: BOB,
+        last_message: 'zzz',
+      },
+    ]);
+    warpnetService.getProfile.mockImplementation(async (id) => ({
+      id,
+      username: id,
+      avatar_key: 'some-key',
+    }));
+    warpnetService.getImage.mockImplementation(() => new Promise(() => {}));
+
+    renderConversations();
+
+    expect(await screen.findByText(BOB, undefined, { timeout: 3000 })).toBeInTheDocument();
+    expect(screen.getByText('zzz')).toBeInTheDocument();
+  });
+
   it('clears the loader when the chat list request fails', async () => {
     warpnetService.getChats.mockRejectedValue(new Error('node unreachable'));
 


### PR DESCRIPTION
The node holds a route for up to sendTimeout (10s, core/stream) while it dials a dead peer: fetching an avatar blob or a single tweet whose owner is offline hangs exactly that long before falling back. Both list views serialized their first paint behind every such call, so one offline peer held the whole page on the spinner for 10 seconds.

Chats now seeds a placeholder row per participant, stores the resolved profile before the avatar arrives, dedups in-flight profile fetches, and caps the initial hydration wait at one second — rows render immediately and names/avatars fill in place. The poll no longer blocks on hydration either.

Bookmarks got the same treatment: getBookmarks returns the index page without hydrating tweets, and the view hydrates each row in place with the same one-second first-paint cap, so a bookmarked tweet of an offline owner appears when the node's local fallback delivers it instead of gating the page.

Verified against a live node with an offline peer: the bookmarks page unblocked in ~2s while the offline owner's tweet filled in at ~11s when the node's 10s dial timeout expired.