### PR TITLE
Show reactions before the node has answered

### DIFF
--- a/frontend/src/components/TweetBlock.vue
+++ b/frontend/src/components/TweetBlock.vue
@@ -895,37 +895,68 @@ export default {
       this.showReactionBar = false;
 
       const removing = this.myReaction === emoji;
-      let resp;
+      // Painted up front: on a bridged tweet this call waits on the gateway
+      // handing the reaction to the author's instance, and a button that does
+      // nothing for those seconds reads as broken.
+      const previous = {
+        emoji: this.myReaction,
+        reactions: this.reactions,
+        count: this.reactionsCount.get(this.tweet.id),
+      };
+      this.paintOwnReaction(removing ? "" : emoji);
+
       try {
         if (removing) {
-          resp = await warpnetService.unreactTweet(this.tweet.id, this.tweet.user_id)
+          await warpnetService.unreactTweet(this.tweet.id, this.tweet.user_id)
         } else {
-          resp = await warpnetService.reactToTweet(this.tweet.id, this.tweet.user_id, emoji)
+          await warpnetService.reactToTweet(this.tweet.id, this.tweet.user_id, emoji)
         }
       } catch (err) {
         console.error(`failed to react to tweet [${this.tweet.id}]`, err);
         toast.error(err?.message || "Couldn't update reaction. Please try again.");
+        this.myReaction = previous.emoji;
+        this.reactions = previous.reactions;
+        this.reactionsCount.set(this.tweet.id, previous.count);
         await this.loadTweetStats(this.tweet.id, this.tweet.user_id);
         return;
       }
       if (removing) {
         await warpnetService.deleteReactor(this.tweet.id, owner.user_id)
-        this.myReaction = "";
       } else {
         await warpnetService.setReactor(this.tweet.id, owner.user_id, owner, emoji)
-        this.myReaction = emoji;
       }
 
-      this.reactions = resp.reactions;
-      this.reactionsCount.set(this.tweet.id, resp.count);
-      // A bridged tweet's real reaction count lives on the remote instance, not
-      // in this node's CRDT counter (which only knows our own), so refresh
-      // from the author's node the way retweet() does.
+      // The response carries this node's own tally, which on a bridged tweet
+      // counts only our reaction; the real breakdown comes from the author's
+      // node, the way retweet() refreshes.
       try {
         await this.loadTweetStats(this.tweet.id, this.tweet.user_id);
       } catch (err) {
         console.error(`failed to refresh tweet stats [${this.tweet.id}]`, err);
       }
+    },
+    // paintOwnReaction moves the viewer's own reaction to `emoji` ("" takes it
+    // back) in the tally on screen, so the chips and the counter follow the
+    // click instead of waiting for the network.
+    paintOwnReaction(emoji) {
+      const reactions = {...this.reactions};
+      let count = this.reactionsCount.get(this.tweet.id) || 0;
+      if (this.myReaction) {
+        const left = (reactions[this.myReaction] || 1) - 1;
+        if (left > 0) {
+          reactions[this.myReaction] = left;
+        } else {
+          delete reactions[this.myReaction];
+        }
+        count = Math.max(0, count - 1);
+      }
+      if (emoji) {
+        reactions[emoji] = (reactions[emoji] || 0) + 1;
+        count += 1;
+      }
+      this.myReaction = emoji;
+      this.reactions = reactions;
+      this.reactionsCount.set(this.tweet.id, count);
     },
     getReactionsCount(tweetId) {
       return this.reactionsCount.get(tweetId);
@@ -955,8 +986,6 @@ export default {
         return;
       }
 
-      this.reactionsCount.set(stats.tweet_id, stats.reactions_count);
-      this.reactions = stats.reactions || {};
       // my_reaction is answered from our own node, so it outranks the
       // local cache — it survives a browser reset and other devices. An
       // absent key means an older node that knows nothing of reactions;
@@ -965,6 +994,17 @@ export default {
         this._reactionAnswered = true;
         this.myReaction = stats.my_reaction || "";
       }
+      // A bridged tweet's breakdown comes from the author's instance, which
+      // hears of our reaction only once the gateway has delivered it. Keep
+      // showing it until then instead of letting the answer take it away.
+      const reactions = {...(stats.reactions || {})};
+      let reactionsCount = stats.reactions_count || 0;
+      if (this.myReaction && !reactions[this.myReaction]) {
+        reactions[this.myReaction] = 1;
+        reactionsCount += 1;
+      }
+      this.reactions = reactions;
+      this.reactionsCount.set(stats.tweet_id, reactionsCount);
       this.retweetsCount.set(stats.tweet_id, stats.retweets_count);
       this.repliesCount.set(stats.tweet_id, stats.replies_count);
       // Views are monotonically non-decreasing: a stale read raced with

--- a/frontend/tests/components/TweetBlockReactions.spec.js
+++ b/frontend/tests/components/TweetBlockReactions.spec.js
@@ -88,6 +88,13 @@ const renderTweet = () =>
 const chipFor = (emoji) =>
   [...document.querySelectorAll('button[aria-pressed]')].find((b) => b.textContent.includes(emoji));
 
+// The counter beside the react button; the retweet counter is the only other
+// button with this exact class, and it is absent whenever retweets_count is 0.
+const totalCounter = () =>
+  document.querySelector('button[class="hover:underline flat-btn"]');
+
+const chipText = (emoji) => chipFor(emoji).textContent.replace(/\s/g, '');
+
 describe('TweetBlock reactions', () => {
   it('renders one chip per emoji and marks the viewer’s own reaction', async () => {
     renderTweet();
@@ -135,14 +142,19 @@ describe('TweetBlock reactions', () => {
   });
 
   it('reacts with a heart when the button is clicked with no reaction held', async () => {
-    warpnetService.getTweetStats.mockResolvedValue({
+    const stats = {
       tweet_id: 't1',
       retweets_count: 0,
       reactions_count: 0,
       replies_count: 0,
       views_count: 0,
       my_reaction: '',
-    });
+    };
+    // The reaction is stored on our own node before it is federated, so the
+    // refresh that follows the click already reports it back as ours.
+    warpnetService.getTweetStats
+      .mockResolvedValueOnce(stats)
+      .mockResolvedValue({...stats, reactions_count: 1, reactions: {'❤️': 1}, my_reaction: '❤️'});
     warpnetService.reactToTweet.mockResolvedValue({count: 1, reactions: {'❤️': 1}});
     renderTweet();
 
@@ -155,5 +167,66 @@ describe('TweetBlock reactions', () => {
 
     await waitFor(() => expect(warpnetService.reactToTweet).toHaveBeenCalledWith('t1', 'author1', '❤️'));
     await waitFor(() => expect(chipFor('❤️')).toBeTruthy());
+  });
+
+  it('shows the reaction before the node has answered', async () => {
+    // A bridged tweet's react call waits on the gateway; nothing resolves here.
+    warpnetService.reactToTweet.mockReturnValue(new Promise(() => {}));
+    renderTweet();
+
+    await waitFor(() => expect(chipFor('❤️')).toBeTruthy());
+    await fireEvent.click(chipFor('❤️'));
+
+    expect(chipFor('❤️').getAttribute('aria-pressed')).toBe('true');
+    expect(chipText('❤️')).toBe('❤️2');
+    expect(chipText('🔥')).toBe('🔥1');
+    expect(chipFor('🔥').getAttribute('aria-pressed')).toBe('false');
+    // Moving the reaction leaves the total where it was.
+    expect(totalCounter().textContent.trim()).toBe('3');
+  });
+
+  it('drops the reaction from the tally up front when taking it back', async () => {
+    warpnetService.unreactTweet.mockReturnValue(new Promise(() => {}));
+    renderTweet();
+
+    await waitFor(() => expect(chipFor('🔥')).toBeTruthy());
+    await fireEvent.click(chipFor('🔥'));
+
+    expect(chipText('🔥')).toBe('🔥1');
+    expect(chipFor('🔥').getAttribute('aria-pressed')).toBe('false');
+    expect(totalCounter().textContent.trim()).toBe('2');
+  });
+
+  it('puts the reaction back when the node refuses it', async () => {
+    warpnetService.reactToTweet.mockRejectedValue(new Error('node is offline'));
+    renderTweet();
+
+    await waitFor(() => expect(chipFor('❤️')).toBeTruthy());
+    await fireEvent.click(chipFor('❤️'));
+
+    await waitFor(() => expect(chipFor('🔥').getAttribute('aria-pressed')).toBe('true'));
+    expect(chipText('🔥')).toBe('🔥2');
+    expect(chipText('❤️')).toBe('❤️1');
+    expect(totalCounter().textContent.trim()).toBe('3');
+  });
+
+  it('keeps the viewer’s reaction while the author’s instance is unaware of it', async () => {
+    // Our own node reports the reaction as ours, but the bridged breakdown
+    // comes from the remote instance, which the gateway hasn't reached yet.
+    warpnetService.getTweetStats.mockResolvedValue({
+      tweet_id: 't1',
+      retweets_count: 0,
+      reactions_count: 5,
+      replies_count: 0,
+      views_count: 0,
+      reactions: {'🔥': 5},
+      my_reaction: '❤️',
+    });
+    renderTweet();
+
+    await waitFor(() => expect(chipFor('❤️')).toBeTruthy());
+    expect(chipText('❤️')).toBe('❤️1');
+    expect(chipFor('❤️').getAttribute('aria-pressed')).toBe('true');
+    expect(totalCounter().textContent.trim()).toBe('6');
   });
 });


### PR DESCRIPTION
A reaction on a bridged tweet waits on the gateway handing it to the author's instance, so the chip and the counters only moved seconds after the click. Paint the viewer's own reaction right away and put it back if the node refuses it.

A bridged tweet's breakdown comes from the remote instance, which hears of the reaction only once the gateway has delivered it, so keep our own reaction in the tally until it shows up there instead of letting the answer take it away again.