### PR TITLE
feat(chat): last-message previews, unread markers and recency-sorted …

### DIFF
--- a/database/chat-repo.go
+++ b/database/chat-repo.go
@@ -305,7 +305,56 @@ func (repo *ChatRepo) CreateMessage(msg domain.ChatMessage) (domain.ChatMessage,
 	if err != nil {
 		return msg, err
 	}
+	if err = repo.bumpChatPreview(txn, msg); err != nil {
+		return msg, err
+	}
 	return msg, txn.Commit()
+}
+
+const lastMessagePreviewLimit = 128
+
+// bumpChatPreview stores the latest message text and time on the chat record
+// so the chat list can render previews and sort by recency.
+func (repo *ChatRepo) bumpChatPreview(txn local_store.WarpTransactioner, msg domain.ChatMessage) error {
+	fixedChatKey := local_store.NewPrefixBuilder(ChatNamespace).
+		AddRootID(msg.ChatId).
+		AddRange(local_store.FixedRangeKey).
+		Build()
+
+	sortableKey, err := txn.Get(fixedChatKey)
+	if err != nil && !local_store.IsNotFoundError(err) {
+		return err
+	}
+	if len(sortableKey) == 0 { // message stored before its chat record exists
+		return nil
+	}
+	bt, err := txn.Get(local_store.DatabaseKey(sortableKey))
+	if err != nil {
+		if local_store.IsNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+	var chat domain.Chat
+	if err := json.Unmarshal(bt, &chat); err != nil {
+		return err
+	}
+
+	preview := msg.Text
+	if preview == "" && (len(msg.ImageKeys) > 0 || msg.VideoKey != nil) {
+		preview = "Attachment"
+	}
+	if runes := []rune(preview); len(runes) > lastMessagePreviewLimit {
+		preview = string(runes[:lastMessagePreviewLimit])
+	}
+	chat.LastMessage = preview
+	chat.UpdatedAt = msg.CreatedAt
+
+	data, err := json.Marshal(chat)
+	if err != nil {
+		return err
+	}
+	return txn.Set(local_store.DatabaseKey(sortableKey), data)
 }
 
 func (repo *ChatRepo) ListMessages(chatId string, limit *uint64, cursor *string) ([]domain.ChatMessage, string, error) {

--- a/database/chat-repo_test.go
+++ b/database/chat-repo_test.go
@@ -135,6 +135,24 @@ func (s *ChatRepoSuite) TestCreateAndGetMessage() {
 	s.Equal(msg.Text, got.Text)
 }
 
+func (s *ChatRepoSuite) TestCreateMessageBumpsChatPreview() {
+	ownerID := testUserID
+	otherID := ulid.Make().String()
+
+	chat, err := s.repo.CreateChat(nil, ownerID, otherID)
+	s.NoError(err)
+	s.Empty(chat.LastMessage)
+	defer s.repo.DeleteChat(chat.Id)
+
+	created, err := s.repo.CreateMessage(domain.ChatMessage{ChatId: chat.Id, Text: "latest words"})
+	s.NoError(err)
+
+	bumped, err := s.repo.GetChat(chat.Id)
+	s.NoError(err)
+	s.Equal("latest words", bumped.LastMessage)
+	s.Equal(created.CreatedAt.Unix(), bumped.UpdatedAt.Unix())
+}
+
 func (s *ChatRepoSuite) TestCreateMessageIdempotent() {
 	ownerID := testUserID
 	otherID := ulid.Make().String()

--- a/frontend/src/filters/time.js
+++ b/frontend/src/filters/time.js
@@ -49,13 +49,13 @@ export default function time(_date) {
     .startOf("day");
 
   if (date <= yesterday) {
-    // Jan 31, 6:30 PM
-    return date.format("MMM D, h:mm A");
+    // Jan 31, 18:30
+    return date.format("MMM D, HH:mm");
   } else if (date <= today) {
-    // Yesterday, 6:30 PM
-    return `Yesterday, ${date.format("h:mm A")}`;
+    // Yesterday, 18:30
+    return `Yesterday, ${date.format("HH:mm")}`;
   } else {
-    // 6:30 PM
-    return date.format("h:mm A");
+    // 18:30
+    return date.format("HH:mm");
   }
 }

--- a/frontend/src/lib/backend-mock.js
+++ b/frontend/src/lib/backend-mock.js
@@ -482,7 +482,11 @@ function generateResponse(arg) {
                 created_at: new Date().toISOString(),
             };
             const targetChat = mockMap.get("chat:"+arg.body.chat_id);
-            if (targetChat) targetChat.messages.push(message);
+            if (targetChat) {
+                targetChat.messages.push(message);
+                targetChat.last_message = message.text;
+                targetChat.updated_at = message.created_at;
+            }
             mockMap.set("message:"+msgId, message);
             return message;
 

--- a/frontend/src/service/service.js
+++ b/frontend/src/service/service.js
@@ -2097,6 +2097,18 @@ export const warpnetService = {
         return chatsResp.chats;
     },
 
+    // Chat read marks live only in localStorage: the node keeps no per-chat
+    // read state, so "unread" is chat.updated_at newer than this local mark.
+    markChatRead(chatId) {
+        if (!chatId) return;
+        localStorage.setItem(`chat_read::${chatId}`, String(Date.now()));
+    },
+
+    getChatReadAt(chatId) {
+        const readAt = Number(localStorage.getItem(`chat_read::${chatId}`));
+        return Number.isFinite(readAt) ? readAt : 0;
+    },
+
     async deleteChat(chatId) {
         const request = {
             path: PRIVATE_DELETE_CHAT,

--- a/frontend/src/views/Conversation.vue
+++ b/frontend/src/views/Conversation.vue
@@ -51,7 +51,7 @@ resulting from the use or misuse of this software.
           <div v-for="message in messages" :key="message.id" 
                class="mb-4 flex"
                :class="{'justify-end': message.sender_id === currentUserId}">
-            <div class="max-w-3/4 rounded-lg px-4 py-2"
+            <div class="max-w-[75%] break-words rounded-lg px-4 py-2"
                  :class="message.sender_id === currentUserId ?
                         'bg-blue text-white' : 'bg-lighter'">
               <p v-linkify>{{ message.text }}</p>
@@ -234,6 +234,7 @@ export default {
           this.messages = [...this.messages, ...fresh]
               .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
           this.scrollToBottom();
+          warpnetService.markChatRead(this.chatId);
         }
       } catch (err) {
         console.error('Failed to refresh messages:', err);
@@ -253,6 +254,7 @@ export default {
     ]);
     this.loading = false;
     this.scrollToBottom();
+    warpnetService.markChatRead(this.chatId);
 
     this.loadOtherUser();
 
@@ -263,6 +265,9 @@ export default {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
+    // Everything on screen was seen, including own just-sent messages
+    // that bumped the chat's updated_at.
+    warpnetService.markChatRead(this.chatId);
   },
 };
 </script>

--- a/frontend/src/views/Conversations.vue
+++ b/frontend/src/views/Conversations.vue
@@ -65,11 +65,15 @@ resulting from the use or misuse of this software.
                   <div class="w-full truncate">
                     <div class="flex items-center w-full">
                       <p class="font-semibold truncate min-w-0">{{ getUser(chat.other_user_id).username || 'Anonymous' }}</p>
-                      <p class="text-sm text-dark ml-auto whitespace-nowrap flex-none pl-2">
+                      <span v-if="chat.unread" class="flex-none w-3 h-3 rounded-full bg-blue ml-2" aria-label="Unread messages"></span>
+                      <p class="text-sm ml-auto whitespace-nowrap flex-none pl-2" :class="chat.unread ? 'text-blue font-semibold' : 'text-dark'">
                         {{ $filters.timeago(chat.updated_at) }}
                       </p>
                     </div>
-                    <p class="pb-2 truncate" v-linkify>{{ chat.last_message || "" }}</p>
+                    <!-- v-linkify rewrites innerHTML on mount only, which detaches
+                         the text vnode — key by the text so a new preview remounts
+                         the element instead of patching a dead node. -->
+                    <p :key="chat.last_message" class="pb-2 truncate" :class="{ 'font-semibold text-blue': chat.unread }" v-linkify>{{ chat.last_message || "" }}</p>
                   </div>
                 </div>
               </div>
@@ -127,8 +131,15 @@ export default {
   computed: {
     // Only chats whose other user resolved are listed. Bridged Mastodon
     // accounts never land in the map, so their legacy chats stay hidden.
+    // Unread chats float to the top; within each group the freshest
+    // message comes first.
     visibleChats() {
-      return this.chats.filter((c) => this.usersMap.has(c.other_user_id));
+      return this.chats
+        .filter((chat) => this.usersMap.has(chat.other_user_id))
+        .map((chat) => ({ ...chat, unread: this.isUnread(chat) }))
+        .sort((a, b) =>
+          (b.unread - a.unread) ||
+          (new Date(b.updated_at) - new Date(a.updated_at)));
     },
   },
   methods: {
@@ -179,6 +190,12 @@ export default {
     },
     getUser(userId) {
       return this.usersMap.get(userId);
+    },
+    // An empty last_message means the chat predates preview support (or has
+    // no messages yet) — there is nothing to mark unread then.
+    isUnread(chat) {
+      if (!chat.last_message) return false;
+      return new Date(chat.updated_at).getTime() > warpnetService.getChatReadAt(chat.id);
     },
     async loadChatUser(userId) {
       if (!userId || userId.length === 0) {

--- a/frontend/src/views/Messages.vue
+++ b/frontend/src/views/Messages.vue
@@ -60,14 +60,18 @@ resulting from the use or misuse of this software.
             <div class="w-full truncate">
               <div class="flex items-center">
                 <p class="font-semibold truncate">{{ getUser(chat.other_user_id)?.username || 'Anonymous' }}</p>
+                <span v-if="chat.unread" class="flex-none w-3 h-3 rounded-full bg-blue ml-2" aria-label="Unread messages"></span>
                 <p class="text-sm text-dark ml-2 truncate hidden md:block">
                   @{{ chat.other_user_id }}
                 </p>
-                <p class="text-sm text-dark ml-auto">
+                <p class="text-sm ml-auto" :class="chat.unread ? 'text-blue font-semibold' : 'text-dark'">
                   {{ $filters.timeago(chat.updated_at) }}
                 </p>
               </div>
-              <p class="text-sm truncate" v-linkify>{{ chat.last_message || '' }}</p>
+              <!-- v-linkify rewrites innerHTML on mount only, which detaches
+                   the text vnode — key by the text so a new preview remounts
+                   the element instead of patching a dead node. -->
+              <p :key="chat.last_message" class="text-sm truncate" :class="{ 'font-semibold text-blue': chat.unread }" v-linkify>{{ chat.last_message || '' }}</p>
             </div>
           </div>
         </div>
@@ -138,7 +142,7 @@ resulting from the use or misuse of this software.
               >
                 <i class="fas fa-trash text-sm text-red-500" aria-hidden="true"></i>
               </button>
-              <div class="text-white py-2 px-4 rounded-tl-3xl rounded-bl-3xl rounded-tr-xl" :class="message.pending ? 'bg-blue opacity-70' : 'bg-blue'">
+              <div class="max-w-[70%] break-words text-white py-2 px-4 rounded-tl-3xl rounded-bl-3xl rounded-tr-xl" :class="message.pending ? 'bg-blue opacity-70' : 'bg-blue'">
                 <p v-if="message.text">{{ message.text }}</p>
                 <ChatVideo
                     v-if="message.video_key"
@@ -165,7 +169,7 @@ resulting from the use or misuse of this software.
                   />
                 </div>
               </div>
-              <p class="text-xs text-dark ml-2">
+              <p class="text-xs text-dark ml-2 flex-none whitespace-nowrap">
                 <span v-if="message.pending"><i class="fas fa-clock" aria-hidden="true"></i> Sending…</span>
                 <span v-else>{{ $filters.time(message.created_at) }}</span>
               </p>
@@ -177,7 +181,7 @@ resulting from the use or misuse of this software.
                   class="h-8 w-8 rounded-full mr-2 object-cover bg-transparent cursor-pointer"
                   @click="gotoProfile(active.other_user_id)"
               />
-              <div class="bg-lighter text-black py-2 px-4 rounded-tr-3xl rounded-tl-xl rounded-br-3xl">
+              <div class="max-w-[70%] break-words bg-lighter text-black py-2 px-4 rounded-tr-3xl rounded-tl-xl rounded-br-3xl">
                 <p v-if="message.text">{{ message.text }}</p>
                 <ChatVideo
                     v-if="message.video_key"
@@ -204,7 +208,7 @@ resulting from the use or misuse of this software.
                   />
                 </div>
               </div>
-              <p class="text-xs text-dark ml-2">{{ $filters.time(message.created_at) }}</p>
+              <p class="text-xs text-dark ml-2 flex-none whitespace-nowrap">{{ $filters.time(message.created_at) }}</p>
             </div>
           </div>
           <div ref="scrollToMe"></div>
@@ -391,8 +395,15 @@ export default {
     // Only chats whose other user resolved are listed. Bridged Mastodon
     // accounts never land in the map, so their legacy chats stay hidden
     // instead of rendering as a clickable "Anonymous" row.
+    // Unread chats float to the top; within each group the freshest
+    // message comes first.
     visibleChats() {
-      return this.chats.filter((c) => this.usersMap.has(c.other_user_id));
+      return this.chats
+        .filter((chat) => this.usersMap.has(chat.other_user_id))
+        .map((chat) => ({ ...chat, unread: this.isUnread(chat) }))
+        .sort((a, b) =>
+          (b.unread - a.unread) ||
+          (new Date(b.updated_at) - new Date(a.updated_at)));
     },
     acceptedVideoTypes() {
       return acceptedVideoAccept;
@@ -684,6 +695,9 @@ export default {
             last_message: preview,
             updated_at: new Date().toISOString(),
           });
+          // The local updated_at bump above is newer than the mark selectChat
+          // just set — refresh it so the own-sent message reads as seen.
+          warpnetService.markChatRead(this.active.id);
         }
       } catch (err) {
         console.warn('post-send refresh failed (message was sent):', err);
@@ -749,6 +763,7 @@ export default {
       }
       this.messages = []; // reset messages
       this.active = chat;
+      warpnetService.markChatRead(chat.id);
 
       const messages = await warpnetService.getDirectMessages(
           {chatId: chat.id, cursorReset: true},
@@ -802,6 +817,14 @@ export default {
     },
     getUser(userId) {
       return this.usersMap.get(userId);
+    },
+    // The open chat is never unread — its messages are on screen. An empty
+    // last_message means the chat predates preview support (or has no
+    // messages yet), so there is nothing to mark unread either.
+    isUnread(chat) {
+      if (!chat.last_message) return false;
+      if (chat.id && chat.id === this.active?.id) return false;
+      return new Date(chat.updated_at).getTime() > warpnetService.getChatReadAt(chat.id);
     },
     async loadChatUser(userId) {
       if (!userId || userId.length === 0) {
@@ -917,6 +940,7 @@ export default {
         const wasNearBottom = this.isNearBottom();
         this.messages = [...this.messages, ...fresh]
             .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+        warpnetService.markChatRead(activeId);
         // Hydrate through the reactive array so the fill-in triggers a render.
         this.hydrateMedia(this.messages.filter((m) => freshIds.has(m.id)));
         if (wasNearBottom) {
@@ -967,6 +991,9 @@ export default {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
+    }
+    if (this.active?.id) {
+      warpnetService.markChatRead(this.active.id);
     }
   },
 };

--- a/frontend/tests/views/Conversation.spec.js
+++ b/frontend/tests/views/Conversation.spec.js
@@ -8,6 +8,7 @@ vi.mock('@/service/service', () => ({
     getProfile: vi.fn(),
     getImage: vi.fn(),
     sendDirectMessage: vi.fn(),
+    markChatRead: vi.fn(),
   },
 }));
 

--- a/frontend/tests/views/Conversations.spec.js
+++ b/frontend/tests/views/Conversations.spec.js
@@ -10,6 +10,8 @@ vi.mock('@/service/service', () => ({
     markMessageNotificationsRead: vi.fn(),
     getCursor: vi.fn(),
     setCursor: vi.fn(),
+    markChatRead: vi.fn(),
+    getChatReadAt: vi.fn(() => 0),
   },
 }));
 
@@ -61,6 +63,7 @@ afterAll(() => {
 const ALICE = '01KY0357FD1DS8X2E6HHHVXJBG';
 const BOB = '01KTRA1Q83VBTES33BRQV79JN6';
 const CAROL = '01KSGHBHKG0N77T6A3RZV8WSH5';
+const DAVE = '01KV5Y0M4E8Q1W9Z7X3C2B6NRD';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -103,6 +106,46 @@ describe('Conversations.vue', () => {
     expect(await screen.findByText(BOB)).toBeInTheDocument();
     expect(screen.getByText('see you tomorrow')).toBeInTheDocument();
     expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
+  });
+
+  it('floats unread chats to the top and sorts the rest by recency', async () => {
+    const readAt = new Date('2026-01-02T00:00:00Z').getTime();
+    warpnetService.getChatReadAt.mockImplementation((chatId) =>
+      chatId === 'chat-unread' ? 0 : readAt,
+    );
+    warpnetService.getChats.mockResolvedValue([
+      {
+        id: 'chat-read-old',
+        owner_id: ALICE,
+        other_user_id: BOB,
+        last_message: 'old news',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'chat-unread',
+        owner_id: ALICE,
+        other_user_id: CAROL,
+        last_message: 'unseen',
+        updated_at: '2026-01-01T06:00:00Z',
+      },
+      {
+        id: 'chat-read-new',
+        owner_id: ALICE,
+        other_user_id: DAVE,
+        last_message: 'fresh',
+        updated_at: '2026-01-01T12:00:00Z',
+      },
+    ]);
+
+    renderConversations();
+
+    await screen.findByText('unseen');
+    const previews = screen
+      .getAllByText(/^(old news|unseen|fresh)$/)
+      .map((el) => el.textContent);
+    expect(previews).toEqual(['unseen', 'fresh', 'old news']);
+    // Only the unread chat carries the dot.
+    expect(screen.getByLabelText('Unread messages')).toBeInTheDocument();
   });
 
   it('navigates to Messages when a chat row is clicked', async () => {

--- a/frontend/tests/views/Messages.spec.js
+++ b/frontend/tests/views/Messages.spec.js
@@ -13,6 +13,8 @@ vi.mock('@/service/service', () => ({
     createChat: vi.fn(),
     sendDirectMessage: vi.fn(),
     markMessageNotificationsRead: vi.fn(),
+    markChatRead: vi.fn(),
+    getChatReadAt: vi.fn(() => 0),
   },
 }));
 


### PR DESCRIPTION
…chat lists

Chat records now get their last_message/updated_at bumped when a message is stored (database/chat-repo.go), so both chat lists can render previews. The lists sort unread-first then by recency, mark unread chats with an accent dot, and track read state locally (the node keeps no per-chat read state). Also: 24-hour message timestamps, long unbroken messages wrap inside capped-width bubbles, and v-linkify previews are keyed by text so live poll updates don't patch a detached text node.