### PR TITLE
Support deploying a pinned version to mainnet nodes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to build (e.g., v0.7.475). Empty = build selected ref as latest"
+        required: false
+        type: string
 
 jobs:
   build-relay:
@@ -15,6 +22,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve image tag
+        id: meta
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "image_tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "image_tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,7 +52,7 @@ jobs:
           context: .
           file: Dockerfile.relay
           push: true
-          tags: ghcr.io/warp-net/warpnet-relay:latest
+          tags: ghcr.io/warp-net/warpnet-relay:${{ steps.meta.outputs.image_tag }}
           cache-from: type=gha,scope=relay
           cache-to: type=gha,mode=max,scope=relay
 

--- a/.github/workflows/deploy-mainnet.yaml
+++ b/.github/workflows/deploy-mainnet.yaml
@@ -2,6 +2,12 @@ name: Deploy Mainnet Nodes
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Relay image tag to deploy (e.g., v0.7.475). Build Mainnet must have pushed this tag to ghcr first"
+        required: false
+        default: "latest"
+        type: string
 
 jobs:
   deploy:
@@ -29,5 +35,5 @@ jobs:
         run: |
           scp ./deploy/deploy.sh root@207.154.221.44:/root
           scp ./deploy/docker-compose-warpnet.yml root@207.154.221.44:/root/docker-compose-mainnet.yml
-          ssh root@207.154.221.44 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} MAINNET=true bash /root/deploy.sh'
+          ssh root@207.154.221.44 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} MAINNET=true WARPNET_VERSION=${{ inputs.version || 'latest' }} bash /root/deploy.sh'
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -48,8 +48,11 @@ if [ -z "$GITHUB_TOKEN" ]; then
   exit 1
 fi
 
+export WARPNET_VERSION="${WARPNET_VERSION:-latest}"
+echo "Deploying warpnet-relay:$WARPNET_VERSION"
+
 echo $GITHUB_TOKEN | docker login ghcr.io -u filinvadim --password-stdin
-docker pull ghcr.io/warp-net/warpnet-relay:latest
+docker pull ghcr.io/warp-net/warpnet-relay:"$WARPNET_VERSION"
 docker pull ghcr.io/warp-net/warpnet-moderator:latest
 docker pull ghcr.io/warp-net/warpnet-echo:latest
 docker pull ghcr.io/warp-net/warpnet-vadim:latest

--- a/deploy/docker-compose-warpnet.yml
+++ b/deploy/docker-compose-warpnet.yml
@@ -1,7 +1,7 @@
 services:
   warpnet1:
     container_name: warpnet-mainnet-1
-    image: ghcr.io/warp-net/warpnet-relay:latest
+    image: ghcr.io/warp-net/warpnet-relay:${WARPNET_VERSION:-latest}
     network_mode: host
     restart: unless-stopped
     mem_limit: 256m
@@ -21,7 +21,7 @@ services:
 
   warpnet2:
     container_name: warpnet-mainnet-2
-    image: ghcr.io/warp-net/warpnet-relay:latest
+    image: ghcr.io/warp-net/warpnet-relay:${WARPNET_VERSION:-latest}
     network_mode: host
     restart: unless-stopped
     mem_limit: 256m
@@ -41,7 +41,7 @@ services:
 
   warpnet3:
     container_name: warpnet-mainnet-3
-    image: ghcr.io/warp-net/warpnet-relay:latest
+    image: ghcr.io/warp-net/warpnet-relay:${WARPNET_VERSION:-latest}
     network_mode: host
     restart: unless-stopped
     mem_limit: 256m


### PR DESCRIPTION
Build Mainnet can now build an existing git tag (dispatch input or tag push) and publishes the relay image as warpnet-relay:<tag> instead of overwriting :latest. Deploy Mainnet Nodes takes a 'version' input (default latest) that is passed through deploy.sh into the compose file via WARPNET_VERSION, so a specific release like v0.7.475 can be deployed even when it is not the latest image.


