### PR TITLE
Fix grimdark leftovers: QR magenta, poll contrast, chip shape, Mastod…

### DIFF
--- a/frontend/src/assets/tailwind.css
+++ b/frontend/src/assets/tailwind.css
@@ -424,9 +424,13 @@ i.fa-retweet.text-green-500 {
 /* bg-blue is both the brand button fill and Root's full-height hero panel.
    Blood red works on a button and overwhelms a panel, so surfaces get leather
    in the light theme (iron in the dark one, below) and buttons keep the blood. */
+/* Spelled out as channels rather than theme("colors.dark") so the
+   --tw-bg-opacity channel survives: a flat hex here silently drops
+   bg-opacity-*, which turned the poll's 25% tint into a solid leather bar
+   with its percentage label the exact same color. */
 .bg-blue,
 .bg-darkblue {
-  background-color: theme("colors.dark");
+  background-color: rgb(92 74 48 / var(--tw-bg-opacity, 1));
 }
 button.bg-blue,
 button.bg-darkblue {
@@ -453,7 +457,7 @@ button.bg-darkblue {
    dark iron; buttons paint their gradient over it (rule further down). */
 .dark .bg-blue,
 .dark .bg-darkblue {
-  background-color: theme("colors.darktheme.foreground") !important;
+  background-color: rgb(43 34 25 / var(--tw-bg-opacity, 1)) !important;
 }
 .dark button.bg-blue,
 .dark button.bg-darkblue {

--- a/frontend/src/components/PollWidget.vue
+++ b/frontend/src/components/PollWidget.vue
@@ -11,7 +11,7 @@
       >
         {{ option }}
       </button>
-      <div v-else class="relative rounded border border-lighter overflow-hidden">
+      <div v-else class="relative rounded border border-[color:var(--gd-trim)] overflow-hidden">
         <!-- A translucent brand tint, not a solid light fill: the themed
              surface shows through, so the label keeps its contrast in the
              dark theme as well as the light one. -->

--- a/frontend/src/components/TweetBlock.vue
+++ b/frontend/src/components/TweetBlock.vue
@@ -232,7 +232,7 @@ resulting from the use or misuse of this software.
           type="button"
           class="flex items-center gap-1 rounded-full border px-2 py-0.5 text-sm transition-colors flat-btn"
           :class="chip.emoji === myReaction
-            ? 'border-blue bg-lightblue text-blue font-semibold'
+            ? 'border-dark bg-lightblue text-blue font-semibold'
             : 'border-lighter hover:bg-lightblue'"
           :aria-pressed="chip.emoji === myReaction"
           :aria-label="`${chip.count} reacted with ${chip.emoji}`"

--- a/frontend/src/components/WhoToFollow.vue
+++ b/frontend/src/components/WhoToFollow.vue
@@ -27,7 +27,7 @@ resulting from the use or misuse of this software.
       <div class="p-3 flex items-center">
         <p class="text-lg font-bold">Who to follow</p>
         <img v-if="section.key === 'warpnet'" src="@/assets/logo-transparent.png" alt="Warpnet" class="w-5 h-5 ml-2 object-contain" />
-        <i v-else class="fab fa-mastodon text-lg ml-2 text-[#6364FF]" role="img" aria-label="Mastodon"></i>
+        <i v-else class="fab fa-mastodon text-lg ml-2 text-[color:var(--gd-trim)]" role="img" aria-label="Mastodon"></i>
       </div>
       <!-- No v-if here: on one element Vue 3 evaluates v-if BEFORE v-for, so
            "profile" resolved to the component prop, not the loop item — the

--- a/frontend/src/lib/qr.js
+++ b/frontend/src/lib/qr.js
@@ -35,9 +35,12 @@ const qrOptions = {
     // upscaling blur. 768px gives a clean 2x for the displayed w-96 box.
     width: 768,
     margin: 2,
+    // Sepia ink on parchment: the magenta this used to draw is the pre-grimdark
+    // brand color, and a saturated mid-tone is the worst case for a camera
+    // binarising the modules. 12:1 keeps it scannable and on-palette.
     color: {
-        dark: "#c5007f",
-        light: "#ffffff",
+        dark: "#2a2118",
+        light: "#efe7d3",
     },
 };
 

--- a/frontend/src/views/WhoToFollow.vue
+++ b/frontend/src/views/WhoToFollow.vue
@@ -49,7 +49,7 @@ resulting from the use or misuse of this software.
         </div>
         <div v-if="mastodonProfiles.length > 0">
           <h2 class="px-5 pt-3 text-left text-lg font-bold">
-            <i class="fab fa-mastodon text-[#6364FF]" role="img" aria-label="Mastodon"></i>
+            <i class="fab fa-mastodon text-[color:var(--gd-trim)]" role="img" aria-label="Mastodon"></i>
           </h2>
           <Users :users="mastodonProfiles" :loading="loading" />
         </div>


### PR DESCRIPTION
…on icon

Four off-palette or unreadable spots the theme swap left behind.

The pairing QR drew its modules in #c5007f, the pre-grimdark brand magenta. A saturated mid-tone is also the worst case for a camera binarising modules, so it is now sepia ink on parchment at 12:1.

Poll option rows outlined themselves with border-lighter, which is 1.16:1 on bg-lightest and 1.71:1 on the dark card - no visible boundary in either theme. They now use the metal trim the checkboxes already use: 3.86:1 and 5.31:1.

The voted row's percentage was invisible rather than merely faint: the non-button .bg-blue override set a flat background-color, which drops the --tw-bg-opacity channel, so bg-opacity-25 was ignored and the "translucent brand tint" painted a solid leather bar in exactly the text-dark the label is drawn in. Spelling the override out as rgb() channels restores the tint and takes the label from 1:1 to 4.7:1.

A reaction chip the viewer holds carried border-blue, which the theme's chamfer rule targets, so one's own reaction rendered as a rectangle while everyone else's stayed a pill. It highlights with border-dark instead, leaving the chamfer to the buttons it was written for.

The Mastodon icon kept Mastodon's #6364FF indigo, the only cold color left in the app; it follows the logo's precedent and takes the theme's metal.