### PR TITLE
fix(moderation): answer reporter on unreviewable content, reuse verdi…

### DIFF
--- a/cmd/node/moderator/moderator/moderator.go
+++ b/cmd/node/moderator/moderator/moderator.go
@@ -29,6 +29,7 @@ package moderator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -193,27 +194,70 @@ func (m *Moderator) notifyReporter(
 	}
 }
 
+const fetchAttempts = 3
+
+// fetchRetryDelay is a var so tests can zero it out.
+var fetchRetryDelay = 3 * time.Second
+
+// fetchObject dials the target node with a few short retries: the origin
+// node may be restarting or re-connecting right when the report arrives, and
+// a report is fire-and-forget — there is no second chance once this returns.
+// A failed fetch (not found, offline-forward) arrives as an
+// event.ResponseError envelope, not a transport error; both count as misses.
+func (m *Moderator) fetchObject(nodeID string, route stream.WarpRoute, payload any) ([]byte, error) {
+	var done <-chan struct{}
+	if m.ctx != nil {
+		done = m.ctx.Done()
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < fetchAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-done:
+				return nil, m.ctx.Err()
+			case <-time.After(fetchRetryDelay):
+			}
+		}
+
+		data, err := m.node.GenericStream(nodeID, route, payload)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var respErr event.ResponseError
+		if json.Unmarshal(data, &respErr) == nil && respErr.Message != "" {
+			lastErr = errors.New(respErr.Message)
+			continue
+		}
+		return data, nil
+	}
+	return nil, lastErr
+}
+
+// notifyUnreviewable tells the reporter their report cannot be reviewed —
+// without it a lost fetch reads as a lost report. The OK result keeps every
+// receiver from touching local state; the sentinel reason lets member nodes
+// word the notification honestly.
+func (m *Moderator) notifyUnreviewable(rep event.ReportEvent, objectID *domain.ID, targetUserID domain.ID) {
+	reason := event.ModerationReasonUnavailable
+	m.notifyReporter(rep, domain.OK, &reason, objectID, targetUserID)
+}
+
 func (m *Moderator) handleTweetReport(ev event.ReportEvent) error {
 	if ev.ObjectID == nil || *ev.ObjectID == "" {
 		log.Warn("moderator: tweet report missing object_id")
 		return nil
 	}
 
-	data, err := m.node.GenericStream(
+	data, err := m.fetchObject(
 		ev.TargetNodeID,
 		event.PUBLIC_GET_TWEET,
 		event.GetTweetEvent{TweetId: *ev.ObjectID, UserId: ev.TargetUserID},
 	)
 	if err != nil {
-		return fmt.Errorf("moderator: fetch tweet %s: %w", *ev.ObjectID, err)
-	}
-
-	// The target node serialises a failed fetch (tweet not found, moderated,
-	// offline-forward) as an event.ResponseError envelope, not a transport
-	// error. Detect it so it isn't silently parsed into a zero-value tweet.
-	var respErr event.ResponseError
-	if json.Unmarshal(data, &respErr) == nil && respErr.Message != "" {
-		log.Warnf("moderator: fetch tweet %s from node %s failed: %s", *ev.ObjectID, ev.TargetNodeID, respErr.Message)
+		log.Warnf("moderator: fetch tweet %s from node %s failed: %v", *ev.ObjectID, ev.TargetNodeID, err)
+		m.notifyUnreviewable(ev, ev.ObjectID, ev.TargetUserID)
 		return nil
 	}
 
@@ -223,10 +267,22 @@ func (m *Moderator) handleTweetReport(ev event.ReportEvent) error {
 	}
 	if tweet.Id == "" {
 		log.Warnf("moderator: tweet %s not found on node %s", *ev.ObjectID, ev.TargetNodeID)
+		m.notifyUnreviewable(ev, ev.ObjectID, ev.TargetUserID)
 		return nil
 	}
 	if tweet.Text == "" {
 		log.Infof("moderator: tweet %s has no text to moderate", tweet.Id)
+		m.notifyUnreviewable(ev, &tweet.Id, tweet.UserId)
+		return nil
+	}
+
+	// A tweet that already carries a verdict was moderated on an earlier
+	// report — reuse it instead of burning another model run. The followers
+	// broadcast for a FAIL went out back then; only the reporter is new here.
+	if tweet.Moderation != nil {
+		log.Infof("moderator: tweet %s already moderated ok=%t, reusing verdict",
+			tweet.Id, bool(tweet.Moderation.IsOk))
+		m.notifyReporter(ev, tweet.Moderation.IsOk, tweet.Moderation.Reason, &tweet.Id, tweet.UserId)
 		return nil
 	}
 
@@ -254,18 +310,14 @@ func (m *Moderator) handleTweetReport(ev event.ReportEvent) error {
 }
 
 func (m *Moderator) handleUserReport(ev event.ReportEvent) error {
-	data, err := m.node.GenericStream(
+	data, err := m.fetchObject(
 		ev.TargetNodeID,
 		event.PUBLIC_GET_USER,
 		event.GetUserEvent{UserId: ev.TargetUserID},
 	)
 	if err != nil {
-		return fmt.Errorf("fetch user %s: %w", ev.TargetUserID, err)
-	}
-
-	var respErr event.ResponseError
-	if json.Unmarshal(data, &respErr) == nil && respErr.Message != "" {
-		log.Warnf("moderator: fetch user %s from node %s failed: %s", ev.TargetUserID, ev.TargetNodeID, respErr.Message)
+		log.Warnf("moderator: fetch user %s from node %s failed: %v", ev.TargetUserID, ev.TargetNodeID, err)
+		m.notifyUnreviewable(ev, nil, ev.TargetUserID)
 		return nil
 	}
 
@@ -275,12 +327,14 @@ func (m *Moderator) handleUserReport(ev event.ReportEvent) error {
 	}
 	if user.Id == "" {
 		log.Warnf("moderator: user %s not found on node %s", ev.TargetUserID, ev.TargetNodeID)
+		m.notifyUnreviewable(ev, nil, ev.TargetUserID)
 		return nil
 	}
 
 	text := buildProfileText(user)
 	if text == "" {
 		log.Warn("moderator: empty profile text")
+		m.notifyUnreviewable(ev, nil, user.Id)
 		return nil
 	}
 

--- a/cmd/node/moderator/moderator/moderator.go
+++ b/cmd/node/moderator/moderator/moderator.go
@@ -196,14 +196,12 @@ func (m *Moderator) notifyReporter(
 
 const fetchAttempts = 3
 
-// fetchRetryDelay is a var so tests can zero it out.
-var fetchRetryDelay = 3 * time.Second
+var (
+	fetchRetryDelay = 3 * time.Second
 
-// fetchObject dials the target node with a few short retries: the origin
-// node may be restarting or re-connecting right when the report arrives, and
-// a report is fire-and-forget — there is no second chance once this returns.
-// A failed fetch (not found, offline-forward) arrives as an
-// event.ResponseError envelope, not a transport error; both count as misses.
+	ErrFetchFailed = errors.New("moderator: fetch failed")
+)
+
 func (m *Moderator) fetchObject(nodeID string, route stream.WarpRoute, payload any) ([]byte, error) {
 	var done <-chan struct{}
 	if m.ctx != nil {
@@ -211,7 +209,7 @@ func (m *Moderator) fetchObject(nodeID string, route stream.WarpRoute, payload a
 	}
 
 	var lastErr error
-	for attempt := 0; attempt < fetchAttempts; attempt++ {
+	for attempt := range fetchAttempts {
 		if attempt > 0 {
 			select {
 			case <-done:
@@ -227,7 +225,7 @@ func (m *Moderator) fetchObject(nodeID string, route stream.WarpRoute, payload a
 		}
 		var respErr event.ResponseError
 		if json.Unmarshal(data, &respErr) == nil && respErr.Message != "" {
-			lastErr = errors.New(respErr.Message)
+			lastErr = fmt.Errorf("%w: %s", ErrFetchFailed, respErr.Message)
 			continue
 		}
 		return data, nil
@@ -235,10 +233,6 @@ func (m *Moderator) fetchObject(nodeID string, route stream.WarpRoute, payload a
 	return nil, lastErr
 }
 
-// notifyUnreviewable tells the reporter their report cannot be reviewed —
-// without it a lost fetch reads as a lost report. The OK result keeps every
-// receiver from touching local state; the sentinel reason lets member nodes
-// word the notification honestly.
 func (m *Moderator) notifyUnreviewable(rep event.ReportEvent, objectID *domain.ID, targetUserID domain.ID) {
 	reason := event.ModerationReasonUnavailable
 	m.notifyReporter(rep, domain.OK, &reason, objectID, targetUserID)
@@ -276,9 +270,6 @@ func (m *Moderator) handleTweetReport(ev event.ReportEvent) error {
 		return nil
 	}
 
-	// A tweet that already carries a verdict was moderated on an earlier
-	// report — reuse it instead of burning another model run. The followers
-	// broadcast for a FAIL went out back then; only the reporter is new here.
 	if tweet.Moderation != nil {
 		log.Infof("moderator: tweet %s already moderated ok=%t, reusing verdict",
 			tweet.Id, bool(tweet.Moderation.IsOk))

--- a/cmd/node/moderator/moderator/moderator_test.go
+++ b/cmd/node/moderator/moderator/moderator_test.go
@@ -2,8 +2,11 @@
 package moderator
 
 import (
+	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Warp-net/warpnet/cmd/node/moderator/isolation"
 	"github.com/Warp-net/warpnet/core/stream"
@@ -62,6 +65,16 @@ func withEngine(t *testing.T, e Engine) {
 	prev := engine
 	engine = e
 	t.Cleanup(func() { engine = prev })
+	withFastRetry(t)
+}
+
+// withFastRetry zeroes the fetch retry delay so failure-path tests don't
+// sleep through real backoff.
+func withFastRetry(t *testing.T) {
+	t.Helper()
+	prev := fetchRetryDelay
+	fetchRetryDelay = 0
+	t.Cleanup(func() { fetchRetryDelay = prev })
 }
 
 func marshal(t *testing.T, v any) []byte {
@@ -138,6 +151,303 @@ func TestHandleTweetReport_EmptyTextSkipsEngine(t *testing.T) {
 	}
 	if rec.called {
 		t.Fatal("image-only tweet has no text to moderate")
+	}
+}
+
+// A tweet report without an object id has nothing to fetch: no dial, no
+// engine run, no reporter delivery.
+func TestHandleTweetReport_MissingObjectIDIsNoop(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	node := stubModeratorNode{
+		streamFn: func(_ string, _ stream.WarpRoute, _ any) ([]byte, error) {
+			t.Fatal("must not dial anything without an object id")
+			return nil, nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	rep := tweetReport("")
+	rep.ObjectID = nil
+	if err := m.handleTweetReport(rep); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if rec.called {
+		t.Fatal("engine must not run without an object id")
+	}
+}
+
+// A transport-level dial error counts as a miss exactly like an error
+// envelope: retried, then reported back as unreviewable.
+func TestHandleTweetReport_TransportErrorNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		fetches   int
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_TWEET {
+				fetches++
+				return nil, warpnet.ErrNodeIsOffline
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	rep := tweetReport("tweet-1")
+	rep.ReporterID = "reporter-1"
+	rep.ReporterNodeID = "reporter-node-1"
+
+	if err := m.handleTweetReport(rep); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if fetches != fetchAttempts {
+		t.Fatalf("expected %d fetch attempts, got %d", fetchAttempts, fetches)
+	}
+	if rec.called {
+		t.Fatal("engine must not run when the dial never succeeded")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// A syntactically valid but zero-value tweet ({}) is not an error envelope
+// and not content either — the reporter must still hear "unavailable".
+func TestHandleTweetReport_ZeroValueTweetNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		fetches   int
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_TWEET {
+				fetches++
+				return []byte(`{}`), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	rep := tweetReport("tweet-1")
+	rep.ReporterID = "reporter-1"
+	rep.ReporterNodeID = "reporter-node-1"
+
+	if err := m.handleTweetReport(rep); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if fetches != 1 {
+		t.Fatalf("a well-formed empty object is not transient, expected 1 fetch, got %d", fetches)
+	}
+	if rec.called {
+		t.Fatal("engine must not run on a zero-value tweet")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// Cancelling the moderator context aborts the retry loop instead of
+// sleeping through the remaining attempts.
+func TestFetchObject_ContextCancelledStopsRetries(t *testing.T) {
+	withFastRetry(t)
+	fetchRetryDelay = time.Hour // force the retry wait to block on ctx
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fetches := 0
+	node := stubModeratorNode{
+		streamFn: func(_ string, _ stream.WarpRoute, _ any) ([]byte, error) {
+			fetches++
+			return marshal(t, event.ResponseError{Code: 500, Message: "tweet not found"}), nil
+		},
+	}
+	m := &Moderator{ctx: ctx, node: node, isClosed: new(atomic.Bool)}
+
+	_, err := m.fetchObject("node-1", event.PUBLIC_GET_TWEET, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if fetches != 1 {
+		t.Fatalf("expected the retry wait to abort after 1 fetch, got %d", fetches)
+	}
+}
+
+// A fetch that fails on every attempt must still answer the reporter —
+// silence reads as a lost report. The verdict is OK (no state touched
+// anywhere) with the sentinel "unavailable" reason.
+func TestHandleTweetReport_FetchFailureNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		fetches   int
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_TWEET {
+				fetches++
+				return marshal(t, event.ResponseError{Code: 500, Message: "tweet not found"}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	rep := tweetReport("tweet-1")
+	rep.ReporterID = "reporter-1"
+	rep.ReporterNodeID = "reporter-node-1"
+
+	if err := m.handleTweetReport(rep); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if fetches != fetchAttempts {
+		t.Fatalf("expected %d fetch attempts, got %d", fetchAttempts, fetches)
+	}
+	if rec.called {
+		t.Fatal("engine must not run when the content was never fetched")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Result != domain.OK {
+		t.Fatal("an unreviewable report must carry an OK (no-op) result")
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// A transient miss must be retried: fail twice, succeed on the third try.
+func TestHandleTweetReport_FetchRetriesTransientFailure(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	fetches := 0
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, _ any) ([]byte, error) {
+			if path == event.PUBLIC_GET_TWEET {
+				fetches++
+				if fetches < 3 {
+					return marshal(t, event.ResponseError{Code: 500, Message: "tweet not found"}), nil
+				}
+				return marshal(t, domain.Tweet{Id: "tweet-1", Text: "hello world"}), nil
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	if err := m.handleTweetReport(tweetReport("tweet-1")); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if fetches != 3 {
+		t.Fatalf("expected 3 fetch attempts, got %d", fetches)
+	}
+	if !rec.called {
+		t.Fatal("engine must run once the retry succeeds")
+	}
+}
+
+// A tweet that already carries a verdict was moderated on an earlier report:
+// reuse it — no model run, no repeated followers broadcast, reporter notified.
+func TestHandleTweetReport_AlreadyModeratedReusesVerdict(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	reason := "Violent Crimes"
+	var (
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_TWEET {
+				return marshal(t, domain.Tweet{
+					Id:     "tweet-1",
+					UserId: "offender",
+					Text:   "already judged",
+					Moderation: &domain.TweetModeration{
+						IsOk:   domain.FAIL,
+						Reason: &reason,
+					},
+				}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	pub := &recordingPublisher{}
+	m := &Moderator{
+		node:      node,
+		isolation: isolation.NewIsolationProtocol(pub),
+		isClosed:  new(atomic.Bool),
+	}
+
+	rep := tweetReport("tweet-1")
+	rep.ReporterID = "reporter-1"
+	rep.ReporterNodeID = "reporter-node-1"
+
+	if err := m.handleTweetReport(rep); err != nil {
+		t.Fatalf("handleTweetReport: %v", err)
+	}
+	if rec.called {
+		t.Fatal("engine must not re-run on an already moderated tweet")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Result != domain.FAIL {
+		t.Fatal("the stored FAIL verdict must be propagated to the reporter")
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != reason {
+		t.Fatalf("the stored reason must be propagated, got %v", gotResult.Reason)
+	}
+	if pub.calls != 0 {
+		t.Fatalf("the followers broadcast already went out on the first verdict, got %d publishes", pub.calls)
 	}
 }
 
@@ -270,5 +580,261 @@ func TestHandleTweetReport_NoReporterNoDelivery(t *testing.T) {
 
 	if err := m.handleTweetReport(tweetReport("tweet-1")); err != nil {
 		t.Fatalf("handleTweetReport: %v", err)
+	}
+}
+
+func userReport() event.ReportEvent {
+	return event.ReportEvent{
+		Type:           domain.ModerationUserType,
+		TargetUserID:   "user-1",
+		TargetNodeID:   "node-1",
+		Reason:         "Hate",
+		ReporterID:     "reporter-1",
+		ReporterNodeID: "reporter-node-1",
+	}
+}
+
+// A real profile reaches the engine as the concatenated profile text; an OK
+// verdict goes to the reporter and never to the followers broadcast.
+func TestHandleUserReport_ValidProfileReachesEngine(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_USER {
+				return marshal(t, domain.User{Id: "user-1", Username: "troll", Bio: "some bio"}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	pub := &recordingPublisher{}
+	m := &Moderator{
+		node:      node,
+		isolation: isolation.NewIsolationProtocol(pub),
+		isClosed:  new(atomic.Bool),
+	}
+
+	if err := m.handleUserReport(userReport()); err != nil {
+		t.Fatalf("handleUserReport: %v", err)
+	}
+	if !rec.called {
+		t.Fatal("engine must run on a real profile")
+	}
+	if rec.text != "troll\nsome bio" {
+		t.Fatalf("engine got %q, want the concatenated profile text", rec.text)
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Result != domain.OK {
+		t.Fatal("expected the OK verdict propagated to the reporter")
+	}
+	if pub.calls != 0 {
+		t.Fatalf("an OK verdict must not be broadcast to followers, got %d publishes", pub.calls)
+	}
+}
+
+// A FAIL verdict on a profile isolates the user via the followers broadcast
+// and tells the reporter.
+func TestHandleUserReport_FailVerdictIsolatesAndNotifies(t *testing.T) {
+	withEngine(t, fixedEngine{ok: false, reason: "Hate"})
+
+	var (
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_USER {
+				return marshal(t, domain.User{Id: "user-1", Username: "troll", Bio: "some bio"}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	pub := &recordingPublisher{}
+	m := &Moderator{
+		node:      node,
+		isolation: isolation.NewIsolationProtocol(pub),
+		isClosed:  new(atomic.Bool),
+	}
+
+	if err := m.handleUserReport(userReport()); err != nil {
+		t.Fatalf("handleUserReport: %v", err)
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Result != domain.FAIL {
+		t.Fatal("expected the FAIL verdict propagated to the reporter")
+	}
+	if pub.calls == 0 {
+		t.Fatal("a FAIL verdict must be broadcast to the offender's followers")
+	}
+}
+
+// A profile fetch that fails on every attempt must answer the reporter with
+// the unavailable sentinel instead of silence.
+func TestHandleUserReport_FetchFailureNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		fetches   int
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_USER {
+				fetches++
+				return marshal(t, event.ResponseError{Code: 500, Message: "user not found"}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	if err := m.handleUserReport(userReport()); err != nil {
+		t.Fatalf("handleUserReport: %v", err)
+	}
+	if fetches != fetchAttempts {
+		t.Fatalf("expected %d fetch attempts, got %d", fetchAttempts, fetches)
+	}
+	if rec.called {
+		t.Fatal("engine must not run when the profile was never fetched")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Result != domain.OK {
+		t.Fatal("an unreviewable report must carry an OK (no-op) result")
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// A zero-value user ({}) is not content; the reporter hears "unavailable".
+func TestHandleUserReport_ZeroValueUserNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_USER {
+				return []byte(`{}`), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	if err := m.handleUserReport(userReport()); err != nil {
+		t.Fatalf("handleUserReport: %v", err)
+	}
+	if rec.called {
+		t.Fatal("engine must not run on a zero-value user")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// A profile with no text to judge (no username, bio, website, metadata)
+// cannot be reviewed — the reporter must hear that, not silence.
+func TestHandleUserReport_EmptyProfileTextNotifiesReporter(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	var (
+		delivered int
+		gotResult event.ModerationResultEvent
+	)
+	node := stubModeratorNode{
+		streamFn: func(_ string, path stream.WarpRoute, data any) ([]byte, error) {
+			if path == event.PUBLIC_GET_USER {
+				return marshal(t, domain.User{Id: "user-1"}), nil
+			}
+			if path == event.PUBLIC_POST_MODERATION_RESULT {
+				delivered++
+				if r, ok := data.(event.ModerationResultEvent); ok {
+					gotResult = r
+				}
+			}
+			return []byte(event.Accepted), nil
+		},
+	}
+	m := &Moderator{node: node, isClosed: new(atomic.Bool)}
+
+	if err := m.handleUserReport(userReport()); err != nil {
+		t.Fatalf("handleUserReport: %v", err)
+	}
+	if rec.called {
+		t.Fatal("engine must not run on an empty profile text")
+	}
+	if delivered != 1 {
+		t.Fatalf("expected exactly one reporter delivery, got %d", delivered)
+	}
+	if gotResult.Reason == nil || *gotResult.Reason != event.ModerationReasonUnavailable {
+		t.Fatalf("expected the unavailable sentinel reason, got %v", gotResult.Reason)
+	}
+}
+
+// handleReport is the dispatch point: a closed moderator ignores reports.
+func TestHandleReport_ClosedModeratorIsNoop(t *testing.T) {
+	rec := &recordingEngine{}
+	withEngine(t, rec)
+
+	node := stubModeratorNode{
+		streamFn: func(_ string, _ stream.WarpRoute, _ any) ([]byte, error) {
+			t.Fatal("a closed moderator must not dial anything")
+			return nil, nil
+		},
+	}
+	closed := new(atomic.Bool)
+	closed.Store(true)
+	m := &Moderator{node: node, isClosed: closed}
+
+	if err := m.handleReport(tweetReport("tweet-1")); err != nil {
+		t.Fatalf("handleReport: %v", err)
+	}
+	if rec.called {
+		t.Fatal("engine must not run on a closed moderator")
 	}
 }

--- a/cmd/node/moderator/moderator/moderator_test.go
+++ b/cmd/node/moderator/moderator/moderator_test.go
@@ -68,8 +68,6 @@ func withEngine(t *testing.T, e Engine) {
 	withFastRetry(t)
 }
 
-// withFastRetry zeroes the fetch retry delay so failure-path tests don't
-// sleep through real backoff.
 func withFastRetry(t *testing.T) {
 	t.Helper()
 	prev := fetchRetryDelay
@@ -154,8 +152,6 @@ func TestHandleTweetReport_EmptyTextSkipsEngine(t *testing.T) {
 	}
 }
 
-// A tweet report without an object id has nothing to fetch: no dial, no
-// engine run, no reporter delivery.
 func TestHandleTweetReport_MissingObjectIDIsNoop(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -178,8 +174,6 @@ func TestHandleTweetReport_MissingObjectIDIsNoop(t *testing.T) {
 	}
 }
 
-// A transport-level dial error counts as a miss exactly like an error
-// envelope: retried, then reported back as unreviewable.
 func TestHandleTweetReport_TransportErrorNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -227,8 +221,6 @@ func TestHandleTweetReport_TransportErrorNotifiesReporter(t *testing.T) {
 	}
 }
 
-// A syntactically valid but zero-value tweet ({}) is not an error envelope
-// and not content either — the reporter must still hear "unavailable".
 func TestHandleTweetReport_ZeroValueTweetNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -276,11 +268,9 @@ func TestHandleTweetReport_ZeroValueTweetNotifiesReporter(t *testing.T) {
 	}
 }
 
-// Cancelling the moderator context aborts the retry loop instead of
-// sleeping through the remaining attempts.
 func TestFetchObject_ContextCancelledStopsRetries(t *testing.T) {
 	withFastRetry(t)
-	fetchRetryDelay = time.Hour // force the retry wait to block on ctx
+	fetchRetryDelay = time.Hour
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -303,9 +293,6 @@ func TestFetchObject_ContextCancelledStopsRetries(t *testing.T) {
 	}
 }
 
-// A fetch that fails on every attempt must still answer the reporter —
-// silence reads as a lost report. The verdict is OK (no state touched
-// anywhere) with the sentinel "unavailable" reason.
 func TestHandleTweetReport_FetchFailureNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -356,7 +343,6 @@ func TestHandleTweetReport_FetchFailureNotifiesReporter(t *testing.T) {
 	}
 }
 
-// A transient miss must be retried: fail twice, succeed on the third try.
 func TestHandleTweetReport_FetchRetriesTransientFailure(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -387,8 +373,6 @@ func TestHandleTweetReport_FetchRetriesTransientFailure(t *testing.T) {
 	}
 }
 
-// A tweet that already carries a verdict was moderated on an earlier report:
-// reuse it — no model run, no repeated followers broadcast, reporter notified.
 func TestHandleTweetReport_AlreadyModeratedReusesVerdict(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -594,8 +578,6 @@ func userReport() event.ReportEvent {
 	}
 }
 
-// A real profile reaches the engine as the concatenated profile text; an OK
-// verdict goes to the reporter and never to the followers broadcast.
 func TestHandleUserReport_ValidProfileReachesEngine(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -645,8 +627,6 @@ func TestHandleUserReport_ValidProfileReachesEngine(t *testing.T) {
 	}
 }
 
-// A FAIL verdict on a profile isolates the user via the followers broadcast
-// and tells the reporter.
 func TestHandleUserReport_FailVerdictIsolatesAndNotifies(t *testing.T) {
 	withEngine(t, fixedEngine{ok: false, reason: "Hate"})
 
@@ -689,8 +669,6 @@ func TestHandleUserReport_FailVerdictIsolatesAndNotifies(t *testing.T) {
 	}
 }
 
-// A profile fetch that fails on every attempt must answer the reporter with
-// the unavailable sentinel instead of silence.
 func TestHandleUserReport_FetchFailureNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -737,7 +715,6 @@ func TestHandleUserReport_FetchFailureNotifiesReporter(t *testing.T) {
 	}
 }
 
-// A zero-value user ({}) is not content; the reporter hears "unavailable".
 func TestHandleUserReport_ZeroValueUserNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -776,8 +753,6 @@ func TestHandleUserReport_ZeroValueUserNotifiesReporter(t *testing.T) {
 	}
 }
 
-// A profile with no text to judge (no username, bio, website, metadata)
-// cannot be reviewed — the reporter must hear that, not silence.
 func TestHandleUserReport_EmptyProfileTextNotifiesReporter(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)
@@ -816,7 +791,6 @@ func TestHandleUserReport_EmptyProfileTextNotifiesReporter(t *testing.T) {
 	}
 }
 
-// handleReport is the dispatch point: a closed moderator ignores reports.
 func TestHandleReport_ClosedModeratorIsNoop(t *testing.T) {
 	rec := &recordingEngine{}
 	withEngine(t, rec)

--- a/core/handler/moderation.go
+++ b/core/handler/moderation.go
@@ -137,10 +137,6 @@ func StreamModerationResultHandler(
 			if err := tweetRepo.Update(tweet); err != nil {
 				log.Errorf("moderation: failed to update tweet: %v", err)
 			}
-			// The home timeline is keyed by the LOCAL owner's id — on a
-			// reporter's or follower's node the offender's id addresses a
-			// timeline that doesn't exist and the delete silently no-ops,
-			// leaving the moderated tweet visible.
 			if authRepo != nil {
 				if ownerId := authRepo.GetOwner().UserId; ownerId != "" {
 					if err := timelineRepo.DeleteTweetFromTimeline(ownerId, *ev.ObjectID); err != nil {
@@ -216,9 +212,6 @@ func reportResultText(ev event.ModerationResultEvent) string {
 		subject = "profile"
 	}
 	if bool(ev.Result) {
-		// Not a real review: the moderator could not fetch the content
-		// (origin node offline or the object is gone). Saying "no violation
-		// found" here would misreport a fetch failure as a clean verdict.
 		if ev.Reason != nil && *ev.Reason == event.ModerationReasonUnavailable {
 			return fmt.Sprintf("The %s you reported could not be reviewed: the content is unavailable", subject)
 		}

--- a/core/handler/moderation.go
+++ b/core/handler/moderation.go
@@ -137,8 +137,16 @@ func StreamModerationResultHandler(
 			if err := tweetRepo.Update(tweet); err != nil {
 				log.Errorf("moderation: failed to update tweet: %v", err)
 			}
-			if err := timelineRepo.DeleteTweetFromTimeline(ev.UserID, *ev.ObjectID); err != nil {
-				log.Errorf("moderation: failed to delete timeline: %v", err)
+			// The home timeline is keyed by the LOCAL owner's id — on a
+			// reporter's or follower's node the offender's id addresses a
+			// timeline that doesn't exist and the delete silently no-ops,
+			// leaving the moderated tweet visible.
+			if authRepo != nil {
+				if ownerId := authRepo.GetOwner().UserId; ownerId != "" {
+					if err := timelineRepo.DeleteTweetFromTimeline(ownerId, *ev.ObjectID); err != nil {
+						log.Errorf("moderation: failed to delete timeline: %v", err)
+					}
+				}
 			}
 
 		case domain.ModerationUserType:
@@ -208,6 +216,12 @@ func reportResultText(ev event.ModerationResultEvent) string {
 		subject = "profile"
 	}
 	if bool(ev.Result) {
+		// Not a real review: the moderator could not fetch the content
+		// (origin node offline or the object is gone). Saying "no violation
+		// found" here would misreport a fetch failure as a clean verdict.
+		if ev.Reason != nil && *ev.Reason == event.ModerationReasonUnavailable {
+			return fmt.Sprintf("The %s you reported could not be reviewed: the content is unavailable", subject)
+		}
 		return fmt.Sprintf("The %s you reported was reviewed: no violation found", subject)
 	}
 	if ev.Reason != nil && *ev.Reason != "" {

--- a/core/handler/moderation_test.go
+++ b/core/handler/moderation_test.go
@@ -290,10 +290,6 @@ func TestStreamModerationResultHandler(t *testing.T) {
 		}
 	})
 
-	// The home timeline is keyed by the LOCAL owner's id. On a reporter's or
-	// follower's node the offender's id addresses a timeline that doesn't
-	// exist, so the delete silently no-ops and the moderated tweet stays
-	// visible in the list while the tweet card already renders as moderated.
 	t.Run("tweet moderation FAIL - deletes from the local owner's timeline", func(t *testing.T) {
 		var gotUserID, gotTweetID string
 		h := mkHandler(
@@ -322,8 +318,6 @@ func TestStreamModerationResultHandler(t *testing.T) {
 		}
 	})
 
-	// A fetch-failure verdict (OK + sentinel reason) must tell the reporter
-	// the content could not be reviewed — not claim a clean review.
 	t.Run("unreviewable report - notifies reporter honestly", func(t *testing.T) {
 		var got domain.Notification
 		notified := false

--- a/core/handler/moderation_test.go
+++ b/core/handler/moderation_test.go
@@ -290,6 +290,79 @@ func TestStreamModerationResultHandler(t *testing.T) {
 		}
 	})
 
+	// The home timeline is keyed by the LOCAL owner's id. On a reporter's or
+	// follower's node the offender's id addresses a timeline that doesn't
+	// exist, so the delete silently no-ops and the moderated tweet stays
+	// visible in the list while the tweet card already renders as moderated.
+	t.Run("tweet moderation FAIL - deletes from the local owner's timeline", func(t *testing.T) {
+		var gotUserID, gotTweetID string
+		h := mkHandler(
+			stubModerationNotifier{},
+			stubModerationTweetUpdater{},
+			stubModerationUserUpdater{},
+			stubModerationTimelineDeleter{deleteFn: func(userID, tweetID string) error {
+				gotUserID, gotTweetID = userID, tweetID
+				return nil
+			}},
+		)
+		_, err := h(marshal(t, event.ModerationResultEvent{
+			Type:     domain.ModerationTweetType,
+			ObjectID: &tweetId,
+			UserID:   "offender",
+			Result:   domain.FAIL,
+		}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if gotUserID != owner {
+			t.Fatalf("timeline delete must use the local owner's id, got %q", gotUserID)
+		}
+		if gotTweetID != tweetId {
+			t.Fatalf("expected tweet %q deleted, got %q", tweetId, gotTweetID)
+		}
+	})
+
+	// A fetch-failure verdict (OK + sentinel reason) must tell the reporter
+	// the content could not be reviewed — not claim a clean review.
+	t.Run("unreviewable report - notifies reporter honestly", func(t *testing.T) {
+		var got domain.Notification
+		notified := false
+		h := mkHandler(
+			stubModerationNotifier{addFn: func(not domain.Notification) error {
+				notified = true
+				got = not
+				return nil
+			}},
+			stubModerationTweetUpdater{},
+			stubModerationUserUpdater{},
+			stubModerationTimelineDeleter{},
+		)
+		reason := event.ModerationReasonUnavailable
+		resp, err := h(marshal(t, event.ModerationResultEvent{
+			Type:       domain.ModerationTweetType,
+			ObjectID:   &tweetId,
+			UserID:     "offender",
+			Result:     domain.OK,
+			Reason:     &reason,
+			ReporterID: owner,
+		}), nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if resp != event.Accepted {
+			t.Fatalf("expected accepted, got: %v", resp)
+		}
+		if !notified {
+			t.Fatal("the reporter must be notified")
+		}
+		if !strings.Contains(got.Text, "could not be reviewed") {
+			t.Fatalf("expected 'could not be reviewed' wording, got: %q", got.Text)
+		}
+		if strings.Contains(got.Text, "no violation") {
+			t.Fatalf("a fetch failure must not read as a clean verdict: %q", got.Text)
+		}
+	})
+
 	// An OK verdict arrives only on the reporter-bound delivery. It must
 	// notify the reporter with the "no violation" wording and leave the
 	// local tweet and timeline untouched.

--- a/core/middleware/auth.go
+++ b/core/middleware/auth.go
@@ -97,7 +97,7 @@ func (p *WarpMiddleware) AuthMiddleware(next warpnet.StreamHandler) warpnet.Stre
 
 		pubKey := warpnet.FromIDToPubKey(remotePeer)
 		if err := security.VerifySignature(pubKey, msg.SigningBytes(), msg.Signature); err != nil {
-			log.Errorf("middleware: auth: signature invalid: %v", err)
+			log.Errorf("middleware: auth: signature invalid: %v: route %s, peer %s", err, route, remotePeer)
 			_, _ = s.Write(ErrInternalNodeError.Bytes())
 			return
 		}

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -112,7 +112,9 @@ func NewWarpNode(
 		return nil, err
 	}
 
-	ya := yamux.DefaultTransport
+	// Copy the transport config: DefaultTransport is a shared package-level
+	// pointer that live yamux sessions of other nodes read concurrently.
+	ya := *yamux.DefaultTransport
 	ya.KeepAliveInterval = 15 * time.Second
 	ya.ConnectionWriteTimeout = 30 * time.Second
 
@@ -120,7 +122,7 @@ func NewWarpNode(
 		libp2p.ResourceManager(rm),
 		libp2p.ConnectionManager(manager),
 		libp2p.DisableMetrics(), // TODO move to settings
-		libp2p.Muxer(yamux.ID, ya),
+		libp2p.Muxer(yamux.ID, &ya),
 	}
 
 	opts = append(opts, managersOpts...)

--- a/event/event.go
+++ b/event/event.go
@@ -571,6 +571,12 @@ type ReportEvent struct {
 	ReporterNodeID domain.ID `json:"reporter_node_id,omitempty"`
 }
 
+// ModerationReasonUnavailable is the sentinel reason on a reporter-bound
+// verdict that carries no real review: the moderator could not fetch the
+// reported content. It rides an OK result so receivers touch no local state;
+// member nodes key on it to word the reporter's notification honestly.
+const ModerationReasonUnavailable = "content unavailable for review"
+
 type ModerationResultEvent struct {
 	Type     domain.ModerationObjectType `json:"type"`
 	Result   domain.ModerationResult     `json:"result"`

--- a/event/event.go
+++ b/event/event.go
@@ -571,10 +571,6 @@ type ReportEvent struct {
 	ReporterNodeID domain.ID `json:"reporter_node_id,omitempty"`
 }
 
-// ModerationReasonUnavailable is the sentinel reason on a reporter-bound
-// verdict that carries no real review: the moderator could not fetch the
-// reported content. It rides an OK result so receivers touch no local state;
-// member nodes key on it to word the reporter's notification honestly.
 const ModerationReasonUnavailable = "content unavailable for review"
 
 type ModerationResultEvent struct {

--- a/event/signing_test.go
+++ b/event/signing_test.go
@@ -35,9 +35,6 @@ func TestMessage_SigningBytes_JSONRoundTrip(t *testing.T) {
 	}
 }
 
-// A body-less message (e.g. discovery's GET_INFO) marshals its nil Body as
-// JSON null and the receiver unmarshals it back as the literal bytes "null";
-// SigningBytes must produce identical bytes on both sides regardless.
 func TestMessage_SigningBytes_NilBodyJSONRoundTrip(t *testing.T) {
 	msg := event.Message{
 		Body:      nil,

--- a/event/signing_test.go
+++ b/event/signing_test.go
@@ -35,6 +35,30 @@ func TestMessage_SigningBytes_JSONRoundTrip(t *testing.T) {
 	}
 }
 
+// A body-less message (e.g. discovery's GET_INFO) marshals its nil Body as
+// JSON null and the receiver unmarshals it back as the literal bytes "null";
+// SigningBytes must produce identical bytes on both sides regardless.
+func TestMessage_SigningBytes_NilBodyJSONRoundTrip(t *testing.T) {
+	msg := event.Message{
+		Body:      nil,
+		Timestamp: time.Now().UTC(),
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got event.Message
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if string(got.SigningBytes()) != string(msg.SigningBytes()) {
+		t.Fatalf("signing bytes changed across JSON round-trip:\n before = %q\n after  = %q", msg.SigningBytes(), got.SigningBytes())
+	}
+}
+
 // Tampering with the timestamp must invalidate the signature.
 func TestMessage_SignatureBindsTimestamp(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(nil)


### PR DESCRIPTION
…cts, fix timeline delete

Live-testing moderation on testnet surfaced three defects:

- moderator: a failed content fetch (origin node offline or object gone, e.g. the echo node's in-memory store after a restart) silently dropped the report - the reporter never heard anything. The fetch is now retried (3 attempts, 3s apart) and on exhaustion the reporter receives an OK verdict carrying the ModerationReasonUnavailable sentinel, which member nodes render as "could not be reviewed" instead of "no violation found".
- moderator: a tweet already carrying a moderation sidecar was re-fetched and re-run through the model on every new report. The stored verdict is now reused: reporter notified, no model run, no repeated broadcast.
- handler: the FAIL verdict deleted the tweet from the timeline keyed by the offender's id, but home timelines are keyed by the local owner's id, so on reporter/follower nodes the delete silently no-oped and the denormalized timeline row kept showing the original text while the tweet card already rendered as moderated. Delete by the local owner's id.

Also include route and remote peer in the middleware signature-invalid log line - the anonymous version made a single pre-#371 node (old signing format) look like network-wide "version drift" - and pin the nil-body SigningBytes JSON round-trip with a regression test.