### PR TITLE
fix(auth): stop login from clobbering a renamed profile username

### DIFF
--- a/cmd/node/member/auth/auth.go
+++ b/cmd/node/member/auth/auth.go
@@ -176,8 +176,10 @@ func (as *AuthService) AuthLogin(message event.LoginEvent, psk security.PSK) (au
 			panic("auth: node id is missing")
 		}
 
+		// user.Username is deliberately left empty: the repo's merge-style
+		// Update keeps the profile's (possibly renamed) username, while
+		// owner.Username stays the immutable login name.
 		user.Id = owner.UserId
-		user.Username = owner.Username
 		user.CreatedAt = owner.CreatedAt
 		user.RoundTripTime = math.MaxInt64 // put your user at the end of a who-to-follow list
 		user.NodeId = authInfo.ID
@@ -187,7 +189,7 @@ func (as *AuthService) AuthLogin(message event.LoginEvent, psk security.PSK) (au
 		log.Infof(
 			"auth: user authenticated: id: %s, name: '%s', node_id: %s, created_at: %s, latency: %d",
 			user.Id,
-			user.Username,
+			owner.Username,
 			user.NodeId,
 			user.CreatedAt,
 			user.RoundTripTime,

--- a/cmd/node/member/auth/auth_test.go
+++ b/cmd/node/member/auth/auth_test.go
@@ -277,6 +277,24 @@ func TestAuthLogin_ReturningOwnerIsNotRecreated(t *testing.T) {
 	assert.Equal(t, "existing-id", updated[0].Id)
 }
 
+func TestAuthLogin_ReloginKeepsRenamedProfileUsername(t *testing.T) {
+	repo := newFakeAuthRepo()
+	repo.owner = domain.Owner{UserId: "existing-id", Username: "alice", CreatedAt: time.Now().Add(-time.Hour)}
+	users := &fakeUserRepo{}
+
+	as := newService(t, repo, users, &domain.AuthNodeInfo{ID: testNodeID})
+
+	_, err := as.AuthLogin(event.LoginEvent{Username: "alice", Password: "Claude1234$"}, security.PSK{})
+	require.NoError(t, err)
+
+	_, updated := users.snapshot()
+	require.Len(t, updated, 1)
+	// The login refresh must not carry the owner's login name: the user
+	// repo's merge-style Update keeps the profile's (possibly renamed)
+	// username, which a non-empty value here would clobber.
+	assert.Empty(t, updated[0].Username)
+}
+
 func TestAuthLogin_OwnerCreationFailureAborts(t *testing.T) {
 	repo := newFakeAuthRepo()
 	repo.setErr = errors.New("disk full")


### PR DESCRIPTION
The post-login user refresh copied owner.Username (the immutable login name) into the user record, so a profile rename lasted only until the next login. The refresh now leaves the username empty and the user repo's merge-style Update keeps the profile's one.