### PR TITLE
Derive identity and database keys through Argon2id

### DIFF
--- a/database/auth-repo.go
+++ b/database/auth-repo.go
@@ -32,8 +32,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"math/big"
-	"strings"
 	"sync"
 	"time"
 
@@ -47,6 +45,8 @@ const (
 	AuthRepoName    = "/AUTH"
 	PassSubName     = "PASS" // TODO pass restore functionality
 	DefaultOwnerKey = "OWNER"
+
+	sessionTokenSize = 32
 )
 
 var ErrNilAuthRepo = local_store.DBError("auth repo is nil")
@@ -104,22 +104,16 @@ func (repo *AuthRepo) Authenticate(username, password string) (err error) {
 }
 
 func (repo *AuthRepo) generateSecrets(username, password string) (token string, pk ed25519.PrivateKey, err error) {
-	n, err := rand.Int(rand.Reader, big.NewInt(127))
-	if err != nil {
-		return "", nil, err
+	tokenSeed := make([]byte, sessionTokenSize)
+	if _, err := rand.Read(tokenSeed); err != nil {
+		return "", nil, fmt.Errorf("generate session token: %w", err)
 	}
-	randChar := string(uint8(n.Uint64())) //#nosec
-	tokenSeed := []byte(username + "@" + password + "@" + repo.network + "@" + randChar + "@" + time.Now().String())
-	token = base64.StdEncoding.EncodeToString(security.ConvertToSHA256(tokenSeed))
+	token = base64.StdEncoding.EncodeToString(tokenSeed)
 
-	pkSeed := base64.StdEncoding.EncodeToString(
-		security.ConvertToSHA256(
-			[]byte(username + "@" + password + "@" + repo.network + strings.Repeat("@", len(password))), // no random - private key must be determined
-		),
-	)
-	privateKey, err := security.GenerateKeyFromSeed([]byte(pkSeed))
+	// no random - private key must be determined
+	privateKey, err := security.DeriveIdentityKey(username, password, repo.network)
 	if err != nil {
-		return "", nil, fmt.Errorf("generate private key from seed: %w", err)
+		return "", nil, fmt.Errorf("derive identity key: %w", err)
 	}
 
 	return token, privateKey, nil

--- a/database/local-store/db.go
+++ b/database/local-store/db.go
@@ -251,8 +251,11 @@ func (db *DB) Run(username, password string) (err error) {
 	if db.isRunning.Load() {
 		return nil
 	}
-	hashSum := security.ConvertToSHA256([]byte(username + "@" + password))
-	execOpts := db.badgerOpts.WithEncryptionKey(hashSum)
+	encryptionKey, err := security.DeriveDatabaseKey(username, password)
+	if err != nil {
+		return err
+	}
+	execOpts := db.badgerOpts.WithEncryptionKey(encryptionKey)
 
 	db.badger, err = badger.Open(execOpts)
 	if errors.Is(err, badger.ErrEncryptionKeyMismatch) {

--- a/security/kdf.go
+++ b/security/kdf.go
@@ -1,0 +1,59 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package security
+
+import (
+	"crypto/ed25519"
+	"strings"
+)
+
+const (
+	identityKeyContext = "warpnet/kdf/v1/identity-key"
+	databaseKeyContext = "warpnet/kdf/v1/database-key"
+)
+
+func DeriveIdentityKey(username, password, network string) (ed25519.PrivateKey, error) {
+	if password == "" {
+		return nil, ErrEmptyPassword
+	}
+	seed := deriveKey([]byte(password), derivationSalt(identityKeyContext, network, username))
+	defer Wipe(seed)
+
+	return GenerateKeyFromSeed(seed)
+}
+
+func DeriveDatabaseKey(username, password string) ([]byte, error) {
+	if password == "" {
+		return nil, ErrEmptyPassword
+	}
+	return deriveKey([]byte(password), derivationSalt(databaseKeyContext, username)), nil
+}
+
+func derivationSalt(parts ...string) []byte {
+	return ConvertToSHA256([]byte(strings.Join(parts, "\x00")))
+}

--- a/security/kdf_test.go
+++ b/security/kdf_test.go
@@ -1,0 +1,118 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package security
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testUser     = "alice"
+	testPassword = "CorrectHorse1!"
+	testNetwork  = "testnet"
+)
+
+func TestDeriveIdentityKey_IsDeterministic(t *testing.T) {
+	first, err := DeriveIdentityKey(testUser, testPassword, testNetwork)
+	require.NoError(t, err)
+	second, err := DeriveIdentityKey(testUser, testPassword, testNetwork)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second, "the same credentials must rebuild the same peer ID")
+	assert.Len(t, first, ed25519.PrivateKeySize)
+}
+
+func TestDeriveIdentityKey_SeparatesAccountsAndNetworks(t *testing.T) {
+	base, err := DeriveIdentityKey(testUser, testPassword, testNetwork)
+	require.NoError(t, err)
+
+	otherUser, err := DeriveIdentityKey("bob", testPassword, testNetwork)
+	require.NoError(t, err)
+	assert.NotEqual(t, base, otherUser)
+
+	otherNetwork, err := DeriveIdentityKey(testUser, testPassword, "mainnet")
+	require.NoError(t, err)
+	assert.NotEqual(t, base, otherNetwork)
+
+	otherPassword, err := DeriveIdentityKey(testUser, testPassword+"x", testNetwork)
+	require.NoError(t, err)
+	assert.NotEqual(t, base, otherPassword)
+}
+
+func TestDeriveDatabaseKey_IsDeterministicAndSized(t *testing.T) {
+	first, err := DeriveDatabaseKey(testUser, testPassword)
+	require.NoError(t, err)
+	second, err := DeriveDatabaseKey(testUser, testPassword)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Len(t, first, keySize, "badger needs a 32-byte AES key")
+
+	otherUser, err := DeriveDatabaseKey("bob", testPassword)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, otherUser)
+}
+
+func TestDerivedRootSecretsAreDomainSeparated(t *testing.T) {
+	identity, err := DeriveIdentityKey(testUser, testPassword, testNetwork)
+	require.NoError(t, err)
+	dbKey, err := DeriveDatabaseKey(testUser, testPassword)
+	require.NoError(t, err)
+
+	assert.False(t, bytes.Contains(identity, dbKey))
+	assert.NotEqual(t, derivationSalt(identityKeyContext, testNetwork, testUser),
+		derivationSalt(databaseKeyContext, testUser))
+}
+
+func TestDerivationRunsThroughArgon2id(t *testing.T) {
+	salt := derivationSalt(identityKeyContext, testNetwork, testUser)
+	assert.Len(t, salt, keySize)
+
+	assert.Equal(t,
+		deriveKey([]byte(testPassword), salt),
+		deriveKey([]byte(testPassword), salt),
+	)
+	assert.NotEqual(t,
+		ConvertToSHA256([]byte(testUser+"@"+testPassword)),
+		deriveKey([]byte(testPassword), salt),
+	)
+}
+
+func TestDerivation_RefusesEmptyPassword(t *testing.T) {
+	_, err := DeriveIdentityKey(testUser, "", testNetwork)
+	assert.ErrorIs(t, err, ErrEmptyPassword)
+
+	_, err = DeriveDatabaseKey(testUser, "")
+	assert.ErrorIs(t, err, ErrEmptyPassword)
+}


### PR DESCRIPTION
Both of an account's root secrets came from the password via a single unsalted SHA-256: the ed25519 identity, whose public half is the peer ID and is broadcast by design, and the BadgerDB at-rest key. A guess cost about two SHA-256 plus a keygen, so a known peer ID or a stolen database directory opened the password to a GPU search against an 8-character policy floor. The strong KDF already existed in-tree, applied only to the deliberately weak single-use media password.

Route both through the existing Argon2id deriveKey helper (64 MiB, t=1, p=4): ~20 ms per derivation, ~40 ms added to a login.

Determinism across runs with nothing kept on disk rules out a random salt and the wrapped-random-identity design, so the salt is deterministic and public - SHA256(context | network | username). It buys domain separation between the two keys and denies shared rainbow tables; the work factor is the whole defence, and identity compromise stays unrevocable.

The session token in the same function was also a SHA-256 over the password, and it is handed to a pairing device, so it is now 32 random bytes.

Existing stores no longer open - both keys change, so this needs re-enrollment.

WRP-07.