### PR TITLE
ci(release): rebuild the gomobile lib at F-Droid's build path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,12 +193,6 @@ jobs:
           test -d "$NDK_DIR"
           echo "ANDROID_NDK_HOME=$NDK_DIR" >> "$GITHUB_ENV"
 
-      # Build the gomobile native library at the SAME absolute path F-Droid's
-      # buildserver uses (/home/vagrant/build/<appid>). gomobile ignores -trimpath
-      # for the main module, so libgojni.so's .go.buildinfo embeds the checkout
-      # path; matching the path is F-Droid's documented fix for embedded build
-      # paths (https://f-droid.org/docs/Reproducible_Builds/). The built .aar is
-      # then copied back into the workspace for the Gradle step.
       - name: Build Warpnet native library (gomobile) at F-Droid's build path
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -193,12 +193,25 @@ jobs:
           test -d "$NDK_DIR"
           echo "ANDROID_NDK_HOME=$NDK_DIR" >> "$GITHUB_ENV"
 
-      - name: Build Warpnet native library (gomobile)
-        working-directory: warpdroid/node
+      # Build the gomobile native library at the SAME absolute path F-Droid's
+      # buildserver uses (/home/vagrant/build/<appid>). gomobile ignores -trimpath
+      # for the main module, so libgojni.so's .go.buildinfo embeds the checkout
+      # path; matching the path is F-Droid's documented fix for embedded build
+      # paths (https://f-droid.org/docs/Reproducible_Builds/). The built .aar is
+      # then copied back into the workspace for the Gradle step.
+      - name: Build Warpnet native library (gomobile) at F-Droid's build path
         run: |
           set -euo pipefail
-          (cd "$GITHUB_WORKSPACE" && go mod download)
-          bash build-native.sh
+          FDROID_DIR=/home/vagrant/build/site.warpnet.warpdroid
+          sudo mkdir -p /home/vagrant/build
+          sudo cp -a "$GITHUB_WORKSPACE" "$FDROID_DIR"
+          sudo chown -R "$(id -un):$(id -gn)" /home/vagrant/build
+          (cd "$FDROID_DIR" && go mod download)
+          (cd "$FDROID_DIR/warpdroid/node" && bash build-native.sh)
+          libs="$GITHUB_WORKSPACE/warpdroid/warpnet-transport/libs"
+          mkdir -p "$libs"
+          cp "$FDROID_DIR/warpdroid/warpnet-transport/libs/warpnet.aar" "$libs/warpnet.aar"
+          cp "$FDROID_DIR/warpdroid/warpnet-transport/libs/warpnet-sources.jar" "$libs/warpnet-sources.jar"
 
       - name: Decode release keystore (if configured)
         id: keystore


### PR DESCRIPTION
Commit c81072bf1 dropped the "Build Warpnet native library (gomobile) at F-Droid's build path" step, so release.yaml now builds warpdroid straight in the Actions workspace. gomobile ignores -trimpath for the main module, so libgojni.so's .go.buildinfo embeds the checkout path: the published v0.8.3 APK carries /home/runner/work/warpnet/warpnet, while F-Droid builds at /home/vagrant/build/site.warpnet.warpdroid. The paths differ, so F-Droid's binary verification cannot reproduce the APK.

warpdroid/node/build-native.sh still documents this contract ("handled by building at the same absolute path F-Droid uses ... see release.yaml") — only its counterpart was deleted. The other two reproducibility fixes (GOTOOLCHAIN=local, -buildid=, -buildvcs=false) are intact.

Restore the step verbatim from 26d953ea7, the last revision where the byte comparison matched.