### PR TITLE
Resolve an unknown actor from the node that delivered the event

### DIFF
--- a/core/authorship/authorship.go
+++ b/core/authorship/authorship.go
@@ -1,0 +1,111 @@
+/*
+
+Warpnet - Decentralized Social Network
+Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+<github.com.mecdy@passmail.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package authorship resolves the actor behind an incoming event and checks the
+// event came from that actor's own node. It sits above warpnet.VerifyAuthorship,
+// which only compares an already-known node id, and below the handlers, which
+// each read the actor id out of their own payload.
+package authorship
+
+import (
+	"errors"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	log "github.com/sirupsen/logrus"
+)
+
+// UserStorer reads the actor behind an incoming event and stores one learned
+// from the network.
+type UserStorer interface {
+	Get(userId string) (user domain.User, err error)
+	Create(user domain.User) (domain.User, error)
+}
+
+// NodeStreamer asks another node for a profile.
+type NodeStreamer interface {
+	GenericStream(nodeId string, path stream.WarpRoute, data any) ([]byte, error)
+}
+
+// FetchActor returns actorId's profile, resolving it from the node that
+// delivered the event when it is unknown locally, and storing it. The
+// delivering node is the right source on any network — it is either the
+// actor's own node or the home node the actor is bridged from.
+func FetchActor(
+	userRepo UserStorer, streamer NodeStreamer, s warpnet.WarpStream, actorId string,
+) (domain.User, error) {
+	actor, err := userRepo.Get(actorId)
+	if err == nil {
+		return actor, nil
+	}
+	if !errors.Is(err, database.ErrUserNotFound) {
+		return domain.User{}, err
+	}
+	if s == nil || s.Conn() == nil {
+		return domain.User{}, err
+	}
+
+	senderNodeId := s.Conn().RemotePeer().String()
+	resp, err := streamer.GenericStream(senderNodeId, event.PUBLIC_GET_USER, event.GetUserEvent{
+		UserId: domain.ID(actorId),
+		NodeId: senderNodeId,
+	})
+	if err != nil {
+		return domain.User{}, err
+	}
+	if err := json.Unmarshal(resp, &actor); err != nil {
+		return domain.User{}, err
+	}
+	if actor.Id == "" {
+		return domain.User{}, database.ErrUserNotFound
+	}
+	if _, err := userRepo.Create(actor); err != nil && !errors.Is(err, database.ErrUserAlreadyExists) {
+		return domain.User{}, err
+	}
+	return actor, nil
+}
+
+// VerifyActor checks that the event came from its actor's own node, resolving
+// an actor unknown locally from the delivering node first. Replying to or
+// favouriting a post without following its author is ordinary on the Fediverse,
+// so a bridged actor reaches a node with no prior record of them and only the
+// gateway that delivered the event can answer for them. A failed resolve stays
+// non-fatal: it leaves an empty node id, which VerifyAuthorship rejects exactly
+// as before.
+func VerifyActor(
+	userRepo UserStorer, streamer NodeStreamer, s warpnet.WarpStream, actorId string,
+) (domain.User, error) {
+	actor, err := FetchActor(userRepo, streamer, s, actorId)
+	if err != nil {
+		log.Infof("verify actor %s: %v", actorId, err)
+	}
+	return actor, warpnet.VerifyAuthorship(s, actor.NodeId)
+}

--- a/core/handler/first_contact_test.go
+++ b/core/handler/first_contact_test.go
@@ -1,0 +1,198 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+)
+
+// Replying to or favouriting a post without following its author first is an
+// ordinary Fediverse interaction, so a bridged actor reaches a node that has
+// never stored them - only a follow used to store one. The authorship gate then
+// has no node id to compare, and the interaction is dropped. These tests pin
+// the first contact: the actor is resolved from the node that delivered the
+// event, and the gate still refuses anyone that node does not host.
+func TestFirstContactActor(t *testing.T) {
+	const (
+		owner       = "owner-1"
+		parentUser  = "parent-user"
+		bridged     = "someone@mastodon.social"
+		tweetId     = "tweet-1"
+		ownerNode   = warpnet.WarpPeerID("owner-node")
+		gatewayNode = warpnet.WarpPeerID("gateway-node")
+	)
+
+	ownInfo := warpnet.NodeInfo{OwnerId: owner, ID: ownerNode}
+	_, fromGateway := stream.NewLoopbackStream(ownerNode, gatewayNode, "/test/route/0.0.0")
+
+	// What the gateway answers PUBLIC_GET_USER with: the bridged actor, homed
+	// on the gateway itself.
+	bridgedUser := func(nodeId string) domain.User {
+		return domain.User{Id: bridged, Username: "someone", NodeId: nodeId, Network: "mastodon"}
+	}
+
+	// unknownActor knows every local user but has never heard of the bridged one.
+	unknownActor := func(created *domain.User) stubReplyUserRepo {
+		return stubReplyUserRepo{
+			getFn: func(userId string) (domain.User, error) {
+				if userId == bridged {
+					return domain.User{}, database.ErrUserNotFound
+				}
+				return domain.User{Id: userId, NodeId: ownerNode.String()}, nil
+			},
+			createFn: func(u domain.User) (domain.User, error) {
+				*created = u
+				return u, nil
+			},
+		}
+	}
+
+	reply := func() event.NewTweetEvent {
+		pu, pid := parentUser, tweetId
+		return event.NewTweetEvent{
+			CreatedAt:    time.Now(),
+			Id:           "reply-1",
+			ParentId:     &pid,
+			ParentUserId: &pu,
+			RootId:       tweetId,
+			Text:         "a reply from mastodon",
+			UserId:       bridged,
+			Username:     "someone",
+		}
+	}
+
+	t.Run("reply: the delivering node resolves an actor nobody here knows", func(t *testing.T) {
+		var created domain.User
+		var routes []stream.WarpRoute
+		var askedNode string
+
+		streamer := stubStreamer{
+			nodeInfo: ownInfo,
+			genericStreamFn: func(nodeId string, path stream.WarpRoute, _ any) ([]byte, error) {
+				routes = append(routes, path)
+				askedNode = nodeId
+				return marshal(t, bridgedUser(gatewayNode.String())), nil
+			},
+		}
+		h := StreamNewReplyHandler(stubTweetRepo{}, unknownActor(&created), stubModerationNotifier{}, streamer)
+
+		resp, err := h(marshal(t, reply()), fromGateway)
+		if err != nil {
+			t.Fatalf("first-contact reply rejected: %v", err)
+		}
+		if resp.(domain.Tweet).Text != "a reply from mastodon" {
+			t.Fatalf("expected the reply to be stored, got %+v", resp)
+		}
+		if len(routes) != 1 || routes[0] != event.PUBLIC_GET_USER {
+			t.Fatalf("expected a single %s call, got %v", event.PUBLIC_GET_USER, routes)
+		}
+		if askedNode != gatewayNode.String() {
+			t.Fatalf("expected the actor resolved from the delivering node %q, got %q", gatewayNode.String(), askedNode)
+		}
+		if created.Id != bridged || created.NodeId != gatewayNode.String() {
+			t.Fatalf("expected the resolved actor to be stored, got %+v", created)
+		}
+	})
+
+	t.Run("reply: an actor the delivering node does not host is still refused", func(t *testing.T) {
+		var created domain.User
+		streamer := stubStreamer{
+			nodeInfo: ownInfo,
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return marshal(t, bridgedUser("somebody-elses-node")), nil
+			},
+		}
+		h := StreamNewReplyHandler(stubTweetRepo{}, unknownActor(&created), stubModerationNotifier{}, streamer)
+
+		if _, err := h(marshal(t, reply()), fromGateway); !errors.Is(err, warpnet.ErrForeignAuthor) {
+			t.Fatalf("expected ErrForeignAuthor, got %v", err)
+		}
+	})
+
+	t.Run("reply: an actor nobody vouches for is still refused", func(t *testing.T) {
+		var created domain.User
+		streamer := stubStreamer{
+			nodeInfo: ownInfo,
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return nil, errors.New("no such user")
+			},
+		}
+		h := StreamNewReplyHandler(stubTweetRepo{}, unknownActor(&created), stubModerationNotifier{}, streamer)
+
+		if _, err := h(marshal(t, reply()), fromGateway); !errors.Is(err, warpnet.ErrForeignAuthor) {
+			t.Fatalf("expected ErrForeignAuthor, got %v", err)
+		}
+	})
+
+	// The favourite path: same first contact, and the resolved profile is what
+	// gives the notification a name instead of a raw handle.
+	unknownReactor := func(created *domain.User) stubReactionUserRepo {
+		return stubReactionUserRepo{
+			getFn: func(userId string) (domain.User, error) {
+				if userId == bridged {
+					return domain.User{}, database.ErrUserNotFound
+				}
+				return domain.User{Id: userId, NodeId: ownerNode.String()}, nil
+			},
+			createFn: func(u domain.User) (domain.User, error) {
+				*created = u
+				return u, nil
+			},
+		}
+	}
+
+	reaction := event.ReactionEvent{TweetId: tweetId, UserId: owner, OwnerId: bridged, Emoji: "❤️"}
+
+	t.Run("reaction: the delivering node resolves an actor nobody here knows", func(t *testing.T) {
+		var created domain.User
+		var notification domain.Notification
+
+		streamer := stubStreamer{
+			nodeInfo: ownInfo,
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return marshal(t, bridgedUser(gatewayNode.String())), nil
+			},
+		}
+		notifier := stubModerationNotifier{addFn: func(not domain.Notification) error {
+			notification = not
+			return nil
+		}}
+		h := StreamReactionHandler(stubReactionRepo{}, unknownReactor(&created), notifier, streamer)
+
+		resp, err := h(marshal(t, reaction), fromGateway)
+		if err != nil {
+			t.Fatalf("first-contact reaction rejected: %v", err)
+		}
+		if resp.(event.ReactionsCountResponse).Count != 1 {
+			t.Fatalf("expected the reaction to be counted, got %+v", resp)
+		}
+		if created.Id != bridged || created.NodeId != gatewayNode.String() {
+			t.Fatalf("expected the resolved actor to be stored, got %+v", created)
+		}
+		if notification.ActorId != bridged || notification.Text != "someone reacted your tweet" {
+			t.Fatalf("expected the resolved username in the notification, got %+v", notification)
+		}
+	})
+
+	t.Run("reaction: an actor the delivering node does not host is still refused", func(t *testing.T) {
+		var created domain.User
+		streamer := stubStreamer{
+			nodeInfo: ownInfo,
+			genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+				return marshal(t, bridgedUser("somebody-elses-node")), nil
+			},
+		}
+		h := StreamReactionHandler(stubReactionRepo{}, unknownReactor(&created), stubModerationNotifier{}, streamer)
+
+		if _, err := h(marshal(t, reaction), fromGateway); !errors.Is(err, warpnet.ErrForeignAuthor) {
+			t.Fatalf("expected ErrForeignAuthor, got %v", err)
+		}
+	})
+}

--- a/core/handler/following.go
+++ b/core/handler/following.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -70,43 +71,6 @@ type FollowingStorer interface {
 	AddFollowRequest(targetUserId, followerId string) error
 	RemoveFollowRequest(targetUserId, followerId string) error
 	ListFollowRequests(targetUserId string, limit *uint64, cursor *string) ([]string, string, error)
-}
-
-// fetchFollower returns the follower's profile, resolving it from the node that
-// delivered the follow when it is unknown locally, and storing it. A follow is
-// stored only after this succeeds: a follower we hold as an id alone renders as
-// that raw id in the notification and as an empty row in the followers list.
-// The delivering node is the right source on any network — it is either the
-// follower's own node or the home node the follower is bridged from.
-func fetchFollower(
-	userRepo FollowingUserStorer, streamer FollowNodeStreamer, s warpnet.WarpStream, followerId string,
-) (domain.User, error) {
-	follower, err := userRepo.Get(followerId)
-	if err == nil {
-		return follower, nil
-	}
-	if !errors.Is(err, database.ErrUserNotFound) {
-		return domain.User{}, err
-	}
-
-	senderNodeId := s.Conn().RemotePeer().String()
-	resp, err := streamer.GenericStream(senderNodeId, event.PUBLIC_GET_USER, event.GetUserEvent{
-		UserId: domain.ID(followerId),
-		NodeId: senderNodeId,
-	})
-	if err != nil {
-		return domain.User{}, err
-	}
-	if err := json.Unmarshal(resp, &follower); err != nil {
-		return domain.User{}, err
-	}
-	if follower.Id == "" {
-		return domain.User{}, database.ErrUserNotFound
-	}
-	if _, err := userRepo.Create(follower); err != nil && !errors.Is(err, database.ErrUserAlreadyExists) {
-		return domain.User{}, err
-	}
-	return follower, nil
 }
 
 type FollowNotifier interface {
@@ -150,7 +114,7 @@ func StreamFollowHandler(
 			if s == nil || s.Conn() == nil {
 				return nil, warpnet.ErrForeignAuthor
 			}
-			followerUser, err := fetchFollower(userRepo, streamer, s, ev.FollowerId)
+			followerUser, err := authorship.FetchActor(userRepo, streamer, s, ev.FollowerId)
 			if err != nil {
 				return nil, err
 			}
@@ -285,8 +249,7 @@ func StreamUnfollowHandler(
 		isMeUnfollowed := ownerUserId == ev.FollowingId
 
 		if isMeUnfollowed {
-			follower, _ := userRepo.Get(ev.FollowerId)
-			if err := warpnet.VerifyAuthorship(s, follower.NodeId); err != nil {
+			if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.FollowerId); err != nil {
 				return nil, err
 			}
 			err = followRepo.Unfollow(ev.FollowerId, ev.FollowingId)

--- a/core/handler/poll.go
+++ b/core/handler/poll.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -60,6 +61,7 @@ type PollStreamer interface {
 
 type PollUserFetcher interface {
 	Get(userId string) (user domain.User, err error)
+	Create(user domain.User) (domain.User, error)
 }
 
 func StreamPollVoteHandler(
@@ -86,8 +88,7 @@ func StreamPollVoteHandler(
 			return nil, warpnet.WarpError("poll: negative option")
 		}
 
-		voter, _ := userRepo.Get(ev.OwnerId)
-		if err := warpnet.VerifyAuthorship(s, voter.NodeId); err != nil {
+		if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.OwnerId); err != nil {
 			return nil, err
 		}
 

--- a/core/handler/reaction.go
+++ b/core/handler/reaction.go
@@ -33,6 +33,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -52,6 +53,7 @@ type ReactionTweetsStorer interface {
 type ReactedUserFetcher interface {
 	GetBatch(userIds ...string) (users []domain.User, err error)
 	Get(userId string) (users domain.User, err error)
+	Create(user domain.User) (domain.User, error)
 }
 
 type ReactionStreamer interface {
@@ -95,8 +97,8 @@ func StreamReactionHandler(
 			return nil, warpnet.WarpError("react: empty tweet id")
 		}
 
-		reactor, _ := userRepo.Get(ev.OwnerId)
-		if err := warpnet.VerifyAuthorship(s, reactor.NodeId); err != nil {
+		reactor, err := authorship.VerifyActor(userRepo, streamer, s, ev.OwnerId)
+		if err != nil {
 			return nil, err
 		}
 
@@ -216,8 +218,7 @@ func StreamUnreactionHandler(repo ReactionsStorer, userRepo ReactedUserFetcher, 
 			return nil, warpnet.WarpError("empty tweet id")
 		}
 
-		reactor, _ := userRepo.Get(ev.OwnerId)
-		if err := warpnet.VerifyAuthorship(s, reactor.NodeId); err != nil {
+		if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.OwnerId); err != nil {
 			return nil, err
 		}
 

--- a/core/handler/reaction_test.go
+++ b/core/handler/reaction_test.go
@@ -78,6 +78,14 @@ func (s stubReactionRepo) Reacted(userId string, limit *uint64, cursor *string) 
 type stubReactionUserRepo struct {
 	getBatchFn func(userIds ...string) ([]domain.User, error)
 	getFn      func(userId string) (domain.User, error)
+	createFn   func(user domain.User) (domain.User, error)
+}
+
+func (s stubReactionUserRepo) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
 }
 
 func (s stubReactionUserRepo) GetBatch(userIds ...string) ([]domain.User, error) {

--- a/core/handler/reply_test.go
+++ b/core/handler/reply_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 type stubReplyUserRepo struct {
-	getFn func(userId string) (domain.User, error)
+	getFn    func(userId string) (domain.User, error)
+	createFn func(user domain.User) (domain.User, error)
 }
 
 func (s stubReplyUserRepo) Get(userId string) (domain.User, error) {
@@ -24,6 +25,12 @@ func (s stubReplyUserRepo) Get(userId string) (domain.User, error) {
 		return s.getFn(userId)
 	}
 	return domain.User{Id: userId, NodeId: "node-2"}, nil
+}
+func (s stubReplyUserRepo) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
 }
 
 // Replies are created through StreamNewTweetHandler: a tweet with a parent

--- a/core/handler/retweet.go
+++ b/core/handler/retweet.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -48,6 +49,7 @@ type RetweetStreamer interface {
 type RetweetedUserFetcher interface {
 	GetBatch(retweetersIds ...string) (users []domain.User, err error)
 	Get(userId string) (users domain.User, err error)
+	Create(user domain.User) (domain.User, error)
 }
 
 type OwnerReTweetStorer interface {
@@ -90,8 +92,8 @@ func StreamNewReTweetHandler(
 			return nil, warpnet.WarpError("empty retweet id")
 		}
 
-		retweeter, _ := userRepo.Get(*retweetEvent.RetweetedBy)
-		if err := warpnet.VerifyAuthorship(s, retweeter.NodeId); err != nil {
+		retweeter, err := authorship.VerifyActor(userRepo, streamer, s, *retweetEvent.RetweetedBy)
+		if err != nil {
 			return nil, err
 		}
 
@@ -204,8 +206,7 @@ func StreamUnretweetHandler(
 			return nil, warpnet.WarpError("empty tweet id")
 		}
 
-		retweeter, _ := userRepo.Get(ev.RetweeterId)
-		if err := warpnet.VerifyAuthorship(s, retweeter.NodeId); err != nil {
+		if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.RetweeterId); err != nil {
 			return nil, err
 		}
 

--- a/core/handler/retweet_test.go
+++ b/core/handler/retweet_test.go
@@ -17,6 +17,14 @@ import (
 type stubRetweetUserRepo struct {
 	getBatchFn func(ids ...string) ([]domain.User, error)
 	getFn      func(userId string) (domain.User, error)
+	createFn   func(user domain.User) (domain.User, error)
+}
+
+func (s stubRetweetUserRepo) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
 }
 
 func (s stubRetweetUserRepo) GetBatch(ids ...string) ([]domain.User, error) {

--- a/core/handler/tweet.go
+++ b/core/handler/tweet.go
@@ -35,6 +35,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -49,6 +50,7 @@ const tweetCharLimit = 280
 
 type TweetUserFetcher interface {
 	Get(userId string) (user domain.User, err error)
+	Create(user domain.User) (domain.User, error)
 }
 
 type TweetStreamer interface {
@@ -243,8 +245,7 @@ func StreamNewReplyHandler(
 			return nil, err
 		}
 
-		author, _ := userRepo.Get(ev.UserId)
-		if err := warpnet.VerifyAuthorship(s, author.NodeId); err != nil {
+		if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.UserId); err != nil {
 			return nil, err
 		}
 

--- a/core/handler/tweet_test.go
+++ b/core/handler/tweet_test.go
@@ -177,7 +177,8 @@ func authorStream(t *testing.T) (stubTweetUserRepo, warpnet.WarpStream) {
 }
 
 type stubTweetUserRepo struct {
-	getFn func(userId string) (domain.User, error)
+	getFn    func(userId string) (domain.User, error)
+	createFn func(user domain.User) (domain.User, error)
 }
 
 func (s stubTweetUserRepo) Get(userId string) (domain.User, error) {
@@ -185,6 +186,12 @@ func (s stubTweetUserRepo) Get(userId string) (domain.User, error) {
 		return s.getFn(userId)
 	}
 	return domain.User{Id: userId, NodeId: "node-2"}, nil
+}
+func (s stubTweetUserRepo) Create(user domain.User) (domain.User, error) {
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
 }
 
 type stubTweetReactionRepo struct {
@@ -1119,7 +1126,8 @@ func (m *mockFollowChecker) IsFollowing(o, a string) bool {
 }
 
 type mockUserFetcher struct {
-	GetFunc func(string) (domain.User, error)
+	GetFunc    func(string) (domain.User, error)
+	CreateFunc func(domain.User) (domain.User, error)
 }
 
 func (m *mockUserFetcher) Get(id string) (domain.User, error) {
@@ -1127,6 +1135,13 @@ func (m *mockUserFetcher) Get(id string) (domain.User, error) {
 		return m.GetFunc(id)
 	}
 	return domain.User{}, errUserNotFound
+}
+
+func (m *mockUserFetcher) Create(user domain.User) (domain.User, error) {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(user)
+	}
+	return user, nil
 }
 
 type mockBroadcaster struct {

--- a/core/handler/view.go
+++ b/core/handler/view.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Warp-net/warpnet/core/authorship"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
@@ -47,6 +48,7 @@ type ViewsStorer interface {
 
 type ViewUserFetcher interface {
 	Get(userId string) (user domain.User, err error)
+	Create(user domain.User) (domain.User, error)
 }
 
 type ViewStreamer interface {
@@ -71,8 +73,7 @@ func StreamViewHandler(repo ViewsStorer, userRepo ViewUserFetcher, streamer View
 			return nil, warpnet.WarpError("view: empty viewer id")
 		}
 
-		viewer, _ := userRepo.Get(ev.ViewerId)
-		if err := warpnet.VerifyAuthorship(s, viewer.NodeId); err != nil {
+		if _, err := authorship.VerifyActor(userRepo, streamer, s, ev.ViewerId); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
VerifyAuthorship compares the actor's stored NodeId to the sending peer, so a bare userRepo.Get with the error discarded turns an actor nobody here knows into NodeId "" and a hard ErrForeignAuthor reject.

Only fetchFollower ever stored a bridged user, so a Mastodon account that replies to, favourites or boosts a Warpnet post without following its author first was refused — an ordinary Fediverse interaction, and a large share of inbound federation through the ActivityPub gateway.

fetchFollower is generalized into fetchActor, and verifyActor resolves the actor before running the gate: on ErrUserNotFound the profile is fetched over PUBLIC_GET_USER from s.Conn().RemotePeer() and stored. The security property is unchanged — the actor's home node must be the peer that sent the event — and a failed resolve stays non-fatal, leaving the empty node id the gate already rejects.

Applied to the reply, reaction, unreaction, retweet, unretweet, view, poll vote and unfollow handlers, which together cover every activity the gateway maps inbound. As a side effect the reaction and retweet notifications now carry the resolved username instead of a blank one.