### PR TITLE
Restore the version bump and release tag git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Bumps the patch version across every artifact that carries one, so each commit
+# on a release branch is independently installable and self-updatable.
+# Release branches only: feature branches must not move the version, and the
+# .claude/worktrees checkouts run these same hook files (core.hooksPath is an
+# absolute path to the main repo), so they are filtered out here too.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+case "$BRANCH" in
+    main|develop) ;;
+    *) exit 0 ;;
+esac
+
+echo "Pre-commit hook started..."
+
+CONFIG="version"
+SNAPCRAFT="snap/snapcraft.yaml"
+FRONTEND_PKG="frontend/package.json"
+FRONTEND_LOCK="frontend/package-lock.json"
+FDROID_VERSIONCODE="warpdroid/fdroid/versionCode"
+CHANGELOGS="fastlane/metadata/android/en-US/changelogs"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Version file not found!"
+    exit 1
+fi
+
+CURRENT_VERSION=$(grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+' "$CONFIG" || true)
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "Version file is not strict MAJOR.MINOR.PATCH semver!"
+    exit 1
+fi
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+PATCH=$((10#$PATCH + 1))
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+
+echo "Version: $CURRENT_VERSION -> $NEW_VERSION"
+
+# Backend: the single source of truth. Embedded into the binary (embedded.go),
+# load-bearing for the PSK derivation, and read by warpdroid/app/build.gradle,
+# which derives versionName/versionCode from it — so the Android client stays in
+# lockstep without a file of its own.
+sed -i "s/^$CURRENT_VERSION\$/$NEW_VERSION/" "$CONFIG"
+git add "$CONFIG"
+
+# Snap package.
+if [ -f "$SNAPCRAFT" ]; then
+    sed -i -E "s/^version:[[:space:]]*'?([0-9]+\.[0-9]+\.[0-9]+)'?/version: ${NEW_VERSION}/" "$SNAPCRAFT"
+    git add "$SNAPCRAFT"
+fi
+
+# Frontend: kept in lockstep with the node version.
+if [ -f "$FRONTEND_PKG" ]; then
+    FRONTEND_VERSION=$(grep -m1 -Eo '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$FRONTEND_PKG" \
+        | sed -E 's/.*"([^"]+)"$/\1/' || true)
+    sed -i -E "0,/\"version\"[[:space:]]*:/s/(\"version\"[[:space:]]*:[[:space:]]*)\"[^\"]*\"/\1\"${NEW_VERSION}\"/" "$FRONTEND_PKG"
+    git add "$FRONTEND_PKG"
+
+    # npm refuses to install from a lockfile whose own version drifted from
+    # package.json, so the root entries (top level + packages."") move together.
+    if [ -f "$FRONTEND_LOCK" ] && [ -n "$FRONTEND_VERSION" ]; then
+        sed -i "1,12s/\"version\": \"$FRONTEND_VERSION\"/\"version\": \"$NEW_VERSION\"/" "$FRONTEND_LOCK"
+        git add "$FRONTEND_LOCK"
+    fi
+fi
+
+# Publish the F-Droid versionCode so fdroiddata's UpdateCheckMode: Tags can read
+# warpdroid/fdroid/versionCode at the tag. Single APK, no VercodeOperation:
+# code = major*1000000 + minor*10000 + patch, then *10 (no ABI offset), matching
+# warpdroid/app/build.gradle.
+NEW_BASE=$(( (10#$MAJOR * 1000000 + 10#$MINOR * 10000 + 10#$PATCH) * 10 ))
+if [ -f "$FDROID_VERSIONCODE" ]; then
+    echo "$NEW_BASE" > "$FDROID_VERSIONCODE"
+    git add "$FDROID_VERSIONCODE"
+fi
+
+# Keep the warpdroid F-Droid fastlane changelog in sync with the new
+# versionCode. Single-APK model: F-Droid expects exactly one changelog file
+# named <versionCode>.txt. Carry the most recent note forward to the new name
+# and delete any others.
+if [ -d "$CHANGELOGS" ]; then
+    NEW="$CHANGELOGS/$NEW_BASE.txt"
+    LATEST=$(ls "$CHANGELOGS"/*.txt 2>/dev/null | sort -V | tail -1 || true)
+    if [ -n "$LATEST" ] && [ "$LATEST" != "$NEW" ]; then
+        mv -f "$LATEST" "$NEW"
+        echo "Changelog: $(basename "$LATEST") -> $(basename "$NEW")"
+    fi
+    find "$CHANGELOGS" -maxdepth 1 -name '*.txt' ! -name "$NEW_BASE.txt" -exec rm -f {} +
+    git add -A "$CHANGELOGS"
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Mirrors pushed code to the Codeberg mirror (codeberg.org/Warpnet/warpnet).
-# Tags are not mirrored here: the Release workflow owns tagging.
+# Cuts the release tag for the version in `version` (bumped by pre-commit) and
+# mirrors pushed code to the Codeberg mirror (codeberg.org/Warpnet/warpnet).
 
-# Re-entry guard: the mirror push below invokes `git push` again, which would
+# Re-entry guard: the pushes below invoke `git push` again, which would
 # otherwise re-trigger this hook (this recursion previously spawned runaway
 # hook/`git push codeberg` processes that hung for hours).
 if [ -n "${WARPNET_PREPUSH:-}" ]; then
@@ -11,23 +11,55 @@ if [ -n "${WARPNET_PREPUSH:-}" ]; then
 fi
 export WARPNET_PREPUSH=1
 
-# Never mirror a push that is already aimed at the mirror.
+# Never re-process a push that is already aimed at the mirror.
 case "${2:-}" in
     *codeberg.org*) exit 0 ;;
 esac
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
-# Only the long-lived branches exist on the mirror; feature branches stay local.
+# Only the long-lived branches are released and exist on the mirror; feature
+# branches stay local.
 case "$BRANCH" in
     main|develop) ;;
     *) exit 0 ;;
 esac
 
+echo "Pre-push hook started..."
+
+FILE="version"
+
+if [ ! -f "$FILE" ]; then
+    echo "Version file not found!"
+    exit 1
+fi
+
+CURRENT_VERSION=$(grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+' "$FILE" || true)
+
+if [ -n "$CURRENT_VERSION" ]; then
+    TAG="v$CURRENT_VERSION"
+
+    # Create the release tag once; re-running on the same version is a no-op.
+    if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+        echo "Tag $TAG already exists."
+    else
+        git tag -a "$TAG" -m "Release version $CURRENT_VERSION"
+        echo "Tagged $TAG."
+    fi
+
+    # Best-effort: each push is bounded by a timeout so an unreachable or slow
+    # remote can never block or hang the push, and --no-verify keeps the inner
+    # pushes out of this hook.
+    timeout --kill-after=5 20 git push --no-verify origin "$TAG" \
+        || echo "warn: pushing $TAG to origin failed or timed out (continuing)"
+    timeout --kill-after=5 20 git push --no-verify codeberg "$TAG" \
+        || echo "warn: pushing $TAG to codeberg failed or timed out (continuing)"
+else
+    echo "warn: version file is not strict semver, skipping the release tag"
+fi
+
 echo "Pre-push hook: mirroring $BRANCH to codeberg..."
 
-# Best-effort: bounded by a timeout so an unreachable or slow mirror can never
-# block the push, and --no-verify keeps the inner push out of this hook.
 timeout --kill-after=5 20 git push --no-verify codeberg "$BRANCH" \
     || echo "warn: mirroring $BRANCH to codeberg failed or timed out (continuing)"
 


### PR DESCRIPTION
pre-commit bumps the patch across every artifact that carries a version: the root `version` file (backend, also read by warpdroid/app/build.gradle for versionName/versionCode), snap/snapcraft.yaml, frontend/package.json plus both root entries of package-lock.json, warpdroid/fdroid/versionCode and the fastlane changelog filename.

pre-push cuts `v$(cat version)` if it does not exist yet and pushes it to origin and codeberg, keeping the existing code mirroring of main/develop.

Both hooks are gated on main and develop: main now only receives GitHub PR merges, so a main-only gate would never fire locally.