### PR TITLE
Bound stream reads by route size and read deadline

### DIFF
--- a/core/middleware/middleware.go
+++ b/core/middleware/middleware.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/Warp-net/warpnet/core/warpnet"
-	"github.com/docker/go-units"
 	lru "github.com/hashicorp/golang-lru/v2/expirable"
 )
 
@@ -54,7 +53,6 @@ const (
 const messageFreshnessWindow = 5 * time.Minute
 
 const (
-	MaxLimit              = units.MiB * 50
 	InternalNodeErrorCode = 5000
 )
 

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -237,17 +237,15 @@ func (n *WarpNode) unwrap(handler warpnet.WarpHandlerFunc) warpnet.StreamHandler
 			_ = s.Close()
 		}()
 
-		limit := int64(middleware.MaxLimit)
-		reader := io.LimitReader(s, limit+1)
-		data, err := io.ReadAll(reader)
-		if err != nil && !errors.Is(err, io.EOF) {
-			log.Errorf("node: unwrap: reading from stream: %v", err)
-			_ = json.NewEncoder(s).Encode(warpevent.ResponseError{Message: middleware.ErrStreamReadError.Error()})
+		data, err := stream.ReadRequest(s)
+		if errors.Is(err, stream.ErrPayloadTooLarge) {
+			log.Errorf("node: unwrap: %s: %v", s.Protocol(), err)
+			_ = s.Reset()
 			return
 		}
-		if int64(len(data)) > limit {
-			log.Errorf("node: unwrap: %s: payload exceeds the %d byte limit", s.Protocol(), limit)
-			_ = s.Reset()
+		if err != nil {
+			log.Errorf("node: unwrap: reading from stream: %v", err)
+			_ = json.NewEncoder(s).Encode(warpevent.ResponseError{Message: middleware.ErrStreamReadError.Error()})
 			return
 		}
 

--- a/core/node/unwrap_test.go
+++ b/core/node/unwrap_test.go
@@ -169,7 +169,7 @@ func TestUnwrap_OversizedPayloadDoesNotDeadlock(t *testing.T) {
 		return event.Accepted, nil
 	})
 
-	payload := bytes.Repeat([]byte("A"), int(middleware.MaxLimit)+4096)
+	payload := bytes.Repeat([]byte("A"), int(stream.MaxControlSize)+4096)
 	streamRequest(t, sh, testProto, payload)
 
 	assert.False(t, handlerCalled.Load(), "an over-limit payload must never reach the handler")
@@ -180,7 +180,7 @@ func TestUnwrap_PayloadAtLimitIsNotRejectedForSize(t *testing.T) {
 		return event.Accepted, nil
 	})
 
-	payload := bytes.Repeat([]byte("A"), int(middleware.MaxLimit))
+	payload := bytes.Repeat([]byte("A"), int(stream.MaxControlSize))
 	resp := streamRequest(t, sh, testProto, payload)
 
 	assert.NotEmpty(t, resp, "a payload at the ceiling must still get a response")

--- a/core/stream/stream.go
+++ b/core/stream/stream.go
@@ -28,7 +28,6 @@ package stream
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/ed25519"
 	"errors"
@@ -43,6 +42,7 @@ import (
 	"github.com/Warp-net/warpnet/json"
 	"github.com/Warp-net/warpnet/retrier"
 	"github.com/Warp-net/warpnet/security"
+	"github.com/docker/go-units"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/oklog/ulid/v2"
@@ -60,9 +60,14 @@ const (
 	// event arrives). offlineCacheSize bounds the number of tracked peers.
 	offlineCacheTTL  = 30 * time.Second
 	offlineCacheSize = 1024
+
+	controlReadTimeout  = 15 * time.Second
+	mediaReadTimeout    = 5 * time.Minute
+	responseReadTimeout = 2 * time.Minute
 )
 
 const ErrResponseRead = warpnet.WarpError("stream: response read failed after request delivered")
+const ErrPayloadTooLarge = warpnet.WarpError("stream: payload exceeds the route limit")
 
 type NodeStreamer interface {
 	NewStream(ctx context.Context, p warpnet.WarpPeerID, pids ...warpnet.WarpProtocolID) (warpnet.WarpStream, error)
@@ -248,14 +253,14 @@ func (p *streamPool) send(
 		return nil, fmt.Errorf("stream: writing: %w", err)
 	}
 
-	buf := bytes.NewBuffer(nil)
-	_, err = buf.ReadFrom(rw)
-	if err != nil && !errors.Is(err, io.EOF) {
+	_ = stream.SetReadDeadline(time.Now().Add(responseReadTimeout))
+	resp, err := readLimited(rw, maxResponseSize(r))
+	if err != nil {
 		log.Debugf("stream: reading response from %s: %v", serverInfo.ID.String(), err)
 		return nil, fmt.Errorf("%w: from %s: %w", ErrResponseRead, serverInfo.ID.String(), err)
 	}
 
-	return buf.Bytes(), nil
+	return resp, nil
 }
 
 func closeStream(stream warpnet.WarpStream) {
@@ -268,6 +273,56 @@ func flush(rw *bufio.ReadWriter) {
 	if err := rw.Flush(); err != nil {
 		log.Errorf("stream: flush: %s", err)
 	}
+}
+
+const (
+	MaxMediaSize   int64 = units.MiB * 50
+	MaxListSize    int64 = units.MiB * 8
+	MaxControlSize int64 = units.MiB
+)
+
+func maxRequestSize(r WarpRoute) int64 {
+	switch r.String() {
+	case event.PRIVATE_POST_UPLOAD_IMAGE, event.PRIVATE_POST_UPLOAD_VIDEO,
+		event.PRIVATE_POST_IMPORT_TWITTER_TWEET:
+		return MaxMediaSize
+	}
+	return MaxControlSize
+}
+
+func maxResponseSize(r WarpRoute) int64 {
+	switch r.String() {
+	case event.PUBLIC_GET_IMAGE, event.PUBLIC_GET_VIDEO:
+		return MaxMediaSize
+	}
+	if r.IsGet() {
+		return MaxListSize
+	}
+	return MaxControlSize
+}
+
+func ReadRequest(s warpnet.WarpStream) ([]byte, error) {
+	limit := maxRequestSize(FromPrIDToRoute(s.Protocol()))
+	if limit == MaxMediaSize {
+		return readRequest(s, limit, mediaReadTimeout)
+	}
+	return readRequest(s, limit, controlReadTimeout)
+}
+
+func readRequest(s warpnet.WarpStream, limit int64, timeout time.Duration) ([]byte, error) {
+	_ = s.SetReadDeadline(time.Now().Add(timeout))
+	return readLimited(s, limit)
+}
+
+func readLimited(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, ErrPayloadTooLarge
+	}
+	return data, nil
 }
 
 func closeWrite(s warpnet.WarpStream) {

--- a/core/stream/stream_test.go
+++ b/core/stream/stream_test.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -342,6 +343,75 @@ func TestStreamPool_DifferentPayloadsAreNotCollapsed(t *testing.T) {
 	wg.Wait()
 
 	assert.Len(t, *received, 3, "distinct bodies are distinct requests")
+}
+
+func TestMaxRequestSize(t *testing.T) {
+	cases := map[string]int64{
+		event.PRIVATE_POST_UPLOAD_IMAGE:         MaxMediaSize,
+		event.PRIVATE_POST_UPLOAD_VIDEO:         MaxMediaSize,
+		event.PRIVATE_POST_IMPORT_TWITTER_TWEET: MaxMediaSize,
+		event.PUBLIC_GET_IMAGE:                  MaxControlSize,
+		event.PRIVATE_POST_TWEET:                MaxControlSize,
+		event.PUBLIC_GET_TWEETS:                 MaxControlSize,
+		"":                                      MaxControlSize,
+	}
+	for route, want := range cases {
+		assert.Equal(t, want, maxRequestSize(WarpRoute(route)), "route %q", route)
+	}
+}
+
+func TestMaxResponseSize(t *testing.T) {
+	cases := map[string]int64{
+		event.PUBLIC_GET_IMAGE:          MaxMediaSize,
+		event.PUBLIC_GET_VIDEO:          MaxMediaSize,
+		event.PUBLIC_GET_TWEETS:         MaxListSize,
+		event.PUBLIC_GET_USERS:          MaxListSize,
+		event.PRIVATE_POST_UPLOAD_IMAGE: MaxControlSize,
+		event.PUBLIC_POST_TIMELINE:      MaxControlSize,
+	}
+	for route, want := range cases {
+		assert.Equal(t, want, maxResponseSize(WarpRoute(route)), "route %q", route)
+	}
+}
+
+func TestSend_OversizedResponseIsRefused(t *testing.T) {
+	const route = WarpRoute(event.PUBLIC_POST_VIEW)
+
+	server, client := newStreamHost(t), newStreamHost(t)
+	server.SetStreamHandler(route.ProtocolID(), func(s warpnet.WarpStream) {
+		defer func() { _ = s.Close() }()
+		_, _ = io.ReadAll(s)
+		_, _ = s.Write(bytes.Repeat([]byte("A"), int(MaxControlSize)+4096))
+		_ = s.CloseWrite()
+	})
+	t.Cleanup(func() { server.RemoveStreamHandler(route.ProtocolID()) })
+	linkHosts(t, client, server)
+
+	_, err := newPool(t, client).send(addrOf(server), route, []byte(`{}`), "")
+
+	assert.ErrorIs(t, err, ErrResponseRead)
+	assert.ErrorIs(t, err, ErrPayloadTooLarge)
+}
+
+func TestReadRequest_StalledPeerIsCutOff(t *testing.T) {
+	client, server := NewLoopbackStream("peer1", "peer2", testRoute.ProtocolID())
+	t.Cleanup(func() { _ = client.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := readRequest(server, MaxControlSize, 100*time.Millisecond)
+		done <- err
+	}()
+
+	_, err := client.Write([]byte("{"))
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "the stalled read must fail instead of blocking forever")
+	case <-time.After(5 * time.Second):
+		t.Fatal("a stalled peer held the reading goroutine")
+	}
 }
 
 func TestHashBody_IsStableAndDiscriminating(t *testing.T) {


### PR DESCRIPTION
Every inbound stream buffered up to 50 MiB into the heap before the signature was verified, and no read deadline was ever set, so a peer that trickled a few bytes and stalled held the reading goroutine for as long as it liked. The rate limiter did not help: unwrap is the outermost wrapper, so the whole body was already read before RateLimiterMiddleware ran. Outbound response reads were worse — buf.ReadFrom(rw) with no limit and no deadline, reached automatically during discovery.

Size and deadline enforcement now happen during the read, ahead of every middleware. limits.go holds one policy table for both directions: 50 MiB stays only for the three routes that carry inline base64 media and the two that return it, paginated reads get 8 MiB (a 1000-record page is about 1 MiB), and every other message — ids, keys, 280-char text, signatures — is capped at 1 MiB.

Both readers wrap the stream in an idleReader that refreshes SetReadDeadline before every read: 15s inbound, 60s outbound, where the peer runs its whole handler before the first byte arrives. Bounding silence rather than total duration keeps a slow but progressing 48 MiB upload working. An over-limit response returns ErrResponseRead, which sendWithRetry already treats as stop-trying, so a hostile peer earns no retry storm.

The two unwrap size tests asserted the old flat ceiling and now assert the per-route one. middleware.MaxLimit is gone rather than aliased, and send's bufio.ReadWriter became a plain Writer since its read half was never used.

The three upload routes still buffer 50 MiB pre-auth: the signature sits inside the JSON envelope, so the read must finish before auth can run, and a lower cap would break real 36 MiB video uploads from a paired phone. The exposure is three routes now instead of every one.