### PR TITLE
ci(release): freeze warpdroid release for F-Droid review

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,29 +67,32 @@ jobs:
           sed -i "s/^$CURRENT_VERSION\$/$NEW_VERSION/" "$FILE"
           sed -i -E "s/^version:[[:space:]]*'?([0-9]+\.[0-9]+\.[0-9]+)'?/version: ${NEW_VERSION}/" "$SNAPCRAFT"
 
-          # F-Droid versionCode: base = (major*1000000 + minor*10000 + patch) * 10
-          # (single APK, no ABI offset).
-          NEW_BASE=$(( (10#$MAJOR * 1000000 + 10#$MINOR * 10000 + 10#$PATCH) * 10 ))
-
-          # Keep the fastlane changelog named <versionCode>.txt: carry the most
-          # recent note forward to the new name and drop any others.
-          CHANGELOGS="fastlane/metadata/android/en-US/changelogs"
-          if [ -d "$CHANGELOGS" ]; then
-            NEW="$CHANGELOGS/$NEW_BASE.txt"
-            LATEST=$(ls "$CHANGELOGS"/*.txt 2>/dev/null | sort -V | tail -1)
-            if [ -n "$LATEST" ] && [ "$LATEST" != "$NEW" ]; then
-              mv -f "$LATEST" "$NEW"
-              echo "Changelog: $(basename "$LATEST") -> $(basename "$NEW")"
-            fi
-            find "$CHANGELOGS" -maxdepth 1 -name '*.txt' ! -name "$NEW_BASE.txt" -exec rm -f {} +
-          fi
-
-          # Publish the F-Droid versionCode so fdroiddata's UpdateCheckMode: Tags
-          # can read warpdroid/fdroid/versionCode at the tag.
-          FDROID_VERSIONCODE="warpdroid/fdroid/versionCode"
-          if [ -f "$FDROID_VERSIONCODE" ]; then
-            echo "$NEW_BASE" > "$FDROID_VERSIONCODE"
-          fi
+          # CODE FREEZE: warpdroid is under F-Droid inclusion review — keep
+          # warpdroid/fdroid/versionCode and the fastlane changelogs frozen so
+          # checkupdates never sees a new warpdroid version at new tags.
+          # # F-Droid versionCode: base = (major*1000000 + minor*10000 + patch) * 10
+          # # (single APK, no ABI offset).
+          # NEW_BASE=$(( (10#$MAJOR * 1000000 + 10#$MINOR * 10000 + 10#$PATCH) * 10 ))
+          #
+          # # Keep the fastlane changelog named <versionCode>.txt: carry the most
+          # # recent note forward to the new name and drop any others.
+          # CHANGELOGS="fastlane/metadata/android/en-US/changelogs"
+          # if [ -d "$CHANGELOGS" ]; then
+          #   NEW="$CHANGELOGS/$NEW_BASE.txt"
+          #   LATEST=$(ls "$CHANGELOGS"/*.txt 2>/dev/null | sort -V | tail -1)
+          #   if [ -n "$LATEST" ] && [ "$LATEST" != "$NEW" ]; then
+          #     mv -f "$LATEST" "$NEW"
+          #     echo "Changelog: $(basename "$LATEST") -> $(basename "$NEW")"
+          #   fi
+          #   find "$CHANGELOGS" -maxdepth 1 -name '*.txt' ! -name "$NEW_BASE.txt" -exec rm -f {} +
+          # fi
+          #
+          # # Publish the F-Droid versionCode so fdroiddata's UpdateCheckMode: Tags
+          # # can read warpdroid/fdroid/versionCode at the tag.
+          # FDROID_VERSIONCODE="warpdroid/fdroid/versionCode"
+          # if [ -f "$FDROID_VERSIONCODE" ]; then
+          #   echo "$NEW_BASE" > "$FDROID_VERSIONCODE"
+          # fi
 
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
@@ -107,8 +110,10 @@ jobs:
             echo "Tag $TAG already exists."; exit 1
           fi
 
-          git add version snap/snapcraft.yaml warpdroid/fdroid/versionCode
-          git add -A fastlane/metadata/android/en-US/changelogs
+          # CODE FREEZE (F-Droid review): warpdroid versionCode/changelogs are not bumped.
+          # git add version snap/snapcraft.yaml warpdroid/fdroid/versionCode
+          # git add -A fastlane/metadata/android/en-US/changelogs
+          git add version snap/snapcraft.yaml
 
           # [skip ci] keeps the push-to-main workflows from re-running on the bump.
           git commit -m "chore(release): $TAG [skip ci]"
@@ -252,137 +257,139 @@ jobs:
             warpnet_windows_amd64.zip
             warpnet_windows_amd64_checksums.txt
 
-  # APK release runs in parallel with the desktop matrix. Same tag
-  # input — both jobs attach their artifacts to the same GitHub
-  # Release.
-  release-warpdroid:
-    needs: version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.version.outputs.tag }}
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          build-root-directory: warpdroid
-
-      # services.gradle.org redirects to github.com/gradle/gradle-distributions,
-      # which intermittently returns 504. Same workaround as build-warpdroid.yml.
-      - name: Pre-fetch Gradle distribution
-        run: |
-          set -euo pipefail
-          cache_dir="$HOME/.gradle/wrapper/dists/gradle-9.0.0-bin/d6wjpkvcgsg3oed0qlfss3wgl"
-          mkdir -p "$cache_dir"
-          if [ -s "$cache_dir/gradle-9.0.0-bin.zip" ]; then
-            echo "Gradle distribution already cached at $cache_dir."
-            exit 0
-          fi
-          curl --fail --location --show-error \
-            --retry 8 --retry-all-errors --retry-delay 15 \
-            --connect-timeout 30 --max-time 300 \
-            -o "$cache_dir/gradle-9.0.0-bin.zip" \
-            https://services.gradle.org/distributions/gradle-9.0.0-bin.zip
-
-      # The gomobile native library (warpnet.aar) is not committed; build it
-      # from warpdroid/node before Gradle runs.
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      # Pin the exact NDK the F-Droid recipe uses (metadata ndk: r27c ->
-      # 27.2.12479018). libgojni.so is CGO, compiled by the NDK's clang, so the
-      # gomobile build must use the SAME NDK as F-Droid or the reproducible-build
-      # byte-comparison fails. Do NOT use ANDROID_NDK_LATEST_HOME (drifts).
-      - name: Install NDK r27c (match F-Droid recipe)
-        run: |
-          set -euo pipefail
-          SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-          NDK_DIR="$ANDROID_SDK_ROOT/ndk/27.2.12479018"
-          # `yes | sdkmanager` breaks under pipefail (SIGPIPE when sdkmanager
-          # closes stdin). Accept licenses in a guarded step, then install without
-          # a pipe. Licenses are usually pre-accepted on the runner anyway.
-          "$SDKMANAGER" --licenses >/dev/null 2>&1 <<< "$(printf 'y\n%.0s' {1..50})" || true
-          "$SDKMANAGER" "ndk;27.2.12479018"
-          test -d "$NDK_DIR"
-          echo "ANDROID_NDK_HOME=$NDK_DIR" >> "$GITHUB_ENV"
-
-      - name: Build Warpnet native library (gomobile)
-        working-directory: warpdroid/node
-        run: |
-          set -euo pipefail
-          (cd "$GITHUB_WORKSPACE" && go mod download)
-          bash build-native.sh
-
-      - name: Decode release keystore (if configured)
-        id: keystore
-        env:
-          WARPDROID_KEYSTORE_BASE64: ${{ secrets.WARPDROID_KEYSTORE_BASE64 }}
-        run: |
-          set -euo pipefail
-          echo "$WARPDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/warpdroid.keystore"
-          echo "path=$RUNNER_TEMP/warpdroid.keystore" >> "$GITHUB_OUTPUT"
-
-      - name: Assemble release APK
-        working-directory: warpdroid
-        env:
-          WARPDROID_KEYSTORE: ${{ steps.keystore.outputs.path }}
-          WARPDROID_KEYSTORE_PASSWORD: ${{ secrets.WARPDROID_KEYSTORE_PASSWORD }}
-          WARPDROID_KEY_ALIAS: ${{ secrets.WARPDROID_KEY_ALIAS }}
-          WARPDROID_KEY_PASSWORD: ${{ secrets.WARPDROID_KEY_PASSWORD }}
-        run: ./gradlew :app:assembleRelease --stacktrace
-
-      - name: Locate APK + checksum
-        working-directory: warpdroid
-        run: |
-          set -euo pipefail
-          # Single arm64-v8a APK (no ABI split); ship it as the release artifact.
-          src=$(find app/build/outputs/apk/release -name 'Warpdroid_*_release.apk' -type f | head -1)
-          if [ -z "$src" ]; then
-            echo "FATAL: no release APK produced" >&2
-            ls -la app/build/outputs/apk/release/ >&2 || true
-            exit 1
-          fi
-          dst=warpdroid.apk
-          cp "$src" "$dst"
-          shasum -a 256 "$dst" > "warpdroid_checksums.txt"
-
-      - name: Verify APK signature
-        working-directory: warpdroid
-        env:
-          EXPECTED_SHA256: "eabdd61e5bcbd6615a3f54977c06646c0f5422d845d37c818286b7d34285dfec"
-        run: |
-          set -euo pipefail
-          APKSIGNER=$(find "$ANDROID_SDK_ROOT/build-tools" -name apksigner | sort -V | tail -1)
-          "$APKSIGNER" verify --min-sdk-version 24 warpdroid.apk
-          GOT=$("$APKSIGNER" verify --print-certs warpdroid.apk \
-            | grep -m1 'SHA-256 digest' | awk '{print $NF}')
-          if [ "$GOT" != "$EXPECTED_SHA256" ]; then
-            echo "::error::APK signed by wrong key. got=$GOT want=$EXPECTED_SHA256" >&2
-            exit 1
-          fi
-          echo "OK: signed by expected key."
-
-      - name: Publish APK to GitHub Release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: ${{ needs.version.outputs.tag }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: |
-            warpdroid/warpdroid.apk
-            warpdroid/warpdroid_checksums.txt
+  # CODE FREEZE: warpdroid is under F-Droid inclusion review — no warpdroid
+  # releases and no version/tag-visible warpdroid changes until it completes.
+#  # APK release runs in parallel with the desktop matrix. Same tag
+#  # input — both jobs attach their artifacts to the same GitHub
+#  # Release.
+#  release-warpdroid:
+#    needs: version
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          ref: ${{ needs.version.outputs.tag }}
+#          fetch-depth: 0
+#          fetch-tags: true
+#
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: temurin
+#          java-version: 17
+#
+#      - name: Set up Gradle
+#        uses: gradle/actions/setup-gradle@v4
+#        with:
+#          build-root-directory: warpdroid
+#
+#      # services.gradle.org redirects to github.com/gradle/gradle-distributions,
+#      # which intermittently returns 504. Same workaround as build-warpdroid.yml.
+#      - name: Pre-fetch Gradle distribution
+#        run: |
+#          set -euo pipefail
+#          cache_dir="$HOME/.gradle/wrapper/dists/gradle-9.0.0-bin/d6wjpkvcgsg3oed0qlfss3wgl"
+#          mkdir -p "$cache_dir"
+#          if [ -s "$cache_dir/gradle-9.0.0-bin.zip" ]; then
+#            echo "Gradle distribution already cached at $cache_dir."
+#            exit 0
+#          fi
+#          curl --fail --location --show-error \
+#            --retry 8 --retry-all-errors --retry-delay 15 \
+#            --connect-timeout 30 --max-time 300 \
+#            -o "$cache_dir/gradle-9.0.0-bin.zip" \
+#            https://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+#
+#      # The gomobile native library (warpnet.aar) is not committed; build it
+#      # from warpdroid/node before Gradle runs.
+#      - name: Set up Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version-file: go.mod
+#
+#      # Pin the exact NDK the F-Droid recipe uses (metadata ndk: r27c ->
+#      # 27.2.12479018). libgojni.so is CGO, compiled by the NDK's clang, so the
+#      # gomobile build must use the SAME NDK as F-Droid or the reproducible-build
+#      # byte-comparison fails. Do NOT use ANDROID_NDK_LATEST_HOME (drifts).
+#      - name: Install NDK r27c (match F-Droid recipe)
+#        run: |
+#          set -euo pipefail
+#          SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+#          NDK_DIR="$ANDROID_SDK_ROOT/ndk/27.2.12479018"
+#          # `yes | sdkmanager` breaks under pipefail (SIGPIPE when sdkmanager
+#          # closes stdin). Accept licenses in a guarded step, then install without
+#          # a pipe. Licenses are usually pre-accepted on the runner anyway.
+#          "$SDKMANAGER" --licenses >/dev/null 2>&1 <<< "$(printf 'y\n%.0s' {1..50})" || true
+#          "$SDKMANAGER" "ndk;27.2.12479018"
+#          test -d "$NDK_DIR"
+#          echo "ANDROID_NDK_HOME=$NDK_DIR" >> "$GITHUB_ENV"
+#
+#      - name: Build Warpnet native library (gomobile)
+#        working-directory: warpdroid/node
+#        run: |
+#          set -euo pipefail
+#          (cd "$GITHUB_WORKSPACE" && go mod download)
+#          bash build-native.sh
+#
+#      - name: Decode release keystore (if configured)
+#        id: keystore
+#        env:
+#          WARPDROID_KEYSTORE_BASE64: ${{ secrets.WARPDROID_KEYSTORE_BASE64 }}
+#        run: |
+#          set -euo pipefail
+#          echo "$WARPDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/warpdroid.keystore"
+#          echo "path=$RUNNER_TEMP/warpdroid.keystore" >> "$GITHUB_OUTPUT"
+#
+#      - name: Assemble release APK
+#        working-directory: warpdroid
+#        env:
+#          WARPDROID_KEYSTORE: ${{ steps.keystore.outputs.path }}
+#          WARPDROID_KEYSTORE_PASSWORD: ${{ secrets.WARPDROID_KEYSTORE_PASSWORD }}
+#          WARPDROID_KEY_ALIAS: ${{ secrets.WARPDROID_KEY_ALIAS }}
+#          WARPDROID_KEY_PASSWORD: ${{ secrets.WARPDROID_KEY_PASSWORD }}
+#        run: ./gradlew :app:assembleRelease --stacktrace
+#
+#      - name: Locate APK + checksum
+#        working-directory: warpdroid
+#        run: |
+#          set -euo pipefail
+#          # Single arm64-v8a APK (no ABI split); ship it as the release artifact.
+#          src=$(find app/build/outputs/apk/release -name 'Warpdroid_*_release.apk' -type f | head -1)
+#          if [ -z "$src" ]; then
+#            echo "FATAL: no release APK produced" >&2
+#            ls -la app/build/outputs/apk/release/ >&2 || true
+#            exit 1
+#          fi
+#          dst=warpdroid.apk
+#          cp "$src" "$dst"
+#          shasum -a 256 "$dst" > "warpdroid_checksums.txt"
+#
+#      - name: Verify APK signature
+#        working-directory: warpdroid
+#        env:
+#          EXPECTED_SHA256: "eabdd61e5bcbd6615a3f54977c06646c0f5422d845d37c818286b7d34285dfec"
+#        run: |
+#          set -euo pipefail
+#          APKSIGNER=$(find "$ANDROID_SDK_ROOT/build-tools" -name apksigner | sort -V | tail -1)
+#          "$APKSIGNER" verify --min-sdk-version 24 warpdroid.apk
+#          GOT=$("$APKSIGNER" verify --print-certs warpdroid.apk \
+#            | grep -m1 'SHA-256 digest' | awk '{print $NF}')
+#          if [ "$GOT" != "$EXPECTED_SHA256" ]; then
+#            echo "::error::APK signed by wrong key. got=$GOT want=$EXPECTED_SHA256" >&2
+#            exit 1
+#          fi
+#          echo "OK: signed by expected key."
+#
+#      - name: Publish APK to GitHub Release
+#        uses: softprops/action-gh-release@v2
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          tag_name: ${{ needs.version.outputs.tag }}
+#          name: ${{ needs.version.outputs.tag }}
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          files: |
+#            warpdroid/warpdroid.apk
+#            warpdroid/warpdroid_checksums.txt


### PR DESCRIPTION
warpdroid is under F-Droid inclusion review — comment out the release-warpdroid job and the warpdroid/fdroid/versionCode + fastlane changelog bump so no release run can publish an APK or surface a new version to checkupdates. Marked with CODE FREEZE; uncomment to lift.