### PR TITLE
Cap container memory for the 2 GiB droplet, disable moderators

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -31,6 +31,16 @@ fi
 [ -L /etc/resolv.conf ] || printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' > /etc/resolv.conf
 # ────────────────────────────────────────────────────────────────────────────
 
+SWAPFILE=/swapfile
+if ! swapon --show=NAME --noheadings 2>/dev/null | grep -qx "$SWAPFILE"; then
+  [ -f "$SWAPFILE" ] || fallocate -l 4G "$SWAPFILE" || dd if=/dev/zero of="$SWAPFILE" bs=1M count=4096 || true
+  chmod 600 "$SWAPFILE" 2>/dev/null || true
+  swapon "$SWAPFILE" 2>/dev/null \
+    || { mkswap "$SWAPFILE" >/dev/null 2>&1 && swapon "$SWAPFILE"; } \
+    || echo "WARNING: swap unavailable, 2 GiB RAM only"
+  grep -qs "^$SWAPFILE " /etc/fstab || echo "$SWAPFILE none swap sw 0 0" >> /etc/fstab
+fi
+
 echo "Run deploy script"
 
 if [ -z "$GITHUB_TOKEN" ]; then

--- a/deploy/docker-compose-testnet.yml
+++ b/deploy/docker-compose-testnet.yml
@@ -3,7 +3,10 @@ services:
     container_name: warpnet-testnet-1
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 192m
+    mem_reservation: 96m
+    oom_score_adj: 200
     environment:
       - NODE_PORT=4011
       - NODE_HOST_V4=207.154.221.44
@@ -12,12 +15,16 @@ services:
       - LOGGING_FORMAT=json
       - NODE_SEED=warpnet1
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
+      - GOMEMLIMIT=144MiB
 
   warpnet22:
     container_name: warpnet-testnet-2
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 192m
+    mem_reservation: 96m
+    oom_score_adj: 200
     environment:
       - NODE_PORT=4022
       - NODE_HOST_V4=207.154.221.44
@@ -26,12 +33,16 @@ services:
       - LOGGING_FORMAT=json
       - NODE_SEED=warpnet2
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
+      - GOMEMLIMIT=144MiB
 
   warpnet33:
     container_name: warpnet-testnet-3
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 192m
+    mem_reservation: 96m
+    oom_score_adj: 200
     environment:
       - NODE_PORT=4033
       - NODE_HOST_V4=207.154.221.44
@@ -40,64 +51,80 @@ services:
       - LOGGING_FORMAT=json
       - NODE_SEED=warpnet3
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
+      - GOMEMLIMIT=144MiB
 
-  warpnet-moderator-testnet:
-    container_name: moderator-testnet
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4044
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=testnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-testnet
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      # The model path is hardcoded relative to the container CWD (/warpnet).
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
+#  warpnet-moderator-testnet:
+#    container_name: moderator-testnet
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 96m
+#    oom_score_adj: 500
+#    environment:
+#      - NODE_PORT=4044
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=testnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-testnet
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      # The model path is hardcoded relative to the container CWD (/warpnet).
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
 
-  warpnet-moderator-2-testnet:
-    container_name: moderator-2-testnet
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4045
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=testnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-2-testnet
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
+#  warpnet-moderator-2-testnet:
+#    container_name: moderator-2-testnet
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 96m
+#    oom_score_adj: 500
+#    environment:
+#      - NODE_PORT=4045
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=testnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-2-testnet
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
 
-  warpnet-moderator-3-testnet:
-    container_name: moderator-3-testnet
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4046
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=testnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-3-testnet
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
+#  warpnet-moderator-3-testnet:
+#    container_name: moderator-3-testnet
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 96m
+#    oom_score_adj: 500
+#    environment:
+#      - NODE_PORT=4046
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=testnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-3-testnet
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
 
   vadim-testnet:
     container_name: vadim-testnet
     image: ghcr.io/warp-net/warpnet-vadim:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 512m
+    mem_reservation: 128m
+    oom_score_adj: 500
     environment:
       - NODE_PORT=4055
       - NODE_HOST_V4=207.154.221.44
@@ -107,6 +134,7 @@ services:
       - NODE_SERVER_PORT=4999
       - NODE_SERVER_PASSWORD=${NODE_SERVER_PASSWORD}
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
+      - GOMEMLIMIT=384MiB
     volumes:
       - /root/.warpdata-vadim:/root/.warpdata:rw
 
@@ -116,13 +144,19 @@ services:
     network_mode: host
     command:
       - "--web.listen-address=:4091"
-    restart: always
+    restart: unless-stopped
+    mem_limit: 64m
+    mem_reservation: 24m
+    oom_score_adj: 800
 
   echo:
     container_name: echo-testnet
     image: ghcr.io/warp-net/warpnet-echo:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 384m
+    mem_reservation: 96m
+    oom_score_adj: 700
     environment:
       - NODE_PORT=4066
       - NODE_HOST_V4=207.154.221.44
@@ -130,7 +164,6 @@ services:
       - LOGGING_LEVEL=info
       - LOGGING_FORMAT=json
       - NODE_SEED=echo-testnet
+      - GOMEMLIMIT=288MiB
     volumes:
       - ${HOME}/warpnet-data/testnet/echo:/root/.warpdata/testnet/storage
-
-

--- a/deploy/docker-compose-warpnet.yml
+++ b/deploy/docker-compose-warpnet.yml
@@ -3,7 +3,10 @@ services:
     container_name: warpnet-mainnet-1
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    oom_score_adj: -500
     environment:
 #      - GOLOG_LOG_LEVEL=tcp-tpt=debug,swarm=debug,swarm2=debug,net=debug,connmgr=debug
       - NODE_PORT=4001
@@ -14,12 +17,16 @@ services:
       - LOGGING_LEVEL=info
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
       - SOCKS5_ENABLED=false
+      - GOMEMLIMIT=192MiB
 
   warpnet2:
     container_name: warpnet-mainnet-2
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    oom_score_adj: -500
     environment:
 #      - GOLOG_LOG_LEVEL=tcp-tpt=debug,swarm=debug,swarm2=debug,net=debug,connmgr=debug
       - NODE_PORT=4002
@@ -30,12 +37,16 @@ services:
       - LOGGING_LEVEL=info
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
       - SOCKS5_ENABLED=false
+      - GOMEMLIMIT=192MiB
 
   warpnet3:
     container_name: warpnet-mainnet-3
     image: ghcr.io/warp-net/warpnet-relay:latest
     network_mode: host
-    restart: always
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    oom_score_adj: -500
     environment:
       - NODE_PORT=4003
 #      - GOLOG_LOG_LEVEL=tcp-tpt=debug,swarm=debug,swarm2=debug,net=debug,connmgr=debug
@@ -46,56 +57,68 @@ services:
       - LOGGING_LEVEL=info
       - NODE_METRICS_GATEWAY=207.154.221.44:4091
       - SOCKS5_ENABLED=false
+      - GOMEMLIMIT=192MiB
 
-  warpnet-moderator-1:
-    container_name: moderator
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4004
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=warpnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-1
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      # The model path is hardcoded relative to the container CWD (/warpnet).
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
+#  warpnet-moderator-1:
+#    container_name: moderator
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 160m
+#    oom_score_adj: -200
+#    environment:
+#      - NODE_PORT=4004
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=warpnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-1
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      # The model path is hardcoded relative to the container CWD (/warpnet).
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
 
-  warpnet-moderator-2:
-    container_name: moderator-2
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4005
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=warpnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-2
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
+#  warpnet-moderator-2:
+#    container_name: moderator-2
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 160m
+#    oom_score_adj: -200
+#    environment:
+#      - NODE_PORT=4005
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=warpnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-2
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
 
-  warpnet-moderator-3:
-    container_name: moderator-3
-    image: ghcr.io/warp-net/warpnet-moderator:latest
-    network_mode: host
-    restart: always
-    environment:
-      - NODE_PORT=4006
-      - NODE_HOST_V4=207.154.221.44
-      - NODE_NETWORK=warpnet
-      - LOGGING_LEVEL=info
-      - LOGGING_FORMAT=json
-      - NODE_SEED=warpnet-moderator-3
-      - NODE_METRICS_GATEWAY=207.154.221.44:4091
-    volumes:
-      - /root/.warpdata:/root/.warpdata:rw
-      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro
-
+#  warpnet-moderator-3:
+#    container_name: moderator-3
+#    image: ghcr.io/warp-net/warpnet-moderator:latest
+#    network_mode: host
+#    restart: unless-stopped
+#    mem_limit: 1700m
+#    mem_reservation: 160m
+#    oom_score_adj: -200
+#    environment:
+#      - NODE_PORT=4006
+#      - NODE_HOST_V4=207.154.221.44
+#      - NODE_NETWORK=warpnet
+#      - LOGGING_LEVEL=info
+#      - LOGGING_FORMAT=json
+#      - NODE_SEED=warpnet-moderator-3
+#      - NODE_METRICS_GATEWAY=207.154.221.44:4091
+#      - GOMEMLIMIT=512MiB
+#    volumes:
+#      - /root/.warpdata:/root/.warpdata:rw
+#      - /root/.warpdata/Llama-Guard-3-1B-Q4_K_M.gguf:/warpnet/Llama-Guard-3-1B-Q4_K_M.gguf:ro


### PR DESCRIPTION
The droplet hosts both compose stacks at once on 2 GiB of RAM. Give every container a mem_limit/mem_reservation sized to its role, switch the restart policy to unless-stopped, and add an idempotent 4 GiB swapfile to deploy.sh. mainnet outranks testnet via mem_reservation and oom_score_adj, which also keeps sshd off the OOM killer's shortlist.

Moderators are commented out for now: each needs ~1.45 GB RSS (955 MB of Llama-Guard weights) and quorumTarget is 3, so three of them cannot fit under any quota. Their blocks keep the tuned limits for when they return.

GOMEMLIMIT is set per service because Go cannot see the cgroup limit and grows its heap until the kernel intervenes; Dockerfile.moderator bakes in 2750MiB, more than the whole droplet has. mem_swappiness is deliberately absent - cgroup v2 discards it and only logs a warning per container.