### PR TITLE
test: raise coverage from 73.2% to 90.6%

### DIFF
--- a/cmd/node/member/app_test.go
+++ b/cmd/node/member/app_test.go
@@ -1,0 +1,315 @@
+//nolint:all
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	stdjson "encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Warp-net/warpnet/cmd/node/member/auth"
+	"github.com/Warp-net/warpnet/config"
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+type stubAuthService struct {
+	loginFn    func(event.LoginEvent, security.PSK) (event.LoginResponse, error)
+	privateKey ed25519.PrivateKey
+	loggedOut  bool
+}
+
+func (s *stubAuthService) AuthLogin(ev event.LoginEvent, psk security.PSK) (event.LoginResponse, error) {
+	if s.loginFn != nil {
+		return s.loginFn(ev, psk)
+	}
+	return event.LoginResponse{}, nil
+}
+
+func (s *stubAuthService) AuthLogout()                        { s.loggedOut = true }
+func (s *stubAuthService) PrivateKey() ed25519.PrivateKey     { return s.privateKey }
+func (s *stubAuthService) Storage() auth.AuthPersistencyLayer { return nil }
+
+type stubNodeServer struct {
+	info       warpnet.NodeInfo
+	streamFn   func(path stream.WarpRoute, data any) ([]byte, error)
+	stopped    bool
+	startCalls int
+}
+
+func (s *stubNodeServer) SelfStream(_, _ warpnet.WarpPeerID, path stream.WarpRoute, data any) ([]byte, error) {
+	if s.streamFn != nil {
+		return s.streamFn(path, data)
+	}
+	return []byte(`{"ok":true}`), nil
+}
+
+func (s *stubNodeServer) NodeInfo() warpnet.NodeInfo { return s.info }
+func (s *stubNodeServer) Stop()                      { s.stopped = true }
+func (s *stubNodeServer) Start() error               { s.startCalls++; return nil }
+
+func testKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return priv
+}
+
+// liveApp assembles an App in the state startup leaves it: mutex and channel
+// created, auth and node attached.
+func liveApp(t *testing.T, authSvc *stubAuthService, node *stubNodeServer) *App {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+
+	if node != nil {
+		node.info = warpnet.NodeInfo{ID: id}
+	}
+	a := NewApp()
+	a.mx = new(sync.RWMutex)
+	a.readyChan = make(chan domain.AuthNodeInfo, 1)
+	a.auth = authSvc
+	if node != nil {
+		a.node = node
+	}
+	return a
+}
+
+func TestNewApp(t *testing.T) {
+	a := NewApp()
+	require.NotNil(t, a)
+	require.False(t, a.IsFirstRun(), "a pre-startup app has no database to ask")
+	require.Equal(t, config.Config().Node.Network, a.Network())
+}
+
+func TestSelectNetworkRejectsUnknown(t *testing.T) {
+	a := NewApp()
+	err := a.SelectNetwork("not-a-network")
+	require.ErrorIs(t, err, errUnknownNetwork)
+}
+
+func TestDeepLinkPlumbing(t *testing.T) {
+	t.Run("nil app is inert", func(t *testing.T) {
+		var a *App
+		require.NotPanics(t, func() { a.SetPendingDeepLink("warpnet://x") })
+		require.Empty(t, a.ConsumePendingDeepLink())
+		require.NotPanics(t, func() { a.NotifyDeepLink("warpnet://x") })
+	})
+
+	t.Run("pre-startup app stashes without a mutex", func(t *testing.T) {
+		a := NewApp()
+		a.SetPendingDeepLink("warpnet://cold")
+		require.Equal(t, "warpnet://cold", a.deepLink)
+		require.Empty(t, a.ConsumePendingDeepLink(), "nothing can be consumed before startup")
+	})
+
+	t.Run("started app hands the link over exactly once", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		a.SetPendingDeepLink("warpnet://link")
+		require.Equal(t, "warpnet://link", a.ConsumePendingDeepLink())
+		require.Empty(t, a.ConsumePendingDeepLink())
+	})
+
+	t.Run("notify without a wails context only stashes", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		a.NotifyDeepLink("")
+		require.Empty(t, a.ConsumePendingDeepLink(), "an empty link is ignored")
+
+		a.NotifyDeepLink("warpnet://notified")
+		require.Equal(t, "warpnet://notified", a.ConsumePendingDeepLink())
+	})
+}
+
+func TestNewErrorResp(t *testing.T) {
+	var resp event.ResponseError
+	require.NoError(t, json.Unmarshal(newErrorResp("boom"), &resp))
+	require.Equal(t, "boom", resp.Message)
+	require.Equal(t, 500, resp.Code)
+}
+
+func TestAppCall(t *testing.T) {
+	errBody := func(t *testing.T, raw stdjson.RawMessage) string {
+		t.Helper()
+		var resp event.ResponseError
+		require.NoError(t, json.Unmarshal(raw, &resp))
+		return resp.Message
+	}
+
+	t.Run("uninitialised app", func(t *testing.T) {
+		var a *App
+		resp := a.Call(AppMessage{MessageId: "1", Path: "/x"})
+		require.Contains(t, errBody(t, resp.Body), "not ready")
+
+		bare := NewApp()
+		resp = bare.Call(AppMessage{MessageId: "1", Path: "/x"})
+		require.Contains(t, errBody(t, bare.Call(AppMessage{MessageId: "1"}).Body), "not ready")
+		require.Contains(t, errBody(t, resp.Body), "not ready")
+	})
+
+	t.Run("missing message id", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		resp := a.Call(AppMessage{Path: "/x", Body: []byte("{}")})
+		require.Contains(t, errBody(t, resp.Body), "message id is empty")
+	})
+
+	t.Run("missing body", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		resp := a.Call(AppMessage{MessageId: "1", Path: "/x"})
+		require.Contains(t, errBody(t, resp.Body), "message body is empty")
+	})
+
+	t.Run("login with a malformed payload", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		resp := a.Call(AppMessage{MessageId: "1", Path: event.PRIVATE_POST_LOGIN, Body: []byte("{")})
+		require.NotEmpty(t, errBody(t, resp.Body))
+	})
+
+	t.Run("login failure is reported", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{loginFn: func(event.LoginEvent, security.PSK) (event.LoginResponse, error) {
+			return event.LoginResponse{}, errors.New("wrong password")
+		}}, nil)
+		resp := a.Call(AppMessage{
+			MessageId: "1", Path: event.PRIVATE_POST_LOGIN,
+			Body: mustJSON(t, event.LoginEvent{Username: "u", Password: "p"}),
+		})
+		require.Contains(t, errBody(t, resp.Body), "wrong password")
+	})
+
+	t.Run("login success returns the session", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{loginFn: func(event.LoginEvent, security.PSK) (event.LoginResponse, error) {
+			return event.LoginResponse{Token: "session-token"}, nil
+		}}, nil)
+		resp := a.Call(AppMessage{
+			MessageId: "1", Path: event.PRIVATE_POST_LOGIN,
+			Body: mustJSON(t, event.LoginEvent{Username: "u", Password: "p"}),
+		})
+		var out event.LoginResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &out))
+		require.Equal(t, "session-token", out.Token)
+		require.Equal(t, "1", resp.MessageId)
+	})
+
+	t.Run("logout stops the node", func(t *testing.T) {
+		authSvc := &stubAuthService{}
+		node := &stubNodeServer{}
+		a := liveApp(t, authSvc, node)
+
+		resp := a.Call(AppMessage{MessageId: "1", Path: event.PRIVATE_POST_LOGOUT, Body: []byte("{}")})
+		require.JSONEq(t, `["logged_out"]`, string(resp.Body))
+		require.True(t, node.stopped)
+		require.True(t, authSvc.loggedOut)
+	})
+
+	t.Run("routed call without an attached node", func(t *testing.T) {
+		a := liveApp(t, &stubAuthService{}, nil)
+		resp := a.Call(AppMessage{MessageId: "1", Path: "/private/get/info", Body: []byte("{}")})
+		require.Contains(t, errBody(t, resp.Body), "not attached server node")
+	})
+
+	t.Run("routed call is signed and forwarded", func(t *testing.T) {
+		key := testKey(t)
+		var got event.Message
+		node := &stubNodeServer{streamFn: func(path stream.WarpRoute, data any) ([]byte, error) {
+			got = data.(event.Message)
+			return []byte(`{"ok":true}`), nil
+		}}
+		a := liveApp(t, &stubAuthService{privateKey: key}, node)
+
+		resp := a.Call(AppMessage{
+			MessageId: "42", Path: "/private/get/info", NodeId: "caller-node",
+			Body: []byte(`{"a":1}`), Version: "0.0.1", Timestamp: "2026-01-02T15:04:05Z",
+		})
+		require.JSONEq(t, `{"ok":true}`, string(resp.Body))
+		require.Equal(t, node.info.ID.String(), resp.NodeId)
+
+		require.Equal(t, "/private/get/info", got.Destination)
+		require.Equal(t, "caller-node", got.NodeId)
+		require.False(t, got.Timestamp.IsZero())
+		require.NoError(t, security.VerifySignature(
+			key.Public().(ed25519.PublicKey), got.SigningBytes(), got.Signature,
+		))
+	})
+
+	t.Run("a missing timestamp is stamped now", func(t *testing.T) {
+		var got event.Message
+		node := &stubNodeServer{streamFn: func(_ stream.WarpRoute, data any) ([]byte, error) {
+			got = data.(event.Message)
+			return []byte(`{}`), nil
+		}}
+		a := liveApp(t, &stubAuthService{privateKey: testKey(t)}, node)
+
+		a.Call(AppMessage{MessageId: "1", Path: "/private/get/info", Body: []byte("{}")})
+		require.False(t, got.Timestamp.IsZero())
+	})
+
+	t.Run("stream failure is reported", func(t *testing.T) {
+		node := &stubNodeServer{streamFn: func(stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("stream closed")
+		}}
+		a := liveApp(t, &stubAuthService{privateKey: testKey(t)}, node)
+
+		resp := a.Call(AppMessage{MessageId: "1", Path: "/private/get/info", Body: []byte("{}")})
+		require.Contains(t, errBody(t, resp.Body), "stream closed")
+	})
+
+	t.Run("an empty response body is reported", func(t *testing.T) {
+		node := &stubNodeServer{streamFn: func(stream.WarpRoute, any) ([]byte, error) {
+			return nil, nil
+		}}
+		a := liveApp(t, &stubAuthService{privateKey: testKey(t)}, node)
+
+		resp := a.Call(AppMessage{MessageId: "1", Path: "/private/get/info", Body: []byte("{}")})
+		require.Contains(t, errBody(t, resp.Body), "response body is empty")
+	})
+}
+
+func TestAppClose(t *testing.T) {
+	authSvc := &stubAuthService{}
+	node := &stubNodeServer{}
+	a := liveApp(t, authSvc, node)
+
+	a.close(context.Background())
+	require.True(t, node.stopped)
+	require.True(t, authSvc.loggedOut)
+
+	// a second close panics on the already-closed channel and is recovered
+	require.NotPanics(t, func() { a.close(context.Background()) })
+}
+
+func TestRunNodeStopsWithContext(t *testing.T) {
+	a := liveApp(t, &stubAuthService{}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	a.ctx = ctx
+	cancel()
+
+	// The auth handshake never lands, so runNode must return on the context
+	// rather than dialling a node.
+	done := make(chan struct{})
+	go func() {
+		a.runNode("testnet", nil)
+		close(done)
+	}()
+	<-done
+}
+
+func TestSetLinuxDesktopIconSkipsSnap(t *testing.T) {
+	t.Setenv("SNAP", "/snap/warpnet/current")
+	require.NotPanics(t, func() { setLinuxDesktopIcon([]byte("not-really-a-png")) })
+}
+
+func mustJSON(t *testing.T, v any) stdjson.RawMessage {
+	t.Helper()
+	bt, err := json.Marshal(v)
+	require.NoError(t, err)
+	return bt
+}

--- a/cmd/node/member/deeplink/register_linux_test.go
+++ b/cmd/node/member/deeplink/register_linux_test.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+//nolint:all
+package deeplink
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestXdgAppsDir(t *testing.T) {
+	t.Run("honours XDG_DATA_HOME", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "/tmp/xdg-data")
+		dir, err := xdgAppsDir()
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/xdg-data/applications", dir)
+	})
+
+	t.Run("falls back to the home directory", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", "")
+		dir, err := xdgAppsDir()
+		require.NoError(t, err)
+		require.Contains(t, dir, filepath.Join(".local", "share", "applications"))
+	})
+}
+
+func TestRunShortRejectsMissingBinaries(t *testing.T) {
+	require.Error(t, runShort("warpnet-no-such-command"))
+
+	_, err := runShortOut("warpnet-no-such-command")
+	require.Error(t, err)
+}
+
+func TestRunShortRunsAndCaptures(t *testing.T) {
+	require.NoError(t, runShort("true"))
+	require.Error(t, runShort("false"))
+
+	out, err := runShortOut("echo", "warpnet.desktop")
+	require.NoError(t, err)
+	require.Contains(t, out, "warpnet.desktop")
+
+	_, err = runShortOut("false")
+	require.Error(t, err)
+}
+
+// TestRegisterWritesTheDesktopEntry redirects every XDG root at a temp dir so
+// the registration never touches the developer's real desktop database.
+func TestRegisterWritesTheDesktopEntry(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Setenv("HOME", root)
+
+	// xdg-mime is absent on minimal images: the .desktop file is still written,
+	// and only the association step fails.
+	err := Register()
+
+	desktop := filepath.Join(root, "data", "applications", "warpnet.desktop")
+	require.FileExists(t, desktop)
+
+	contents, readErr := os.ReadFile(desktop)
+	require.NoError(t, readErr)
+	require.Contains(t, string(contents), "x-scheme-handler/"+Scheme)
+	require.Contains(t, string(contents), "StartupWMClass=warpnet")
+
+	if err != nil {
+		require.Contains(t, err.Error(), "deeplink:")
+	}
+}
+
+func TestRegisterFailsWhenTheAppsDirCannotBeCreated(t *testing.T) {
+	root := t.TempDir()
+	// a regular file where the applications directory should go
+	blocked := filepath.Join(root, "data")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o600))
+
+	t.Setenv("XDG_DATA_HOME", blocked)
+	require.Error(t, Register())
+}

--- a/cmd/node/member/node/member-node.go
+++ b/cmd/node/member/node/member-node.go
@@ -185,10 +185,12 @@ func (m *MemberNode) Start() (err error) {
 
 	m.node.SetOutbox(database.NewOutboxRepo(m.db))
 
-	m.pubsubService.Run(m)
+	// Discovery first: the gossip listener feeds DiscoveryHandlerPubSub, which
+	// reads the fields discService.Run sets. Starting pubsub first races them.
 	if err := m.discService.Run(m); err != nil {
 		return err
 	}
+	m.pubsubService.Run(m)
 
 	m.mdnsService.Start(m)
 

--- a/cmd/node/member/node/member-node_test.go
+++ b/cmd/node/member/node/member-node_test.go
@@ -37,8 +37,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	corenode "github.com/Warp-net/warpnet/core/node"
-	"testing"
-
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/database"
 	local_store "github.com/Warp-net/warpnet/database/local-store"
@@ -336,8 +334,7 @@ func TestStartBringsUpTheNode(t *testing.T) {
 	// a stream to an unknown peer fails rather than hanging
 	_, err := m.GenericStream(otherID.String(), "/public/get/info", nil)
 	require.Error(t, err)
-	"github.com/stretchr/testify/require"
-)
+}
 
 // The desktop app stops the node twice: logout (PRIVATE_POST_LOGOUT) stops it,
 // then the wails shutdown hook (App.close) stops it again when the window

--- a/cmd/node/member/node/member-node_test.go
+++ b/cmd/node/member/node/member-node_test.go
@@ -1,0 +1,310 @@
+//nolint:all
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	corenode "github.com/Warp-net/warpnet/core/node"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+func testDB(t *testing.T) *local_store.DB {
+	t.Helper()
+	db, err := local_store.New("", local_store.DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	require.NoError(t, db.Run("test", "test"))
+	t.Cleanup(db.Close)
+	return db
+}
+
+func testKeyAndID(t *testing.T) (ed25519.PrivateKey, warpnet.WarpPeerID) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	return priv, id
+}
+
+// newTestMemberNode builds the node without starting it: NewMemberNode wires
+// every service up, Start is what binds sockets.
+func newTestMemberNode(t *testing.T) (*MemberNode, *local_store.DB, *database.AuthRepo) {
+	t.Helper()
+
+	db := testDB(t)
+	authRepo := database.NewAuthRepo(db, "testnet")
+	require.NoError(t, authRepo.Authenticate("test", "test"))
+	_, err := authRepo.SetOwner(domain.Owner{UserId: "owner-1", Username: "owner"})
+	require.NoError(t, err)
+
+	privKey, ownNodeId := testKeyAndID(t)
+	psk, err := security.GeneratePSK("testnet", semver.MustParse("0.0.0"))
+	require.NoError(t, err)
+
+	m, err := NewMemberNode(context.Background(), privKey, psk, ownNodeId, authRepo, db, nil)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	t.Cleanup(m.Stop)
+	return m, db, authRepo
+}
+
+func TestNewMemberNodeRequiresPrivateKey(t *testing.T) {
+	db := testDB(t)
+	authRepo := database.NewAuthRepo(db, "testnet")
+	require.NoError(t, authRepo.Authenticate("test", "test"))
+
+	_, err := NewMemberNode(context.Background(), nil, nil, "", authRepo, db, nil)
+	require.ErrorIs(t, err, corenode.ErrPrivateKeyRequired)
+}
+
+func TestNewMemberNodeWiresServices(t *testing.T) {
+	m, _, _ := newTestMemberNode(t)
+
+	require.NotNil(t, m.discService)
+	require.NotNil(t, m.mdnsService)
+	require.NotNil(t, m.pubsubService)
+	require.NotNil(t, m.dHashTable)
+	require.NotNil(t, m.nodeRepo)
+	require.NotNil(t, m.userRepo)
+	require.Equal(t, "owner-1", m.ownerId)
+	require.NotEmpty(t, m.opts)
+
+	// The mastodon entry account is seeded so the bridge is reachable.
+	entry, err := m.userRepo.Get("warpnet@mastodon.social")
+	require.NoError(t, err)
+	require.Equal(t, "mastodon", entry.Network)
+}
+
+func TestNewMemberNodeCarriesFollowings(t *testing.T) {
+	db := testDB(t)
+	authRepo := database.NewAuthRepo(db, "testnet")
+	require.NoError(t, authRepo.Authenticate("test", "test"))
+	_, err := authRepo.SetOwner(domain.Owner{UserId: "owner-1"})
+	require.NoError(t, err)
+
+	followRepo := database.NewFollowRepo(db)
+	require.NoError(t, followRepo.Follow("owner-1", "followed-1"))
+
+	privKey, ownNodeId := testKeyAndID(t)
+	psk, err := security.GeneratePSK("testnet", semver.MustParse("0.0.0"))
+	require.NoError(t, err)
+
+	m, err := NewMemberNode(context.Background(), privKey, psk, ownNodeId, authRepo, db, nil)
+	require.NoError(t, err)
+	t.Cleanup(m.Stop)
+}
+
+func TestFetchFollowingIds(t *testing.T) {
+	t.Run("nil repo yields nothing", func(t *testing.T) {
+		ids, err := fetchFollowingIds("owner-1", nil)
+		require.NoError(t, err)
+		require.Empty(t, ids)
+	})
+
+	t.Run("skips the owner and pages through", func(t *testing.T) {
+		repo := &pagedFollowStore{pages: [][]domain.ID{
+			// a full page (limit is 20) forces a second round
+			append(idRange(19), "owner-1"),
+			{"late-1"},
+		}}
+		ids, err := fetchFollowingIds("owner-1", repo)
+		require.NoError(t, err)
+		require.NotContains(t, ids, domain.ID("owner-1"))
+		require.Contains(t, ids, "late-1")
+		require.Len(t, ids, 20)
+	})
+
+	t.Run("a lookup failure surfaces", func(t *testing.T) {
+		repo := &pagedFollowStore{err: errors.New("store down")}
+		_, err := fetchFollowingIds("owner-1", repo)
+		require.Error(t, err)
+	})
+}
+
+func idRange(n int) []domain.ID {
+	out := make([]domain.ID, 0, n)
+	for i := range n {
+		out = append(out, domain.ID(string(rune('a'+i%26)))+domain.ID(rune('0'+i/26)))
+	}
+	return out
+}
+
+// pagedFollowStore serves a fixed sequence of following pages.
+type pagedFollowStore struct {
+	pages [][]domain.ID
+	calls int
+	err   error
+}
+
+func (p *pagedFollowStore) GetFollowings(_ string, _ *uint64, _ *string) ([]domain.ID, string, error) {
+	if p.err != nil {
+		return nil, "", p.err
+	}
+	if p.calls >= len(p.pages) {
+		return nil, "", nil
+	}
+	page := p.pages[p.calls]
+	p.calls++
+	return page, "cursor", nil
+}
+
+func (p *pagedFollowStore) GetFollowersCount(string) (uint64, error)  { return 0, nil }
+func (p *pagedFollowStore) GetFollowingsCount(string) (uint64, error) { return 0, nil }
+func (p *pagedFollowStore) Follow(string, string) error               { return nil }
+func (p *pagedFollowStore) Unfollow(string, string) error             { return nil }
+func (p *pagedFollowStore) GetFollowers(string, *uint64, *string) ([]domain.ID, string, error) {
+	return nil, "", nil
+}
+func (p *pagedFollowStore) IsFollowing(string, string) bool          { return false }
+func (p *pagedFollowStore) IsFollower(string, string) bool           { return false }
+func (p *pagedFollowStore) AddFollowRequest(string, string) error    { return nil }
+func (p *pagedFollowStore) RemoveFollowRequest(string, string) error { return nil }
+func (p *pagedFollowStore) ListFollowRequests(string, *uint64, *string) ([]domain.ID, string, error) {
+	return nil, "", nil
+}
+
+// TestHandlerListsAreComplete builds every per-feature handler list. They are
+// pure route tables, so this both covers them and guards against a duplicate
+// route silently shadowing another.
+func TestHandlerListsAreComplete(t *testing.T) {
+	m, db, authRepo := newTestMemberNode(t)
+
+	statsDB := database.NewStatsRepo(db)
+	r := &memberRepos{
+		timelineRepo:     database.NewTimelineRepo(db),
+		tweetRepo:        database.NewTweetRepo(db, nil),
+		reactionRepo:     database.NewReactionRepo(db, nil),
+		pollRepo:         database.NewPollRepo(db, nil),
+		chatRepo:         database.NewChatRepo(db),
+		mediaRepo:        database.NewMediaRepo(db),
+		notificationRepo: database.NewNotificationsRepo(db),
+		settingsRepo:     database.NewSettingsRepo(db),
+		bookmarkRepo:     database.NewBookmarkRepo(db),
+		blocksRepo:       database.NewBlocksRepo(db),
+		mutesRepo:        database.NewMutesRepo(db),
+		subsRepo:         database.NewSubscriptionsRepo(db),
+		filterRepo:       database.NewFilterRepo(db),
+	}
+	_ = statsDB
+
+	followRepo := database.NewFollowRepo(db)
+	userRepo := database.NewUserRepo(db)
+
+	lists := map[string][]warpnet.WarpStreamHandler{
+		"admin":         m.adminHandlers(authRepo, db, r),
+		"tweet":         m.tweetHandlers(authRepo, userRepo, r),
+		"engagement":    m.engagementHandlers(userRepo, r),
+		"follow":        m.followHandlers(authRepo, userRepo, followRepo),
+		"followRequest": m.followRequestHandlers(followRepo),
+		"filter":        m.filterHandlers(r),
+		"user":          m.userHandlers(authRepo, userRepo, followRepo, r),
+		"chat":          m.chatHandlers(authRepo, userRepo, r),
+		"media":         m.mediaHandlers(userRepo, r),
+		"notification":  m.notificationHandlers(authRepo, r),
+		"settings":      m.settingsHandlers(authRepo, r),
+		"socialFilter":  m.socialFilterHandlers(userRepo, r),
+		"bookmarks":     m.bookmarksHandlers(r),
+	}
+
+	seen := map[string]string{}
+	total := 0
+	for group, hs := range lists {
+		require.NotEmpty(t, hs, "%s handlers must not be empty", group)
+		for _, h := range hs {
+			require.NotNil(t, h.Handler, "%s: %s has no handler", group, h.Path)
+			if prev, ok := seen[string(h.Path)]; ok {
+				t.Fatalf("route %s registered by both %s and %s", h.Path, prev, group)
+			}
+			seen[string(h.Path)] = group
+			total++
+		}
+	}
+	require.Greater(t, total, 50, "the member node exposes the full route table")
+}
+
+func TestSetupHandlersRejectsNilNode(t *testing.T) {
+	var m *MemberNode
+	require.Panics(t, func() { m.setupHandlers(nil, nil, nil, nil, nil) })
+}
+
+func TestAccessorsAreNilSafeBeforeStart(t *testing.T) {
+	m, _, _ := newTestMemberNode(t)
+
+	// Start has not run, so the libp2p node is absent: every accessor must
+	// answer rather than dereference it.
+	require.Nil(t, m.Node())
+	require.Nil(t, m.Peerstore())
+	require.Nil(t, m.Network())
+	require.Nil(t, m.PublicAddrs())
+	require.NoError(t, m.Connect(warpnet.WarpAddrInfo{}))
+
+	var nilNode *MemberNode
+	require.Nil(t, nilNode.Node())
+	require.Nil(t, nilNode.Peerstore())
+	require.Nil(t, nilNode.Network())
+	require.Nil(t, nilNode.PublicAddrs())
+	require.NoError(t, nilNode.Connect(warpnet.WarpAddrInfo{}))
+	require.NotPanics(t, nilNode.Stop)
+}
+
+func TestSetUserOffline(t *testing.T) {
+	m, db, _ := newTestMemberNode(t)
+
+	userRepo := database.NewUserRepo(db)
+	_, err := userRepo.Create(domain.User{Id: "user-1", NodeId: "12D3KooWOfflineNode"})
+	require.NoError(t, err)
+
+	// unknown node: nothing to flag, and no panic
+	require.NotPanics(t, func() { m.setUserOffline("12D3KooWUnknownNode") })
+
+	m.setUserOffline("12D3KooWOfflineNode")
+	got, err := userRepo.Get("user-1")
+	require.NoError(t, err)
+	require.True(t, got.IsOffline)
+
+	// already offline: the second call is a no-op
+	require.NotPanics(t, func() { m.setUserOffline("12D3KooWOfflineNode") })
+}
+
+// TestStartBringsUpTheNode exercises the full startup path: libp2p host,
+// pubsub, discovery, mDNS, the CRDT stats store and the route table. It binds
+// the configured port, so it skips when something else already holds it.
+func TestStartBringsUpTheNode(t *testing.T) {
+	m, _, _ := newTestMemberNode(t)
+
+	if err := m.Start(); err != nil {
+		t.Skipf("cannot bind the configured node port: %v", err)
+	}
+
+	info := m.NodeInfo()
+	require.Equal(t, warpnet.MemberNode, info.Type)
+	require.Equal(t, "owner-1", info.OwnerId)
+	require.NotEmpty(t, info.Addresses)
+
+	require.NotNil(t, m.Node())
+	require.NotNil(t, m.Peerstore())
+	require.NotNil(t, m.Network())
+	require.NotNil(t, m.PublicAddrs())
+
+	// priority tuning is a no-op on an unknown peer but must not panic
+	_, otherID := testKeyAndID(t)
+	require.NotPanics(t, func() {
+		m.SetMaxNodePriority(otherID)
+		m.SetMinNodePriority(otherID)
+		m.SetNodePriority(otherID, warpnet.WarpReachability(0))
+	})
+
+	// a stream to an unknown peer fails rather than hanging
+	_, err := m.GenericStream(otherID.String(), "/public/get/info", nil)
+	require.Error(t, err)
+}

--- a/cmd/node/member/remote/bridge_branches_test.go
+++ b/cmd/node/member/remote/bridge_branches_test.go
@@ -1,0 +1,152 @@
+//nolint:all
+package remote
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/flynn/noise"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSameOrigin(t *testing.T) {
+	req := func(origin string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "http://node.local/ws", nil)
+		r.Host = "node.local"
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		return r
+	}
+
+	require.True(t, sameOrigin(req("")), "non-browser clients send no Origin")
+	require.True(t, sameOrigin(req("http://node.local")))
+	require.True(t, sameOrigin(req("https://node.local")))
+	require.False(t, sameOrigin(req("http://evil.example")))
+	require.False(t, sameOrigin(req("://not-a-url")))
+}
+
+func TestEnrolmentIgnoresEmptyKeys(t *testing.T) {
+	b := NewBridgeHandler(nil, nil, nil, nil)
+
+	require.False(t, b.isEnrolled(nil))
+	b.enroll(nil)
+	require.False(t, b.isEnrolled(nil))
+
+	b.enroll([]byte("client-key"))
+	require.True(t, b.isEnrolled([]byte("client-key")))
+	require.False(t, b.isEnrolled([]byte("other-key")))
+}
+
+func TestHandleRejectsCrossOriginUpgrades(t *testing.T) {
+	srv, _, _ := newTestBridge(t)
+
+	header := http.Header{}
+	header.Set("Origin", "http://evil.example")
+
+	_, resp, err := websocket.DefaultDialer.Dial(
+		"ws"+strings.TrimPrefix(srv.URL, "http")+"/ws", header,
+	)
+	require.Error(t, err, "a page on another origin must not open the bridge")
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	}
+}
+
+func TestHandleRejectsAFailedHandshake(t *testing.T) {
+	srv, _, _ := newTestBridge(t)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(
+		"ws"+strings.TrimPrefix(srv.URL, "http")+"/ws", http.Header{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// garbage instead of the first Noise message: the server must drop us
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, []byte("not-a-handshake")))
+
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+}
+
+func TestHandleDropsUndecryptableFrames(t *testing.T) {
+	srv, _, _ := newTestBridge(t)
+	c := dial(t, srv, clientKey(t))
+
+	require.NoError(t, c.conn.WriteMessage(websocket.BinaryMessage, []byte("garbage")))
+
+	_, _, err := c.conn.ReadMessage()
+	require.Error(t, err, "a frame that fails to decrypt closes the connection")
+}
+
+func TestHandleSkipsMalformedEnvelopes(t *testing.T) {
+	srv, _, _ := newTestBridge(t)
+	c := dial(t, srv, clientKey(t))
+
+	sealed, err := c.session.Encrypt([]byte("{"))
+	require.NoError(t, err)
+	require.NoError(t, c.conn.WriteMessage(websocket.BinaryMessage, sealed))
+
+	// the connection survives: a well-formed request still gets an answer
+	resp := c.send(t, pathIsFirstRun, struct{}{})
+	require.NotNil(t, resp.Body)
+}
+
+func TestLoginRejectsAMalformedPayload(t *testing.T) {
+	srv, _, _ := newTestBridge(t)
+	c := dial(t, srv, clientKey(t))
+
+	resp := c.send(t, event.PRIVATE_POST_LOGIN, json.RawMessage(`"not-an-object"`))
+	require.NotEmpty(t, responseError(t, resp).Message)
+}
+
+func TestCallWithoutAnAttachedNode(t *testing.T) {
+	staticKey, err := noise.NewCipherSuite(noise.DH25519, noise.CipherChaChaPoly, noise.HashSHA256).
+		GenerateKeypair(nil)
+	require.NoError(t, err)
+
+	auth := newFakeAuth(t)
+	// deliberately no AttachNode: the dispatcher must say so instead of panicking
+	handler := NewBridgeHandler(
+		func(read func() ([]byte, error), write func([]byte) error) (Channel, error) {
+			return security.NoiseHandshake(staticKey, read, write)
+		},
+		auth,
+		security.PSK("test-psk"),
+		func() bool { return false },
+	)
+	srv := httptest.NewServer(handler.Handle())
+	t.Cleanup(srv.Close)
+
+	c := dial(t, srv, clientKey(t))
+	c.send(t, event.PRIVATE_POST_LOGIN, event.LoginEvent{Username: testUsername, Password: testPassword})
+
+	resp := c.send(t, event.PRIVATE_POST_TWEET, struct{}{})
+	require.Contains(t, responseError(t, resp).Message, "not attached server node")
+}
+
+func TestNewStaticHandler(t *testing.T) {
+	h, err := NewStaticHandler()
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	t.Run("serves the index for the root", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("falls back to the index for client-side routes", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/profile/someone", nil))
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+}

--- a/cmd/node/moderator/audit/wiring_test.go
+++ b/cmd/node/moderator/audit/wiring_test.go
@@ -1,0 +1,170 @@
+//nolint:all
+package audit
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	mrand "math/rand"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+type stubEngine struct {
+	ok     bool
+	reason string
+	err    error
+}
+
+func (e stubEngine) Moderate(string) (bool, string, error) {
+	return e.ok, e.reason, e.err
+}
+
+func challengeFor(text string) Challenge {
+	return Challenge{ChallengeID: "challenge-1", Text: text, ContentHash: ContentHash(text)}
+}
+
+func TestStreamChallengeHandler(t *testing.T) {
+	t.Run("rejects a malformed payload", func(t *testing.T) {
+		_, err := StreamChallengeHandler(stubEngine{}, nil)([]byte("{"), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an empty challenge", func(t *testing.T) {
+		body, err := json.Marshal(Challenge{ChallengeID: "challenge-1"})
+		require.NoError(t, err)
+
+		_, err = StreamChallengeHandler(stubEngine{}, nil)(body, nil)
+		require.ErrorIs(t, err, ErrEmptyChallenge)
+	})
+
+	t.Run("rejects a hash that does not bind the text", func(t *testing.T) {
+		body, err := json.Marshal(Challenge{
+			ChallengeID: "challenge-1", Text: "judge me", ContentHash: "not-the-hash",
+		})
+		require.NoError(t, err)
+
+		_, err = StreamChallengeHandler(stubEngine{}, nil)(body, nil)
+		require.ErrorIs(t, err, ErrChallengeHashMismatch)
+	})
+
+	t.Run("surfaces an engine failure", func(t *testing.T) {
+		engineErr := errors.New("model unavailable")
+		body, err := json.Marshal(challengeFor("judge me"))
+		require.NoError(t, err)
+
+		_, err = StreamChallengeHandler(stubEngine{err: engineErr}, nil)(body, nil)
+		require.ErrorIs(t, err, engineErr)
+	})
+
+	t.Run("answers unsigned when no signer is wired", func(t *testing.T) {
+		body, err := json.Marshal(challengeFor("judge me"))
+		require.NoError(t, err)
+
+		out, err := StreamChallengeHandler(stubEngine{ok: true, reason: "fine"}, nil)(body, nil)
+		require.NoError(t, err)
+
+		resp := out.(ChallengeResponse)
+		require.Equal(t, "challenge-1", resp.ChallengeID)
+		require.Equal(t, ContentHash("judge me"), resp.ContentHash)
+		require.Equal(t, domain.OK, resp.Result)
+		require.Empty(t, resp.Signature)
+	})
+
+	t.Run("signs the answer when a signer is wired", func(t *testing.T) {
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		body, err := json.Marshal(challengeFor("judge me"))
+		require.NoError(t, err)
+
+		signer := NewResponseSigner(priv, "moderator-1", "llama-guard")
+		out, err := StreamChallengeHandler(stubEngine{ok: false, reason: "violent"}, signer)(body, nil)
+		require.NoError(t, err)
+
+		resp := out.(ChallengeResponse)
+		require.NotEmpty(t, resp.Signature)
+		require.Equal(t, domain.ID("moderator-1"), resp.ModeratorID)
+		require.Equal(t, domain.ModelType("llama-guard"), resp.Model)
+	})
+}
+
+type stubStreamer struct {
+	resp []byte
+	err  error
+}
+
+func (s stubStreamer) GenericStream(string, stream.WarpRoute, any) ([]byte, error) {
+	return s.resp, s.err
+}
+
+func TestStreamChallengerAsk(t *testing.T) {
+	ch := challengeFor("judge me")
+
+	t.Run("surfaces a transport failure", func(t *testing.T) {
+		streamErr := errors.New("peer offline")
+		_, err := NewStreamChallenger(stubStreamer{err: streamErr}).Ask("peer-1", ch)
+		require.ErrorIs(t, err, streamErr)
+	})
+
+	t.Run("refuses to read an error envelope as an answer", func(t *testing.T) {
+		body, err := json.Marshal(event.ResponseError{Message: "no thanks"})
+		require.NoError(t, err)
+
+		_, err = NewStreamChallenger(stubStreamer{resp: body}).Ask("peer-1", ch)
+		require.ErrorIs(t, err, ErrChallengeRefused)
+	})
+
+	t.Run("surfaces a malformed answer", func(t *testing.T) {
+		_, err := NewStreamChallenger(stubStreamer{resp: []byte("{")}).Ask("peer-1", ch)
+		require.Error(t, err)
+	})
+
+	t.Run("decodes the answer", func(t *testing.T) {
+		body, err := json.Marshal(ChallengeResponse{
+			ChallengeID: ch.ChallengeID, ContentHash: ch.ContentHash, Result: domain.OK,
+		})
+		require.NoError(t, err)
+
+		resp, err := NewStreamChallenger(stubStreamer{resp: body}).Ask("peer-1", ch)
+		require.NoError(t, err)
+		require.Equal(t, ch.ChallengeID, resp.ChallengeID)
+	})
+}
+
+func TestStandingString(t *testing.T) {
+	require.Equal(t, "probation", StandingProbation.String())
+	require.Equal(t, "trusted", StandingTrusted.String())
+	require.Equal(t, "suspect", StandingSuspect.String())
+	require.Equal(t, "banned", StandingBanned.String())
+	require.Equal(t, "unknown", Standing(99).String())
+}
+
+func TestLedgerIgnoresAnEmptyPeer(t *testing.T) {
+	l := NewLedger()
+	l.Record("", OutcomeCorrect)
+	require.Empty(t, l.Snapshot())
+}
+
+func TestLedgerUnknownPeerIsOnProbation(t *testing.T) {
+	require.Equal(t, StandingProbation, NewLedger().StandingOf("never-seen"))
+}
+
+func TestCorpusIgnoresEmptyText(t *testing.T) {
+	c := NewCorpus()
+	c.Remember("", domain.OK)
+	safe, unsafe := c.Len()
+	require.Zero(t, safe)
+	require.Zero(t, unsafe)
+}
+
+func TestChallengeRandomPeerNeedsACorpus(t *testing.T) {
+	a := NewAuditor("self", nil, NewLedger(), NewCorpus(), mrand.New(mrand.NewSource(1)))
+	require.Nil(t, a.ChallengeRandomPeer([]string{"peer-1"}),
+		"an empty corpus has nothing to ask about")
+}

--- a/cmd/node/moderator/isolation/isolation-protocol_test.go
+++ b/cmd/node/moderator/isolation/isolation-protocol_test.go
@@ -1,0 +1,123 @@
+//nolint:all
+package isolation
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingPublisher struct {
+	err        error
+	ownerIds   []string
+	dests      []string
+	published  []event.ModerationVerdictEvent
+	callsCount int
+}
+
+func (p *recordingPublisher) PublishUpdateToFollowers(ownerId, dest string, body any) error {
+	p.callsCount++
+	p.ownerIds = append(p.ownerIds, ownerId)
+	p.dests = append(p.dests, dest)
+	if ev, ok := body.(event.ModerationVerdictEvent); ok {
+		p.published = append(p.published, ev)
+	}
+	return p.err
+}
+
+func testKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return priv
+}
+
+func TestIsolateTweet(t *testing.T) {
+	reason := "spam"
+	tweet := &domain.Tweet{Id: "tweet-1", UserId: "author-1"}
+	moderation := &domain.TweetModeration{
+		ModeratorID: "moderator-1",
+		Model:       "llama-guard",
+		IsOk:        domain.FAIL,
+		Reason:      &reason,
+	}
+	voters := []domain.ID{"moderator-1", "moderator-2"}
+
+	t.Run("publishes a signed verdict to the author's followers", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		NewIsolationProtocol(pub, testKey(t)).IsolateTweet(tweet, moderation, voters)
+
+		require.Equal(t, 1, pub.callsCount)
+		require.Equal(t, []string{"author-1"}, pub.ownerIds)
+		require.Equal(t, []string{event.PUBLIC_POST_MODERATION_RESULT}, pub.dests)
+
+		require.Len(t, pub.published, 1)
+		got := pub.published[0]
+		require.Equal(t, domain.ModerationTweetType, got.Type)
+		require.Equal(t, domain.ID("author-1"), got.UserID)
+		require.NotNil(t, got.ObjectID)
+		require.Equal(t, domain.ID("tweet-1"), *got.ObjectID)
+		require.Equal(t, voters, got.Voters)
+		require.NotEmpty(t, got.Signature, "the verdict must carry the moderator's signature")
+	})
+
+	t.Run("nil inputs publish nothing", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		ip := NewIsolationProtocol(pub, testKey(t))
+		ip.IsolateTweet(nil, moderation, voters)
+		ip.IsolateTweet(tweet, nil, voters)
+		require.Zero(t, pub.callsCount)
+	})
+
+	t.Run("a publish failure is logged, not returned", func(t *testing.T) {
+		pub := &recordingPublisher{err: errors.New("no subscribers")}
+		NewIsolationProtocol(pub, testKey(t)).IsolateTweet(tweet, moderation, voters)
+		require.Equal(t, 1, pub.callsCount)
+	})
+}
+
+func TestIsolateUser(t *testing.T) {
+	reason := "abuse"
+	user := &domain.User{Id: "user-1"}
+	moderation := &domain.UserModeration{
+		Model:  "llama-guard",
+		IsOk:   false,
+		Reason: &reason,
+	}
+	voters := []domain.ID{"moderator-1"}
+
+	t.Run("publishes a signed verdict on the user's own topic", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		NewIsolationProtocol(pub, testKey(t)).IsolateUser("moderator-1", user, moderation, voters)
+
+		require.Equal(t, 1, pub.callsCount)
+		require.Equal(t, []string{"user-1"}, pub.ownerIds)
+
+		require.Len(t, pub.published, 1)
+		got := pub.published[0]
+		require.Equal(t, domain.ModerationUserType, got.Type)
+		require.Equal(t, domain.ID("user-1"), got.UserID)
+		require.Equal(t, domain.ID("moderator-1"), got.ModeratorID)
+		require.Nil(t, got.ObjectID, "a user verdict names no object")
+		require.NotEmpty(t, got.Signature)
+	})
+
+	t.Run("nil inputs publish nothing", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		ip := NewIsolationProtocol(pub, testKey(t))
+		ip.IsolateUser("moderator-1", nil, moderation, voters)
+		ip.IsolateUser("moderator-1", user, nil, voters)
+		require.Zero(t, pub.callsCount)
+	})
+
+	t.Run("a publish failure is logged, not returned", func(t *testing.T) {
+		pub := &recordingPublisher{err: errors.New("no subscribers")}
+		NewIsolationProtocol(pub, testKey(t)).IsolateUser("moderator-1", user, moderation, voters)
+		require.Equal(t, 1, pub.callsCount)
+	})
+}

--- a/cmd/node/moderator/main_test.go
+++ b/cmd/node/moderator/main_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+//nolint:all
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestMainRunsAndShutsDownOnInterrupt drives the moderator entry point end to
+// end: it boots the node and the vote pubsub, then delivers the interrupt
+// main() waits for.
+//
+// The test registers its own signal handler first. That installs Go's handler
+// process-wide and disables the default terminate-on-SIGINT behaviour, so the
+// signal below can never kill the test binary — even if main() returned early
+// (a busy port, say) before registering its own.
+func TestMainRunsAndShutsDownOnInterrupt(t *testing.T) {
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, os.Interrupt, syscall.SIGINT)
+	t.Cleanup(func() { signal.Stop(guard) })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		main()
+	}()
+
+	// give main() time to reach its own signal.Notify
+	time.Sleep(2 * time.Second)
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("deliver interrupt: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("the moderator did not shut down after the interrupt")
+	}
+}

--- a/cmd/node/moderator/node/moderator-node_test.go
+++ b/cmd/node/moderator/node/moderator-node_test.go
@@ -1,0 +1,115 @@
+//nolint:all
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+func testKeyAndID(t *testing.T) (ed25519.PrivateKey, warpnet.WarpPeerID) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	return priv, id
+}
+
+func newTestModeratorNode(t *testing.T) *ModeratorNode {
+	t.Helper()
+	privKey, ownNodeId := testKeyAndID(t)
+	psk, err := security.GeneratePSK("testnet", semver.MustParse("0.0.0"))
+	require.NoError(t, err)
+
+	mn, err := NewModeratorNode(context.Background(), privKey, psk, ownNodeId)
+	require.NoError(t, err)
+	require.NotNil(t, mn)
+	t.Cleanup(mn.Stop)
+	return mn
+}
+
+// startWithRetry works around the fixed listen port in the config: another
+// package's node test may hold it for a few seconds.
+func startWithRetry(t *testing.T, start func() error) bool {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		err := start()
+		if err == nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			t.Logf("skipping: cannot bind the configured node port: %v", err)
+			return false
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func TestNewModeratorNodeWiresServices(t *testing.T) {
+	mn := newTestModeratorNode(t)
+
+	require.NotNil(t, mn.dHashTable)
+	require.NotNil(t, mn.memoryStoreCloseF)
+	require.NotNil(t, mn.isClosed)
+	require.NotEmpty(t, mn.options)
+	require.NotNil(t, mn.version)
+}
+
+func TestModeratorStartRejectsNilNode(t *testing.T) {
+	var mn *ModeratorNode
+	require.Panics(t, func() { _ = mn.Start() })
+	require.NotPanics(t, mn.Stop)
+}
+
+func TestModeratorSelfStreamIsNotImplemented(t *testing.T) {
+	mn := newTestModeratorNode(t)
+	_, err := mn.SelfStream("", "", "/public/get/info", nil)
+	require.ErrorIs(t, err, warpnet.ErrNotImplemented)
+}
+
+func TestModeratorGenericStreamRejectsMalformedNodeId(t *testing.T) {
+	mn := newTestModeratorNode(t)
+	_, err := mn.GenericStream("not-a-peer-id", "/public/get/info", nil)
+	require.ErrorIs(t, err, warpnet.ErrMalformedNodeId)
+}
+
+// TestModeratorStart drives the full startup: libp2p host, middlewares and the
+// /public/get/info route.
+func TestModeratorStart(t *testing.T) {
+	mn := newTestModeratorNode(t)
+
+	if !startWithRetry(t, mn.Start) {
+		t.Skip("configured node port is busy")
+	}
+
+	info := mn.NodeInfo()
+	require.Equal(t, warpnet.ModeratorNode, info.Type)
+	require.Equal(t, "None", info.OwnerId)
+	require.NotEmpty(t, info.Addresses)
+
+	require.NotNil(t, mn.Node())
+	require.Equal(t, mn.Node().ID(), mn.ID())
+
+	// registering an extra route after startup must not disturb the node
+	require.NotPanics(t, func() {
+		mn.SetStreamHandlers(warpnet.WarpStreamHandler{
+			Path:    "/public/get/moderation",
+			Handler: func([]byte, warpnet.WarpStream) (any, error) { return nil, nil },
+		})
+	})
+
+	require.Empty(t, mn.ClosestPeers(), "an isolated moderator knows no peers")
+
+	_, otherID := testKeyAndID(t)
+	_, err := mn.GenericStream(otherID.String(), "/public/get/info", nil)
+	require.Error(t, err)
+}

--- a/cmd/node/moderator/pubsub/publisher_live_test.go
+++ b/cmd/node/moderator/pubsub/publisher_live_test.go
@@ -1,0 +1,93 @@
+//nolint:all
+package pubsub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/cmd/node/moderator/vote"
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
+)
+
+// liveNode is the minimal PubsubServerNodeConnector backed by a real libp2p
+// host on loopback — gossip refuses to start without one.
+type liveNode struct{ host warpnet.P2PNode }
+
+func (n *liveNode) Node() warpnet.P2PNode { return n.host }
+
+func (n *liveNode) NodeInfo() warpnet.NodeInfo {
+	return warpnet.NodeInfo{ID: n.host.ID(), OwnerId: "moderator-owner"}
+}
+
+func (n *liveNode) SelfStream(_, _ warpnet.WarpPeerID, _ stream.WarpRoute, _ any) ([]byte, error) {
+	return nil, nil
+}
+
+func (n *liveNode) GenericStream(_ string, _ stream.WarpRoute, _ any) ([]byte, error) {
+	return nil, nil
+}
+
+func runningPubSub(t *testing.T) *moderatorPubSub {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+
+	g := NewPubSub(ctx)
+	require.NoError(t, g.Run(&liveNode{host: h}))
+	t.Cleanup(func() { _ = g.Close() })
+	return g
+}
+
+func TestModeratorPubSubRunIsIdempotent(t *testing.T) {
+	g := runningPubSub(t)
+	require.NoError(t, g.Run(nil), "a second Run must be a no-op, not a restart")
+}
+
+func TestModeratorPubSubPublishAndSubscribe(t *testing.T) {
+	g := runningPubSub(t)
+
+	reports := make(chan event.ReportEvent, 1)
+	require.NoError(t, g.SubscribeReports(func(ev event.ReportEvent) error {
+		reports <- ev
+		return nil
+	}))
+
+	votes := make(chan vote.Event, 1)
+	require.NoError(t, g.SubscribeVotes(func(ev vote.Event) error {
+		votes <- ev
+		return nil
+	}))
+
+	require.NoError(t, g.PublishVote(vote.Event{
+		ReportID: "report-1",
+		Type:     domain.ModerationTweetType,
+		Result:   domain.FAIL,
+	}))
+
+	select {
+	case got := <-votes:
+		require.Equal(t, "report-1", got.ReportID)
+		require.NotEmpty(t, got.ModeratorID, "the voter id comes from the verified envelope")
+	case <-time.After(10 * time.Second):
+		t.Fatal("published vote never came back on the votes topic")
+	}
+
+	require.NoError(t, g.PublishUpdateToFollowers(
+		"owner-1", event.PUBLIC_POST_MODERATION_RESULT, event.ModerationVerdictEvent{UserID: "owner-1"},
+	))
+}
+
+func TestModeratorPubSubPublishRejectsUnmarshalableBody(t *testing.T) {
+	g := runningPubSub(t)
+	require.Error(t, g.PublishUpdateToFollowers("owner-1", "dest", make(chan int)))
+}

--- a/cmd/node/moderator/pubsub/publisher_test.go
+++ b/cmd/node/moderator/pubsub/publisher_test.go
@@ -1,0 +1,122 @@
+//nolint:all
+package pubsub
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/cmd/node/moderator/vote"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+// signedEnvelope builds a gossip envelope signed by a freshly minted node key,
+// mirroring what Gossip.Publish puts on the wire.
+func signedEnvelope(t *testing.T, body any) ([]byte, string) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	peerID, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	msg := event.Message{
+		Body:      bodyBytes,
+		NodeId:    peerID.String(),
+		Timestamp: time.Now(),
+		MessageId: "msg-1",
+		Version:   "0.0.0",
+	}
+	msg.Signature = security.Sign(priv, msg.SigningBytes())
+
+	raw, err := json.Marshal(msg)
+	require.NoError(t, err)
+	return raw, peerID.String()
+}
+
+func TestVerifiedEnvelope(t *testing.T) {
+	t.Run("garbage is an error", func(t *testing.T) {
+		msg, err := verifiedEnvelope("votes", []byte("{"))
+		require.Error(t, err)
+		require.Nil(t, msg)
+	})
+
+	t.Run("malformed node id is dropped silently", func(t *testing.T) {
+		raw, err := json.Marshal(event.Message{NodeId: "not-a-peer-id"})
+		require.NoError(t, err)
+
+		msg, err := verifiedEnvelope("votes", raw)
+		require.NoError(t, err)
+		require.Nil(t, msg)
+	})
+
+	t.Run("a forged signature is dropped silently", func(t *testing.T) {
+		raw, _ := signedEnvelope(t, vote.Event{ReportID: "r-1"})
+
+		var msg event.Message
+		require.NoError(t, json.Unmarshal(raw, &msg))
+		msg.Signature = "not-the-signature"
+		tampered, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		got, err := verifiedEnvelope("votes", tampered)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("a tampered body is dropped silently", func(t *testing.T) {
+		raw, _ := signedEnvelope(t, vote.Event{ReportID: "r-1"})
+
+		var msg event.Message
+		require.NoError(t, json.Unmarshal(raw, &msg))
+		msg.Body = []byte(`{"report_id":"r-2"}`)
+		tampered, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		got, err := verifiedEnvelope("votes", tampered)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("a correctly signed envelope passes", func(t *testing.T) {
+		raw, nodeId := signedEnvelope(t, vote.Event{ReportID: "r-1"})
+
+		msg, err := verifiedEnvelope("votes", raw)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		require.Equal(t, nodeId, msg.NodeId)
+	})
+}
+
+// A moderator pubsub whose gossip has never run must refuse every operation
+// rather than publishing into the void.
+func TestModeratorPubSubBeforeRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	g := NewPubSub(ctx)
+	require.NotNil(t, g)
+
+	require.Error(t, g.PublishUpdateToFollowers("owner-1", event.PUBLIC_POST_MODERATION_RESULT, struct{}{}))
+	require.Error(t, g.PublishVote(vote.Event{ReportID: "r-1"}))
+	require.Error(t, g.SubscribeReports(func(event.ReportEvent) error { return nil }))
+	require.Error(t, g.SubscribeVotes(func(vote.Event) error { return nil }))
+	require.NoError(t, g.Close())
+}
+
+func TestModeratorPubSubNilReceiver(t *testing.T) {
+	var g *moderatorPubSub
+	require.Error(t, g.PublishUpdateToFollowers("owner-1", "dest", struct{}{}))
+	require.Error(t, g.PublishVote(vote.Event{}))
+	require.Error(t, g.SubscribeReports(func(event.ReportEvent) error { return nil }))
+	require.Error(t, g.SubscribeVotes(func(vote.Event) error { return nil }))
+}

--- a/cmd/node/moderator/round/registry_branches_test.go
+++ b/cmd/node/moderator/round/registry_branches_test.go
@@ -1,0 +1,222 @@
+//nolint:all
+package round
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/cmd/node/moderator/vote"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryPeers(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+
+	require.Empty(t, rs.Peers(), "nobody has been seen yet")
+
+	rs.AddVote(vote.Event{ReportID: "report-1", ModeratorID: "moderator-a"})
+	rs.AddVote(vote.Event{ReportID: "report-1", ModeratorID: "moderator-b"})
+	require.ElementsMatch(t, []string{"moderator-a", "moderator-b"}, rs.Peers())
+
+	// a participant last seen beyond the TTL is forgotten on the next read
+	rs.mx.Lock()
+	rs.seenMods["moderator-a"] = time.Now().Add(-2 * seenModTTL)
+	rs.mx.Unlock()
+
+	require.Equal(t, []string{"moderator-b"}, rs.Peers())
+}
+
+func TestRegistryLen(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+	require.Zero(t, rs.Len())
+
+	rs.Open(subject("tweet-1"))
+	require.Equal(t, 1, rs.Len())
+
+	rs.StopAll()
+	require.Zero(t, rs.Len())
+}
+
+func TestMarkFinalizedIsIdempotent(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+	rs.Open(subject("tweet-1"))
+	id := subject("tweet-1").ReportID()
+
+	rs.MarkFinalized(id, "moderator-a")
+	require.Zero(t, rs.Len(), "finalizing stops the live round")
+
+	// a second announcement for the same round is dropped rather than
+	// re-registering it
+	rs.MarkFinalized(id, "moderator-b")
+	require.Zero(t, rs.Len())
+	require.Contains(t, rs.Peers(), "moderator-b", "the announcer is still seen")
+}
+
+func TestFinalizedRoundsExpire(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+	id := subject("tweet-1").ReportID()
+
+	rs.MarkFinalized(id, "moderator-a")
+
+	rs.mx.Lock()
+	require.True(t, rs.isFinalizedLocked(id))
+	rs.finalized[id] = time.Now().Add(-2 * finalizedTTL)
+	require.False(t, rs.isFinalizedLocked(id), "an expired finalization no longer blocks the round")
+	_, still := rs.finalized[id]
+	require.False(t, still)
+	rs.mx.Unlock()
+}
+
+func TestForgetPrunesExpiredFinalizations(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+
+	rs.mx.Lock()
+	rs.finalized["stale"] = time.Now().Add(-2 * finalizedTTL)
+	rs.finalized["fresh"] = time.Now()
+	rs.mx.Unlock()
+
+	rs.forget("some-round")
+
+	rs.mx.Lock()
+	defer rs.mx.Unlock()
+	_, stale := rs.finalized["stale"]
+	_, fresh := rs.finalized["fresh"]
+	require.False(t, stale)
+	require.True(t, fresh)
+}
+
+func TestVoteDelayPrunesStaleParticipants(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), DefaultSchedule())
+
+	rs.mx.Lock()
+	rs.seenMods["gone"] = time.Now().Add(-2 * seenModTTL)
+	rs.seenMods["here"] = time.Now()
+	_ = rs.voteDelayLocked("report-1")
+	_, stale := rs.seenMods["gone"]
+	_, live := rs.seenMods["here"]
+	rs.mx.Unlock()
+
+	require.False(t, stale)
+	require.True(t, live)
+}
+
+// failingMember refuses to produce a ballot, or fails to broadcast one.
+type failingMember struct {
+	*stubMember
+	ballotErr    error
+	broadcastErr error
+}
+
+func (m *failingMember) Ballot(reportID string, subject event.ReportEvent) (vote.Event, bool, error) {
+	if m.ballotErr != nil {
+		return vote.Event{}, false, m.ballotErr
+	}
+	return m.stubMember.Ballot(reportID, subject)
+}
+
+func (m *failingMember) Broadcast(v vote.Event) error {
+	if m.broadcastErr != nil {
+		_ = m.stubMember.Broadcast(v)
+		return m.broadcastErr
+	}
+	return m.stubMember.Broadcast(v)
+}
+
+func TestCastVoteToleratesMemberFailures(t *testing.T) {
+	t.Run("a failed ballot casts nothing", func(t *testing.T) {
+		member := &failingMember{
+			stubMember: newStubMember("self", domain.OK),
+			ballotErr:  errors.New("engine down"),
+		}
+		rs := NewRegistry("self", member, Schedule{Window: time.Hour, Failover: time.Hour, Step: 0})
+		rs.Open(subject("tweet-1"))
+
+		require.Eventually(t, func() bool {
+			_, broadcasts, _ := member.counts()
+			return broadcasts == 0
+		}, time.Second, 10*time.Millisecond)
+		rs.StopAll()
+	})
+
+	t.Run("a failed broadcast still counts the own ballot", func(t *testing.T) {
+		member := &failingMember{
+			stubMember:   newStubMember("self", domain.OK),
+			broadcastErr: errors.New("gossip down"),
+		}
+		rs := NewRegistry("self", member, Schedule{Window: time.Hour, Failover: time.Hour, Step: 0})
+		rs.Open(subject("tweet-1"))
+
+		require.Eventually(t, func() bool {
+			_, broadcasts, _ := member.counts()
+			return broadcasts > 0
+		}, 2*time.Second, 10*time.Millisecond)
+		rs.StopAll()
+	})
+}
+
+func TestClosedRoundIgnoresLateInput(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+	rep := subject("tweet-1")
+	id := rep.ReportID()
+
+	// open the round without a report so nothing schedules this node's own
+	// ballot: the test is about what a *closed* round accepts
+	rs.mx.Lock()
+	r := rs.ensureLocked(id)
+	rs.mx.Unlock()
+	require.NotNil(t, r)
+
+	r.stop()
+
+	// neither a repeat report nor a late vote may revive a stopped round
+	r.setReport(rep, 0)
+	r.addVote(vote.Event{ReportID: id, ModeratorID: "late"})
+
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	require.Empty(t, r.votes)
+}
+
+func TestRepeatReportIsIgnored(t *testing.T) {
+	rs := NewRegistry("self", newStubMember("self", domain.OK), frozen())
+	rep := subject("tweet-1")
+	rs.Open(rep)
+	// the same report delivered twice must not schedule a second vote
+	rs.Open(rep)
+	require.Equal(t, 1, rs.Len())
+	rs.StopAll()
+}
+
+func TestDuplicateVoteIsIgnored(t *testing.T) {
+	// an abstaining member never adds a ballot of its own, so the only votes
+	// in the round are the ones this test delivers
+	member := newStubMember("self", domain.OK)
+	member.abstain = true
+
+	rs := NewRegistry("self", member, frozen())
+	rep := subject("tweet-1")
+	rs.Open(rep)
+	id := rep.ReportID()
+
+	rs.AddVote(vote.Event{ReportID: id, ModeratorID: "moderator-a", Result: domain.OK})
+	rs.AddVote(vote.Event{ReportID: id, ModeratorID: "moderator-a", Result: domain.FAIL})
+
+	rs.mx.Lock()
+	r := rs.active[id]
+	rs.mx.Unlock()
+	require.NotNil(t, r)
+
+	r.mx.Lock()
+	count := len(r.votes)
+	result := r.votes["moderator-a"].Result
+	r.mx.Unlock()
+
+	// release the round lock before StopAll: stopping takes it too
+	rs.StopAll()
+
+	require.Equal(t, 1, count)
+	require.Equal(t, domain.OK, result)
+}

--- a/cmd/node/relay/main_test.go
+++ b/cmd/node/relay/main_test.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+//nolint:all
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestMainRunsAndShutsDownOnInterrupt drives the relay entry point end to end:
+// it boots the node, then delivers the interrupt main() waits for.
+//
+// The test registers its own signal handler first. That installs Go's handler
+// process-wide and disables the default terminate-on-SIGINT behaviour, so the
+// signal below can never kill the test binary — even if main() returned early
+// (a busy port, say) before registering its own.
+func TestMainRunsAndShutsDownOnInterrupt(t *testing.T) {
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, os.Interrupt, syscall.SIGINT)
+	t.Cleanup(func() { signal.Stop(guard) })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		main()
+	}()
+
+	// give main() time to reach its own signal.Notify
+	time.Sleep(2 * time.Second)
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("deliver interrupt: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("the relay did not shut down after the interrupt")
+	}
+}

--- a/cmd/node/relay/node/relay-node.go
+++ b/cmd/node/relay/node/relay-node.go
@@ -170,10 +170,12 @@ func (rn *RelayNode) Start() (err error) {
 	}
 	rn.setupHandlers()
 
-	rn.pubsubService.Run(rn)
+	// Discovery first: the gossip listener feeds DiscoveryHandlerPubSub, which
+	// reads the fields discService.Run sets. Starting pubsub first races them.
 	if err := rn.discService.Run(rn); err != nil {
 		return err
 	}
+	rn.pubsubService.Run(rn)
 
 	nodeInfo := rn.NodeInfo()
 	println()

--- a/cmd/node/relay/node/relay-node_test.go
+++ b/cmd/node/relay/node/relay-node_test.go
@@ -1,0 +1,141 @@
+//nolint:all
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	corenode "github.com/Warp-net/warpnet/core/node"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+func testKeyAndID(t *testing.T) (ed25519.PrivateKey, warpnet.WarpPeerID) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	return priv, id
+}
+
+func newTestRelayNode(t *testing.T) *RelayNode {
+	t.Helper()
+	privKey, ownNodeId := testKeyAndID(t)
+	psk, err := security.GeneratePSK("testnet", semver.MustParse("0.0.0"))
+	require.NoError(t, err)
+
+	rn, err := NewRelayNode(context.Background(), privKey, psk, ownNodeId)
+	require.NoError(t, err)
+	require.NotNil(t, rn)
+	t.Cleanup(rn.Stop)
+	return rn
+}
+
+// startWithRetry works around the fixed listen port in the config: another
+// package's node test may hold it for a few seconds.
+func startWithRetry(t *testing.T, start func() error) bool {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		err := start()
+		if err == nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			t.Logf("skipping: cannot bind the configured node port: %v", err)
+			return false
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func TestNewRelayNodeRequiresPrivateKey(t *testing.T) {
+	_, err := NewRelayNode(context.Background(), nil, nil, "")
+	require.ErrorIs(t, err, corenode.ErrPrivateKeyRequired)
+}
+
+func TestNewRelayNodeWiresServices(t *testing.T) {
+	rn := newTestRelayNode(t)
+
+	require.NotNil(t, rn.discService)
+	require.NotNil(t, rn.pubsubService)
+	require.NotNil(t, rn.dHashTable)
+	require.NotNil(t, rn.memoryStoreCloseF)
+	require.NotEmpty(t, rn.opts)
+}
+
+func TestRelayAccessorsAreNilSafeBeforeStart(t *testing.T) {
+	rn := newTestRelayNode(t)
+
+	require.Nil(t, rn.Node())
+	require.Nil(t, rn.Peerstore())
+	require.Nil(t, rn.Network())
+
+	out, err := rn.SelfStream("", "", "/public/get/info", nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	var nilNode *RelayNode
+	require.Nil(t, nilNode.Node())
+	require.Nil(t, nilNode.Peerstore())
+	require.Nil(t, nilNode.Network())
+	require.NotPanics(t, nilNode.Stop)
+	require.Panics(t, func() { _ = nilNode.Start() })
+
+	out, err = nilNode.SelfStream("", "", "/public/get/info", nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	out, err = nilNode.GenericStream("whatever", "/public/get/info", nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+}
+
+func TestRelayGenericStreamRejectsMalformedNodeId(t *testing.T) {
+	rn := newTestRelayNode(t)
+	_, err := rn.GenericStream("not-a-peer-id", "/public/get/info", nil)
+	require.ErrorIs(t, err, warpnet.ErrMalformedNodeId)
+}
+
+func TestSetupHandlersRejectsUnstartedNode(t *testing.T) {
+	rn := newTestRelayNode(t)
+	require.Panics(t, rn.setupHandlers)
+}
+
+// TestRelayStart drives the full startup: libp2p host, middlewares, the
+// /public/get/info route, pubsub and discovery.
+func TestRelayStart(t *testing.T) {
+	rn := newTestRelayNode(t)
+
+	if !startWithRetry(t, rn.Start) {
+		t.Skip("configured node port is busy")
+	}
+
+	info := rn.NodeInfo()
+	require.Equal(t, warpnet.RelayNode, info.Type)
+	require.Equal(t, "bootstrap", info.OwnerId)
+	require.NotEmpty(t, info.Addresses)
+
+	require.NotNil(t, rn.Node())
+	require.NotNil(t, rn.Peerstore())
+	require.NotNil(t, rn.Network())
+
+	_, otherID := testKeyAndID(t)
+	require.NotPanics(t, func() {
+		rn.SetMaxNodePriority(otherID)
+		rn.SetMinNodePriority(otherID)
+		rn.SetNodePriority(otherID, warpnet.WarpReachability(0))
+	})
+
+	// an unreachable peer surfaces as an error rather than hanging
+	_, err := rn.GenericStream(otherID.String(), "/public/get/info", nil)
+	require.Error(t, err)
+
+	require.Error(t, rn.SimpleConnect(warpnet.WarpAddrInfo{ID: otherID}))
+}

--- a/cmd/node/relay/pubsub/relay-pubsub_test.go
+++ b/cmd/node/relay/pubsub/relay-pubsub_test.go
@@ -1,0 +1,73 @@
+//nolint:all
+package pubsub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/pubsub"
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
+)
+
+type liveNode struct{ host warpnet.P2PNode }
+
+func (n *liveNode) Node() warpnet.P2PNode { return n.host }
+
+func (n *liveNode) NodeInfo() warpnet.NodeInfo {
+	return warpnet.NodeInfo{ID: n.host.ID(), OwnerId: "None"}
+}
+
+func (n *liveNode) SelfStream(_, _ warpnet.WarpPeerID, _ stream.WarpRoute, _ any) ([]byte, error) {
+	return nil, nil
+}
+
+func (n *liveNode) GenericStream(_ string, _ stream.WarpRoute, _ any) ([]byte, error) {
+	return nil, nil
+}
+
+func newLiveNode(t *testing.T) *liveNode {
+	t.Helper()
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+	return &liveNode{host: h}
+}
+
+func TestRelayPubSubLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	g := NewPubSubRelay(ctx, pubsub.NewDiscoveryRelayTopicHandler())
+	require.NotNil(t, g)
+	require.Equal(t, "None", g.OwnerID(), "a relay has no owner of its own")
+
+	node := newLiveNode(t)
+	g.Run(node)
+
+	// Run is idempotent: a second call must not restart the router.
+	g.Run(node)
+
+	require.NoError(t, g.Close())
+}
+
+// A relay whose gossip cannot start logs the failure and returns instead of
+// leaving a half-initialised router behind.
+func TestRelayPubSubRunFailureIsLogged(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // a cancelled context makes the gossip router refuse to start
+
+	node := newLiveNode(t)
+	g := NewPubSubRelay(ctx)
+	g.Run(node)
+
+	require.NoError(t, g.Close())
+}
+
+func TestNewMemberDiscoveryTopicHandlerIsExported(t *testing.T) {
+	th := NewMemberDiscoveryTopicHandler(func(warpnet.WarpAddrInfo) {})
+	require.NotEmpty(t, th.TopicName)
+	require.NotNil(t, th.Handler)
+}

--- a/core/authorship/authorship_test.go
+++ b/core/authorship/authorship_test.go
@@ -1,0 +1,174 @@
+//nolint:all
+package authorship
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+type stubUserStore struct {
+	getFn    func(userId string) (domain.User, error)
+	createFn func(user domain.User) (domain.User, error)
+	created  []domain.User
+}
+
+func (s *stubUserStore) Get(userId string) (domain.User, error) {
+	if s.getFn != nil {
+		return s.getFn(userId)
+	}
+	return domain.User{}, database.ErrUserNotFound
+}
+
+func (s *stubUserStore) Create(user domain.User) (domain.User, error) {
+	s.created = append(s.created, user)
+	if s.createFn != nil {
+		return s.createFn(user)
+	}
+	return user, nil
+}
+
+type stubStreamer struct {
+	fn func(nodeId string, path stream.WarpRoute, data any) ([]byte, error)
+}
+
+func (s stubStreamer) GenericStream(nodeId string, path stream.WarpRoute, data any) ([]byte, error) {
+	if s.fn != nil {
+		return s.fn(nodeId, path, data)
+	}
+	return nil, nil
+}
+
+// peerStream mints a real peer id and a loopback stream whose remote peer is it.
+func peerStream(t *testing.T) (warpnet.WarpPeerID, warpnet.WarpStream) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	_, server := stream.NewLoopbackStream(id, id, "/test/route/0.0.0")
+	return id, server
+}
+
+func TestFetchActor(t *testing.T) {
+	const actorId = "actor-1"
+	nodeId, s := peerStream(t)
+
+	t.Run("known actor is returned from storage", func(t *testing.T) {
+		repo := &stubUserStore{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		actor, err := FetchActor(repo, stubStreamer{}, s, actorId)
+		require.NoError(t, err)
+		require.Equal(t, actorId, actor.Id)
+		require.Empty(t, repo.created)
+	})
+
+	t.Run("a non-not-found lookup failure surfaces", func(t *testing.T) {
+		lookupErr := errors.New("store down")
+		repo := &stubUserStore{getFn: func(string) (domain.User, error) {
+			return domain.User{}, lookupErr
+		}}
+		_, err := FetchActor(repo, stubStreamer{}, s, actorId)
+		require.ErrorIs(t, err, lookupErr)
+	})
+
+	t.Run("no stream means no remote lookup", func(t *testing.T) {
+		_, err := FetchActor(&stubUserStore{}, stubStreamer{}, nil, actorId)
+		require.ErrorIs(t, err, database.ErrUserNotFound)
+	})
+
+	t.Run("stream failure surfaces", func(t *testing.T) {
+		streamErr := errors.New("offline")
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, streamErr
+		}}
+		_, err := FetchActor(&stubUserStore{}, streamer, s, actorId)
+		require.ErrorIs(t, err, streamErr)
+	})
+
+	t.Run("garbage response surfaces", func(t *testing.T) {
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		_, err := FetchActor(&stubUserStore{}, streamer, s, actorId)
+		require.Error(t, err)
+	})
+
+	t.Run("an empty remote record is still not found", func(t *testing.T) {
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{})
+		}}
+		_, err := FetchActor(&stubUserStore{}, streamer, s, actorId)
+		require.ErrorIs(t, err, database.ErrUserNotFound)
+	})
+
+	t.Run("a fetched actor is cached locally", func(t *testing.T) {
+		repo := &stubUserStore{}
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{Id: actorId, NodeId: nodeId.String()})
+		}}
+		actor, err := FetchActor(repo, streamer, s, actorId)
+		require.NoError(t, err)
+		require.Equal(t, actorId, actor.Id)
+		require.Len(t, repo.created, 1)
+	})
+
+	t.Run("an already-existing cache entry is not an error", func(t *testing.T) {
+		repo := &stubUserStore{createFn: func(domain.User) (domain.User, error) {
+			return domain.User{}, database.ErrUserAlreadyExists
+		}}
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{Id: actorId, NodeId: nodeId.String()})
+		}}
+		_, err := FetchActor(repo, streamer, s, actorId)
+		require.NoError(t, err)
+	})
+
+	t.Run("a failing cache write surfaces", func(t *testing.T) {
+		createErr := errors.New("write down")
+		repo := &stubUserStore{createFn: func(domain.User) (domain.User, error) {
+			return domain.User{}, createErr
+		}}
+		streamer := stubStreamer{fn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{Id: actorId, NodeId: nodeId.String()})
+		}}
+		_, err := FetchActor(repo, streamer, s, actorId)
+		require.ErrorIs(t, err, createErr)
+	})
+}
+
+func TestVerifyActor(t *testing.T) {
+	const actorId = "actor-1"
+	nodeId, s := peerStream(t)
+
+	t.Run("actor on the sending node is accepted", func(t *testing.T) {
+		repo := &stubUserStore{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		actor, err := VerifyActor(repo, stubStreamer{}, s, actorId)
+		require.NoError(t, err)
+		require.Equal(t, actorId, actor.Id)
+	})
+
+	t.Run("actor on another node is rejected", func(t *testing.T) {
+		repo := &stubUserStore{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "somebody-else"}, nil
+		}}
+		_, err := VerifyActor(repo, stubStreamer{}, s, actorId)
+		require.ErrorIs(t, err, warpnet.ErrForeignAuthor)
+	})
+
+	t.Run("an unresolvable actor is rejected", func(t *testing.T) {
+		_, err := VerifyActor(&stubUserStore{}, stubStreamer{}, nil, actorId)
+		require.ErrorIs(t, err, warpnet.ErrForeignAuthor)
+	})
+}

--- a/core/dht/dht.go
+++ b/core/dht/dht.go
@@ -90,7 +90,16 @@ type distributedHashTable struct {
 	dht       *dht.IpfsDHT
 	stopChan  chan struct{}
 	closeOnce sync.Once
+	// bootstrapped is closed when the goroutine StartRouting launches returns.
+	// Close waits on it: go-libp2p-kad-dht is not safe against a Close that
+	// lands while Bootstrap or RefreshRoutingTable is still in flight, which is
+	// what a node stopped right after starting does.
+	bootstrapped chan struct{}
 }
+
+// bootstrapDrainTimeout bounds how long Close waits for the bootstrap
+// goroutine. A wedged refresh must not hang shutdown.
+const bootstrapDrainTimeout = 5 * time.Second
 
 func defaultNodeRemovedCallback(id warpnet.WarpPeerID) {
 	log.Debugln("dht: node removed", id)
@@ -106,9 +115,10 @@ func NewDHTable(ctx context.Context, opts ...Option) *distributedHashTable {
 		opt(&cfg)
 	}
 	return &distributedHashTable{
-		ctx:      ctx,
-		cfg:      cfg,
-		stopChan: make(chan struct{}),
+		ctx:          ctx,
+		cfg:          cfg,
+		stopChan:     make(chan struct{}),
+		bootstrapped: make(chan struct{}),
 	}
 }
 
@@ -168,7 +178,12 @@ func (d *distributedHashTable) StartRouting(n warpnet.P2PNode) (_ warpnet.WarpPe
 		}
 	}
 
-	go d.bootstrapDHT()
+	// Signalled here rather than inside bootstrapDHT: this is the one goroutine
+	// Close has to wait for, and bootstrapDHT is also called directly.
+	go func() {
+		defer close(d.bootstrapped)
+		d.bootstrapDHT()
+	}()
 	log.Infoln("dht: routing started")
 	return d.dht, nil
 }
@@ -338,6 +353,15 @@ func (d *distributedHashTable) Close() {
 
 	d.closeOnce.Do(func() {
 		close(d.stopChan)
+
+		// Let the bootstrap goroutine finish first: tearing the table down
+		// underneath an in-flight Bootstrap/RefreshRoutingTable races the
+		// library's own refresh manager.
+		select {
+		case <-d.bootstrapped:
+		case <-time.After(bootstrapDrainTimeout):
+			log.Warnln("dht: bootstrap still running at close, tearing down anyway")
+		}
 
 		log.Infoln("dht: closing...")
 		if err := d.dht.Close(); err != nil {

--- a/core/dht/dht_test.go
+++ b/core/dht/dht_test.go
@@ -287,13 +287,7 @@ func TestStartRendezvousAdvertisesAndStops(t *testing.T) {
 			t.Logf("dht close: %v", err)
 		}
 	})
-	"testing"
-
-	datastore "github.com/ipfs/go-datastore"
-	dssync "github.com/ipfs/go-datastore/sync"
-	"github.com/libp2p/go-libp2p"
-	"github.com/stretchr/testify/require"
-)
+}
 
 // The desktop app stops the node twice - logout stops it, then the wails
 // shutdown hook stops it again - so a second close must be a no-op.
@@ -301,17 +295,8 @@ func TestCloseIsIdempotent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
-	require.NoError(t, err)
-	defer func() { _ = h.Close() }()
-
-	table := NewDHTable(
-		ctx,
-		Network("testnet"),
-		RoutingStore(dssync.MutexWrap(datastore.NewMapDatastore())),
-	)
-
-	_, err = table.StartRouting(h)
+	table := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+	_, err := table.StartRouting(newHost(t))
 	require.NoError(t, err)
 
 	table.Close()

--- a/core/dht/dht_test.go
+++ b/core/dht/dht_test.go
@@ -1,0 +1,263 @@
+//nolint:all
+package dht
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
+	drouting "github.com/libp2p/go-libp2p/p2p/discovery/routing"
+	"github.com/stretchr/testify/require"
+)
+
+func newHost(t *testing.T) warpnet.P2PNode {
+	t.Helper()
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+	return h
+}
+
+func memStore() RoutingStorer {
+	return dssync.MutexWrap(ds.NewMapDatastore())
+}
+
+func TestNewDHTableAppliesOptions(t *testing.T) {
+	nodes := []warpnet.WarpAddrInfo{{ID: "peer-1"}}
+	d := NewDHTable(context.Background(),
+		Network("testnet"),
+		RoutingStore(memStore()),
+		BootstrapNodes(nodes...),
+		AddPeerCallbacks(func(warpnet.WarpPeerID) {}),
+		RemovePeerCallbacks(func(warpnet.WarpPeerID) {}),
+	)
+	require.NotNil(t, d)
+	require.Equal(t, "testnet", d.cfg.network)
+	require.Equal(t, nodes, d.BootstrapNodes())
+	require.Len(t, d.cfg.addCallbacks, 1)
+	require.Len(t, d.cfg.removeCallbacks, 1)
+}
+
+func TestStartRoutingRequiresNetwork(t *testing.T) {
+	d := NewDHTable(context.Background(), RoutingStore(memStore()))
+	require.Panics(t, func() { _, _ = d.StartRouting(newHost(t)) })
+}
+
+func TestStartRoutingAndClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var (
+		mx             sync.Mutex
+		added, removed []peer.ID
+	)
+	d := NewDHTable(ctx,
+		Network("testnet"),
+		RoutingStore(memStore()),
+		// a nil entry alongside a real one exercises the nil guard in the loop
+		AddPeerCallbacks(nil, func(id warpnet.WarpPeerID) {
+			mx.Lock()
+			added = append(added, id)
+			mx.Unlock()
+		}),
+		RemovePeerCallbacks(nil, func(id warpnet.WarpPeerID) {
+			mx.Lock()
+			removed = append(removed, id)
+			mx.Unlock()
+		}),
+	)
+
+	host := newHost(t)
+	routing, err := d.StartRouting(host)
+	require.NoError(t, err)
+	require.NotNil(t, routing)
+
+	// The routing table owns when these fire; invoke the installed hooks
+	// directly so the fan-out to the configured callbacks is covered without
+	// depending on DHT server-mode negotiation.
+	other := newHost(t)
+	d.dht.RoutingTable().PeerAdded(other.ID())
+	d.dht.RoutingTable().PeerRemoved(other.ID())
+
+	mx.Lock()
+	require.Equal(t, []peer.ID{other.ID()}, added)
+	require.Equal(t, []peer.ID{other.ID()}, removed)
+	mx.Unlock()
+
+	// An isolated node has no closest peers; the call must still be safe.
+	require.Empty(t, d.ClosestPeers())
+	require.NotNil(t, d.FindProvidersAsync(ctx, cid.Undef, 1))
+
+	d.Close()
+}
+
+func TestStartRoutingWithoutCallbacks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	d := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+	_, err := d.StartRouting(newHost(t))
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	require.Empty(t, d.BootstrapNodes())
+}
+
+func TestBootstrapSkipsSelfAndTolerantOfDeadPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	host := newHost(t)
+	unreachable := newHost(t)
+	unreachableInfo := warpnet.WarpAddrInfo{ID: unreachable.ID(), Addrs: unreachable.Addrs()}
+	require.NoError(t, unreachable.Close())
+
+	d := NewDHTable(ctx,
+		Network("testnet"),
+		RoutingStore(memStore()),
+		BootstrapNodes(
+			// this node itself — skipped rather than dialled
+			warpnet.WarpAddrInfo{ID: host.ID(), Addrs: host.Addrs()},
+			// a peer that is gone: the ping fails without a peer-id mismatch
+			unreachableInfo,
+		),
+	)
+
+	_, err := d.StartRouting(host)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	// Run the bootstrap walk synchronously so the assertions below don't race
+	// the background goroutine StartRouting already launched.
+	d.bootstrapDHT()
+
+	require.Len(t, d.BootstrapNodes(), 2)
+	require.NotEmpty(t, host.Peerstore().Addrs(unreachableInfo.ID),
+		"a bootstrap peer's addresses are pinned even when it is unreachable")
+}
+
+func TestDefaultCallbacksAreSafe(t *testing.T) {
+	require.NotPanics(t, func() {
+		defaultNodeAddedCallback("peer-1")
+		defaultNodeRemovedCallback("peer-1")
+	})
+}
+
+func TestStartRendezvousStopsOnSignals(t *testing.T) {
+	t.Run("nil table returns immediately", func(t *testing.T) {
+		var d *distributedHashTable
+		d.startRendezvous(nil)
+
+		started := NewDHTable(context.Background(), Network("testnet"))
+		started.startRendezvous(nil)
+	})
+
+	t.Run("a cancelled context aborts the wait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		d := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+		_, err := d.StartRouting(newHost(t))
+		require.NoError(t, err)
+		t.Cleanup(d.Close)
+
+		cancel()
+		d.startRendezvous(make(chan struct{})) // never closed: only ctx can end this
+	})
+
+	t.Run("a stopped table aborts the wait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		d := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+		_, err := d.StartRouting(newHost(t))
+		require.NoError(t, err)
+
+		close(d.stopChan)
+		d.startRendezvous(make(chan struct{}))
+	})
+}
+
+func TestAdvertiseAndFindPeersOnAnEmptyTable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	d := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+	_, err := d.StartRouting(newHost(t))
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	rd := drouting.NewRoutingDiscovery(d.dht)
+	ns := rendezvousNamespace("testnet")
+
+	// An empty routing table has nowhere to store the record: advertise is a
+	// no-op and the peer query yields nothing rather than blocking.
+	d.advertise(rd, ns)
+	d.findPeers(rd, ns, d.dht.Host().ID())
+}
+
+func TestCloseIsNilSafeAndIdempotent(t *testing.T) {
+	var d *distributedHashTable
+	require.NotPanics(t, d.Close)
+
+	unstarted := NewDHTable(context.Background(), Network("testnet"))
+	require.NotPanics(t, unstarted.Close)
+}
+
+func TestBootstrapDHTIsNilSafe(t *testing.T) {
+	var d *distributedHashTable
+	require.NotPanics(t, d.bootstrapDHT)
+
+	unstarted := NewDHTable(context.Background(), Network("testnet"))
+	require.NotPanics(t, unstarted.bootstrapDHT)
+}
+
+// TestStartRendezvousAdvertisesAndStops drives the rendezvous loop once the
+// bootstrap signal is in: it advertises, queries for peers, and then exits on
+// the stop channel.
+func TestStartRendezvousAdvertisesAndStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	d := NewDHTable(ctx, Network("testnet"), RoutingStore(memStore()))
+	_, err := d.StartRouting(newHost(t))
+	require.NoError(t, err)
+
+	// a peer in the routing table takes advertise past its "nowhere to store
+	// the record" guard
+	other := newHost(t)
+	d.dht.Host().Peerstore().AddAddrs(other.ID(), other.Addrs(), time.Hour)
+	_, _ = d.dht.RoutingTable().TryAddPeer(other.ID(), true, false)
+
+	bootstrapped := make(chan struct{})
+	close(bootstrapped)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.startRendezvous(bootstrapped)
+	}()
+
+	// the first advertise/findPeers pass runs before the ticker; stop the loop
+	// as soon as it is under way
+	time.Sleep(200 * time.Millisecond)
+	close(d.stopChan)
+
+	select {
+	case <-done:
+	case <-time.After(90 * time.Second):
+		t.Fatal("the rendezvous loop did not stop")
+	}
+
+	// the table is already stopped: Close must not double-close it
+	require.NotPanics(t, func() {
+		if err := d.dht.Close(); err != nil {
+			t.Logf("dht close: %v", err)
+		}
+	})
+}

--- a/core/dht/dht_test.go
+++ b/core/dht/dht_test.go
@@ -205,7 +205,9 @@ func TestStartRendezvousStopsOnSignals(t *testing.T) {
 		_, err := d.StartRouting(newHost(t))
 		require.NoError(t, err)
 
-		close(d.stopChan)
+		// Close is what closes stopChan in production, and it also drains the
+		// bootstrap goroutine before tearing the table down.
+		d.Close()
 		d.startRendezvous(make(chan struct{}))
 	})
 }
@@ -273,7 +275,7 @@ func TestStartRendezvousAdvertisesAndStops(t *testing.T) {
 	// the first advertise/findPeers pass runs before the ticker; stop the loop
 	// as soon as it is under way
 	time.Sleep(200 * time.Millisecond)
-	close(d.stopChan)
+	d.Close()
 
 	select {
 	case <-done:
@@ -281,12 +283,8 @@ func TestStartRendezvousAdvertisesAndStops(t *testing.T) {
 		t.Fatal("the rendezvous loop did not stop")
 	}
 
-	// the table is already stopped: Close must not double-close it
-	require.NotPanics(t, func() {
-		if err := d.dht.Close(); err != nil {
-			t.Logf("dht close: %v", err)
-		}
-	})
+	// already torn down: a second Close is a no-op rather than a double close
+	require.NotPanics(t, d.Close)
 }
 
 // The desktop app stops the node twice - logout stops it, then the wails

--- a/core/discovery/discovery_branches_test.go
+++ b/core/discovery/discovery_branches_test.go
@@ -1,0 +1,140 @@
+//nolint:all
+package discovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/mastodon"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRoutesByNodeRole(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		info warpnet.NodeInfo
+	}{
+		{"member", warpnet.NodeInfo{ID: warpnet.FromStringToPeerID(selfID), Type: warpnet.MemberNode}},
+		{"relay", warpnet.NodeInfo{ID: warpnet.FromStringToPeerID(selfID), Type: warpnet.RelayNode}},
+		{"moderator", warpnet.NodeInfo{ID: warpnet.FromStringToPeerID(selfID), Type: warpnet.ModeratorNode}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			node := newFakeNode()
+			node.info = tt.info
+			node.infoResp = infoJSON(t, warpnet.NodeInfo{ID: warpnet.FromStringToPeerID(peerID)})
+
+			s := NewDiscoveryService(ctx, newFakeUserRepo(), newFakeNodeRepo())
+			t.Cleanup(s.Close)
+			require.NoError(t, s.Run(node))
+
+			s.DiscoveryHandlerPubSub(warpnet.WarpAddrInfo{ID: warpnet.FromStringToPeerID(peerID)})
+
+			// whatever the role does with it, the loop must consume the peer
+			require.Eventually(t, func() bool {
+				return len(s.discoveryChan) == 0
+			}, 5*time.Second, 10*time.Millisecond)
+			_ = node
+		})
+	}
+}
+
+func TestRunRefusesWithoutAChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	s := NewDiscoveryService(ctx, newFakeUserRepo(), newFakeNodeRepo())
+	s.discoveryChan = nil
+	require.Error(t, s.Run(newFakeNode()))
+}
+
+func TestRunLoopStopsOnClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	s := NewDiscoveryService(ctx, newFakeUserRepo(), newFakeNodeRepo())
+	require.NoError(t, s.Run(newFakeNode()))
+	s.Close()
+	// closing twice must stay safe
+	s.Close()
+}
+
+func TestRunLoopStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := NewDiscoveryService(ctx, newFakeUserRepo(), newFakeNodeRepo())
+	t.Cleanup(s.Close)
+	require.NoError(t, s.Run(newFakeNode()))
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestDiscoveryHandlerStreamSkipsKnownPeers(t *testing.T) {
+	s, node, _, _ := newService(t)
+	known := warpnet.FromStringToPeerID(peerID)
+
+	addr, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+	require.NoError(t, err)
+	node.store.AddAddrs(known, []warpnet.WarpAddress{addr}, time.Hour)
+	s.DiscoveryHandlerStream(warpnet.WarpAddrInfo{ID: known})
+	require.Len(t, s.discoveryChan, 0, "a peer already in the peerstore ends the loop")
+
+	unknown := warpnet.FromStringToPeerID(peerID2)
+	s.DiscoveryHandlerStream(warpnet.WarpAddrInfo{ID: unknown})
+	require.Len(t, s.discoveryChan, 1)
+}
+
+func TestEnqueueDropsOldestOnOverflow(t *testing.T) {
+	s, _, _, _ := newService(t)
+
+	// The limiter allows a burst; fill the channel past its capacity so the
+	// overflow branch has to make room.
+	s.limiter = newRateLimiter(10_000, 10_000)
+	peer := warpnet.FromStringToPeerID(peerID)
+	for range cap(s.discoveryChan) + 5 {
+		s.enqueue(warpnet.WarpAddrInfo{ID: peer}, sourceGossip)
+	}
+	require.LessOrEqual(t, len(s.discoveryChan), cap(s.discoveryChan))
+}
+
+func TestEnqueueIgnoresSelfAndEmptyIds(t *testing.T) {
+	s, _, _, _ := newService(t)
+
+	s.enqueue(warpnet.WarpAddrInfo{}, sourceGossip)
+	s.enqueue(warpnet.WarpAddrInfo{ID: s.ownId}, sourceGossip)
+	require.Len(t, s.discoveryChan, 0)
+
+	var nilService *discoveryService
+	require.NotPanics(t, func() {
+		nilService.enqueue(warpnet.WarpAddrInfo{ID: warpnet.FromStringToPeerID(peerID)}, sourceGossip)
+	})
+}
+
+func TestHandleAsMemberSkipsTheMastodonGateway(t *testing.T) {
+	s, node, users, _ := newService(t)
+
+	gateway := warpnet.FromStringToPeerID(mastodon.GatewayNodeID())
+	node.infoResp = infoJSON(t, warpnet.NodeInfo{ID: gateway, OwnerId: "gateway-owner"})
+
+	s.handleAsMember(discoveredPeer{ID: gateway, Source: sourceGossip})
+	require.Empty(t, users.created, "the bridge gateway is not stored as a peer user")
+}
+
+func TestRequestNodeInfoReportsARejection(t *testing.T) {
+	s, node, _, _ := newService(t)
+
+	rejection, err := json.Marshal(event.ResponseError{Message: "not for you"})
+	require.NoError(t, err)
+	node.infoResp = rejection
+
+	_, err = s.requestNodeInfo(warpnet.WarpAddrInfo{ID: warpnet.FromStringToPeerID(peerID)})
+	require.ErrorIs(t, err, errPeerRejectedInfo)
+}

--- a/core/handler/chat_branches_test.go
+++ b/core/handler/chat_branches_test.go
@@ -1,0 +1,153 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChatHandlerGuards drives the payload / empty-id / lookup-failure /
+// not-a-participant guards every chat read handler shares.
+func TestChatHandlerGuards(t *testing.T) {
+	const owner = "owner-1"
+	auth := stubAuth{owner: domain.Owner{UserId: owner}}
+	lookupErr := errors.New("chat store down")
+
+	failingLookup := stubChatRepo{getChatFn: func(string) (domain.Chat, error) {
+		return domain.Chat{}, lookupErr
+	}}
+	foreignChat := stubChatRepo{getChatFn: func(id string) (domain.Chat, error) {
+		return domain.Chat{Id: id, OwnerId: "someone", OtherUserId: "else"}, nil
+	}}
+	ownChat := stubChatRepo{getChatFn: func(id string) (domain.Chat, error) {
+		return domain.Chat{Id: id, OwnerId: owner, OtherUserId: "other-1"}, nil
+	}}
+
+	t.Run("GetUserChat", func(t *testing.T) {
+		_, err := StreamGetUserChatHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamGetUserChatHandler(ownChat, auth)(marshal(t, event.GetChatEvent{}), nil)
+		require.Error(t, err)
+
+		_, err = StreamGetUserChatHandler(failingLookup, auth)(marshal(t, event.GetChatEvent{ChatId: "chat-1"}), nil)
+		require.ErrorIs(t, err, lookupErr)
+
+		_, err = StreamGetUserChatHandler(foreignChat, auth)(marshal(t, event.GetChatEvent{ChatId: "chat-1"}), nil)
+		require.Error(t, err)
+
+		out, err := StreamGetUserChatHandler(ownChat, auth)(marshal(t, event.GetChatEvent{ChatId: "chat-1"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, "chat-1", domain.Chat(out.(event.GetChatResponse)).Id)
+	})
+
+	t.Run("DeleteChat", func(t *testing.T) {
+		_, err := StreamDeleteChatHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamDeleteChatHandler(ownChat, auth)(marshal(t, event.DeleteChatEvent{}), nil)
+		require.Error(t, err)
+
+		_, err = StreamDeleteChatHandler(failingLookup, auth)(marshal(t, event.DeleteChatEvent{ChatId: "chat-1"}), nil)
+		require.ErrorIs(t, err, lookupErr)
+
+		_, err = StreamDeleteChatHandler(foreignChat, auth)(marshal(t, event.DeleteChatEvent{ChatId: "chat-1"}), nil)
+		require.Error(t, err)
+
+		out, err := StreamDeleteChatHandler(ownChat, auth)(marshal(t, event.DeleteChatEvent{ChatId: "chat-1"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+
+	t.Run("DeleteMessage", func(t *testing.T) {
+		_, err := StreamDeleteMessageHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamDeleteMessageHandler(ownChat, auth)(marshal(t, event.DeleteMessageEvent{Id: "msg-1"}), nil)
+		require.Error(t, err)
+		_, err = StreamDeleteMessageHandler(ownChat, auth)(marshal(t, event.DeleteMessageEvent{ChatId: "chat-1"}), nil)
+		require.Error(t, err)
+
+		ev := marshal(t, event.DeleteMessageEvent{ChatId: "chat-1", Id: "msg-1"})
+		_, err = StreamDeleteMessageHandler(failingLookup, auth)(ev, nil)
+		require.ErrorIs(t, err, lookupErr)
+
+		_, err = StreamDeleteMessageHandler(foreignChat, auth)(ev, nil)
+		require.Error(t, err)
+
+		out, err := StreamDeleteMessageHandler(ownChat, auth)(ev, nil)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+
+	t.Run("GetMessages", func(t *testing.T) {
+		_, err := StreamGetMessagesHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamGetMessagesHandler(ownChat, auth)(marshal(t, event.GetAllMessagesEvent{OwnerId: owner}), nil)
+		require.Error(t, err)
+
+		ev := marshal(t, event.GetAllMessagesEvent{ChatId: "chat-1", OwnerId: owner})
+		_, err = StreamGetMessagesHandler(failingLookup, auth)(ev, nil)
+		require.ErrorIs(t, err, lookupErr)
+
+		_, err = StreamGetMessagesHandler(foreignChat, auth)(ev, nil)
+		require.Error(t, err)
+
+		listErr := errors.New("list down")
+		failingList := stubChatRepo{
+			getChatFn:      ownChat.getChatFn,
+			listMessagesFn: func(string, *uint64, *string) ([]domain.ChatMessage, string, error) { return nil, "", listErr },
+		}
+		_, err = StreamGetMessagesHandler(failingList, auth)(ev, nil)
+		require.ErrorIs(t, err, listErr)
+
+		out, err := StreamGetMessagesHandler(ownChat, auth)(ev, nil)
+		require.NoError(t, err)
+		require.Empty(t, out.(event.ChatMessagesResponse).Messages)
+	})
+
+	t.Run("GetMessage", func(t *testing.T) {
+		_, err := StreamGetMessageHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamGetMessageHandler(ownChat, auth)(marshal(t, event.GetMessageEvent{Id: "msg-1"}), nil)
+		require.Error(t, err)
+		_, err = StreamGetMessageHandler(ownChat, auth)(marshal(t, event.GetMessageEvent{ChatId: "chat-1"}), nil)
+		require.Error(t, err)
+
+		ev := marshal(t, event.GetMessageEvent{ChatId: "chat-1", Id: "msg-1"})
+		_, err = StreamGetMessageHandler(failingLookup, auth)(ev, nil)
+		require.ErrorIs(t, err, lookupErr)
+
+		_, err = StreamGetMessageHandler(foreignChat, auth)(ev, nil)
+		require.Error(t, err)
+
+		getErr := errors.New("message store down")
+		failingMessage := stubChatRepo{
+			getChatFn:    ownChat.getChatFn,
+			getMessageFn: func(string, string) (domain.ChatMessage, error) { return domain.ChatMessage{}, getErr },
+		}
+		_, err = StreamGetMessageHandler(failingMessage, auth)(ev, nil)
+		require.ErrorIs(t, err, getErr)
+	})
+
+	t.Run("GetUserChats", func(t *testing.T) {
+		_, err := StreamGetUserChatsHandler(ownChat, auth)([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = StreamGetUserChatsHandler(ownChat, auth)(marshal(t, event.GetAllChatsEvent{}), nil)
+		require.Error(t, err)
+
+		listErr := errors.New("list down")
+		failingList := stubChatRepo{getUserChatsFn: func(string, *uint64, *string) ([]domain.Chat, string, error) {
+			return nil, "", listErr
+		}}
+		_, err = StreamGetUserChatsHandler(failingList, auth)(marshal(t, event.GetAllChatsEvent{UserId: owner}), nil)
+		require.ErrorIs(t, err, listErr)
+	})
+}

--- a/core/handler/filter_block_branches_test.go
+++ b/core/handler/filter_block_branches_test.go
@@ -1,0 +1,231 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/mastodon"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterHandlerBranches(t *testing.T) {
+	const userId, filterId, kwId = "user-1", "filter-1", "kw-1"
+	repoErr := errors.New("filter store down")
+
+	t.Run("invalid payloads", func(t *testing.T) {
+		for name, h := range map[string]warpnet.WarpHandlerFunc{
+			"get":      StreamGetFilterHandler(stubFilterRepo{}),
+			"list":     StreamGetFiltersHandler(stubFilterRepo{}),
+			"create":   StreamNewFilterHandler(stubFilterRepo{}),
+			"update":   StreamUpdateFilterHandler(stubFilterRepo{}),
+			"delete":   StreamDeleteFilterHandler(stubFilterRepo{}),
+			"addKw":    StreamAddFilterKeywordHandler(stubFilterRepo{}),
+			"updateKw": StreamUpdateFilterKeywordHandler(stubFilterRepo{}),
+			"deleteKw": StreamDeleteFilterKeywordHandler(stubFilterRepo{}),
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := h([]byte("{"), nil)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("store failures surface", func(t *testing.T) {
+		_, err := StreamGetFilterHandler(stubFilterRepo{getFn: func(string, string) (domain.Filter, error) {
+			return domain.Filter{}, repoErr
+		}})(marshal(t, event.GetFilterEvent{UserId: userId, FilterId: filterId}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamGetFiltersHandler(stubFilterRepo{listFn: func(string, *uint64, *string) ([]domain.Filter, string, error) {
+			return nil, "", repoErr
+		}})(marshal(t, event.GetFiltersEvent{UserId: userId}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamUpdateFilterHandler(stubFilterRepo{updateFn: func(string, domain.Filter) (domain.Filter, error) {
+			return domain.Filter{}, repoErr
+		}})(marshal(t, event.UpdateFilterEvent{UserId: userId, Id: filterId, Title: "t"}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamDeleteFilterHandler(stubFilterRepo{deleteFn: func(string, string) error {
+			return repoErr
+		}})(marshal(t, event.DeleteFilterEvent{UserId: userId, FilterId: filterId}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamAddFilterKeywordHandler(stubFilterRepo{addKwFn: func(string, string, domain.FilterKeyword) (domain.FilterKeyword, error) {
+			return domain.FilterKeyword{}, repoErr
+		}})(marshal(t, event.AddFilterKeywordEvent{UserId: userId, FilterId: filterId, Keyword: "kw"}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamUpdateFilterKeywordHandler(stubFilterRepo{updateKwFn: func(string, domain.FilterKeyword) (domain.FilterKeyword, error) {
+			return domain.FilterKeyword{}, repoErr
+		}})(marshal(t, event.UpdateFilterKeywordEvent{UserId: userId, KeywordId: kwId, Keyword: "kw"}), nil)
+		require.ErrorIs(t, err, repoErr)
+
+		_, err = StreamDeleteFilterKeywordHandler(stubFilterRepo{deleteKwFn: func(string, string) error {
+			return repoErr
+		}})(marshal(t, event.DeleteFilterKeywordEvent{UserId: userId, KeywordId: kwId}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+}
+
+func TestBlockMuteHandlerBranches(t *testing.T) {
+	const blocker, blockee = "blocker-1", "blockee-1"
+	repoErr := errors.New("block store down")
+
+	t.Run("unblock guards", func(t *testing.T) {
+		h := StreamUnblockHandler(stubBlocksRepo{}, stubBlockUserResolver{}, &stubPeerBlocklister{})
+		_, err := h(marshal(t, event.UnblockEvent{BlockerId: blocker}), nil)
+		require.Error(t, err)
+
+		failing := StreamUnblockHandler(stubBlocksRepo{unblockFn: func(string, string) error {
+			return repoErr
+		}}, stubBlockUserResolver{}, &stubPeerBlocklister{})
+		_, err = failing(marshal(t, event.UnblockEvent{BlockerId: blocker, BlockeeId: blockee}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("blocks listing failure surfaces", func(t *testing.T) {
+		h := StreamGetBlocksHandler(stubBlocksRepo{listFn: func(string, *uint64, *string) ([]string, string, error) {
+			return nil, "", repoErr
+		}})
+		_, err := h(marshal(t, event.GetBlocksEvent{UserId: blocker}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("mute guards", func(t *testing.T) {
+		h := StreamMuteHandler(stubMutesRepo{})
+		_, err := h([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = h(marshal(t, event.MuteEvent{MuterId: blocker}), nil)
+		require.Error(t, err)
+
+		failing := StreamMuteHandler(stubMutesRepo{muteFn: func(string, string) error { return repoErr }})
+		_, err = failing(marshal(t, event.MuteEvent{MuterId: blocker, MuteeId: blockee}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("unmute guards", func(t *testing.T) {
+		h := StreamUnmuteHandler(stubMutesRepo{})
+		_, err := h([]byte("{"), nil)
+		require.Error(t, err)
+
+		_, err = h(marshal(t, event.UnmuteEvent{MuterId: blocker}), nil)
+		require.Error(t, err)
+
+		failing := StreamUnmuteHandler(stubMutesRepo{unmuteFn: func(string, string) error { return repoErr }})
+		_, err = failing(marshal(t, event.UnmuteEvent{MuterId: blocker, MuteeId: blockee}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("peer blocklist removal failure is tolerated", func(t *testing.T) {
+		users := stubBlockUserResolver{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "peer-node"}, nil
+		}}
+		blocklister := &failingBlocklistRemover{}
+		h := StreamUnblockHandler(stubBlocksRepo{}, users, blocklister)
+		out, err := h(marshal(t, event.UnblockEvent{BlockerId: blocker, BlockeeId: blockee}), nil)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+		require.True(t, blocklister.called)
+	})
+}
+
+// failingBlocklistRemover makes the peer-level blocklist removal fail so the
+// handler's "log and carry on" branch runs.
+type failingBlocklistRemover struct{ called bool }
+
+func (f *failingBlocklistRemover) BlocklistPermanent(string) error { return nil }
+func (f *failingBlocklistRemover) BlocklistRemove(string) error {
+	f.called = true
+	return errors.New("peer blocklist down")
+}
+
+func TestStreamGetWhoToFollowHandlerBranches(t *testing.T) {
+	const ownerId = "owner-1"
+	owner := domain.Owner{UserId: ownerId, NodeId: "own-node", Username: "me"}
+	auth := stubAuth{owner: owner}
+
+	t.Run("followings lookup failure is tolerated", func(t *testing.T) {
+		follows := stubUserFollowsCounter{getFollowingsFn: func(string, *uint64, *string) ([]string, string, error) {
+			return nil, "", errors.New("down")
+		}}
+		_, err := StreamGetWhoToFollowHandler(auth, stubUserFetcher{}, follows)(
+			marshal(t, event.GetAllUsersEvent{UserId: ownerId}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("profile lookup failure falls back to the owner", func(t *testing.T) {
+		users := stubUserFetcher{
+			getFn: func(string) (domain.User, error) { return domain.User{}, errors.New("down") },
+			whoToFollowFn: func(*uint64, *string) ([]domain.User, string, error) {
+				return []domain.User{{Id: "cand-1", NodeId: "far-node", Network: warpnet.WarpnetName}}, "", nil
+			},
+		}
+		out, err := StreamGetWhoToFollowHandler(auth, users, stubUserFollowsCounter{})(
+			marshal(t, event.GetAllUsersEvent{UserId: ownerId}), nil)
+		require.NoError(t, err)
+		require.Len(t, out.(event.UsersResponse).Users, 1)
+	})
+
+	t.Run("filters offline, self, followed and cross-network candidates", func(t *testing.T) {
+		older := time.Now().Add(-time.Hour)
+		newer := time.Now()
+
+		users := stubUserFetcher{
+			getFn: func(id string) (domain.User, error) {
+				return domain.User{Id: id, Network: warpnet.WarpnetName}, nil
+			},
+			whoToFollowFn: func(*uint64, *string) ([]domain.User, string, error) {
+				return []domain.User{
+					{Id: "offline", NodeId: "n1", Network: warpnet.WarpnetName, IsOffline: true},
+					{Id: ownerId, NodeId: "own-node", Network: warpnet.WarpnetName},
+					{Id: "already-followed", NodeId: "n2", Network: warpnet.WarpnetName},
+					{Id: "shared-node-old", NodeId: "n3", Network: warpnet.WarpnetName, CreatedAt: older},
+					{Id: "shared-node-new", NodeId: "n3", Network: warpnet.WarpnetName, CreatedAt: newer},
+					{Id: "mastodon-1", NodeId: "n4", Network: mastodon.Network},
+				}, "cursor-1", nil
+			},
+		}
+		follows := stubUserFollowsCounter{getFollowingsFn: func(string, *uint64, *string) ([]string, string, error) {
+			return []string{"already-followed"}, "", nil
+		}}
+
+		out, err := StreamGetWhoToFollowHandler(auth, users, follows)(
+			marshal(t, event.GetAllUsersEvent{UserId: ownerId}), nil)
+		require.NoError(t, err)
+
+		resp := out.(event.UsersResponse)
+		ids := make([]string, 0, len(resp.Users))
+		for _, u := range resp.Users {
+			ids = append(ids, u.Id)
+		}
+		// one entry per node: the newer of the two n3 records wins
+		require.Contains(t, ids, "shared-node-new")
+		require.NotContains(t, ids, "shared-node-old")
+		require.NotContains(t, ids, "offline")
+		require.NotContains(t, ids, ownerId)
+		require.NotContains(t, ids, "already-followed")
+		require.Equal(t, "cursor-1", resp.Cursor)
+	})
+
+	t.Run("a foreign-network profile hides other networks", func(t *testing.T) {
+		users := stubUserFetcher{
+			getFn: func(id string) (domain.User, error) {
+				return domain.User{Id: id, Network: mastodon.Network}, nil
+			},
+			whoToFollowFn: func(*uint64, *string) ([]domain.User, string, error) {
+				return []domain.User{{Id: "warp-1", NodeId: "n1", Network: warpnet.WarpnetName}}, "", nil
+			},
+		}
+		out, err := StreamGetWhoToFollowHandler(auth, users, stubUserFollowsCounter{})(
+			marshal(t, event.GetAllUsersEvent{UserId: "someone-else"}), nil)
+		require.NoError(t, err)
+		require.Empty(t, out.(event.UsersResponse).Users)
+	})
+}

--- a/core/handler/misc_branches_test.go
+++ b/core/handler/misc_branches_test.go
@@ -1,0 +1,250 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamTimelineNewTweetHandlerBranches(t *testing.T) {
+	const owner, author = "owner-1", "author-1"
+	nodeId, s := nodeIdentity(t)
+
+	authorRepo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: nodeId.String()}, nil
+	}}
+	auth := stubAuth{owner: domain.Owner{UserId: owner}}
+	newTweet := event.NewTweetEvent{Id: "tweet-1", UserId: author, Text: "hello", Username: "author"}
+
+	handler := func(repo stubTweetRepo, timeline stubTimelineRepo, follows stubFollowChecker) warpnet.WarpHandlerFunc {
+		return StreamTimelineNewTweetHandler(auth, repo, timeline, follows, authorRepo)
+	}
+
+	t.Run("invalid payload", func(t *testing.T) {
+		_, err := handler(stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{})([]byte("{"), s)
+		require.Error(t, err)
+	})
+
+	t.Run("foreign author is rejected", func(t *testing.T) {
+		foreign := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "another-node"}, nil
+		}}
+		_, err := StreamTimelineNewTweetHandler(auth, stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{}, foreign)(
+			marshal(t, newTweet), s)
+		require.ErrorIs(t, err, warpnet.ErrForeignAuthor)
+	})
+
+	t.Run("a moderated tweet is blocklisted instead of stored", func(t *testing.T) {
+		blocklisted := ""
+		repo := stubTweetRepo{blocklistFn: func(id string) error {
+			blocklisted = id
+			return nil
+		}}
+		fail := domain.FAIL
+		moderated := newTweet
+		moderated.Moderation = &domain.TweetModeration{IsOk: fail}
+
+		_, err := handler(repo, stubTimelineRepo{}, stubFollowChecker{})(marshal(t, moderated), s)
+		require.NoError(t, err)
+		require.Equal(t, "tweet-1", blocklisted)
+	})
+
+	t.Run("an invalid tweet is rejected", func(t *testing.T) {
+		empty := newTweet
+		empty.Text = ""
+		_, err := handler(stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{})(marshal(t, empty), s)
+		require.Error(t, err)
+	})
+
+	t.Run("the owner's own tweet is acknowledged, not re-stored", func(t *testing.T) {
+		own := newTweet
+		own.UserId = owner
+
+		out, err := handler(stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{})(marshal(t, own), s)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+
+	t.Run("a stranger's tweet is acknowledged, not stored", func(t *testing.T) {
+		out, err := handler(stubTweetRepo{}, stubTimelineRepo{}, stubFollowChecker{})(marshal(t, newTweet), s)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+
+	following := stubFollowChecker{following: true}
+
+	t.Run("a store failure surfaces", func(t *testing.T) {
+		repoErr := errors.New("store down")
+		repo := stubTweetRepo{createFn: func(string, domain.Tweet) (domain.Tweet, error) {
+			return domain.Tweet{}, repoErr
+		}}
+		_, err := handler(repo, stubTimelineRepo{}, following)(marshal(t, newTweet), s)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("a tweet stored without an id is rejected", func(t *testing.T) {
+		repo := stubTweetRepo{createFn: func(_ string, tw domain.Tweet) (domain.Tweet, error) {
+			tw.Id = ""
+			return tw, nil
+		}}
+		_, err := handler(repo, stubTimelineRepo{}, following)(marshal(t, newTweet), s)
+		require.Error(t, err)
+	})
+
+	t.Run("a timeline failure is tolerated", func(t *testing.T) {
+		timeline := stubTimelineRepo{addFn: func(string, domain.Tweet) error {
+			return errors.New("timeline down")
+		}}
+		out, err := handler(stubTweetRepo{}, timeline, following)(marshal(t, newTweet), s)
+		require.NoError(t, err)
+		require.NotEmpty(t, out.(domain.Tweet).Id)
+	})
+}
+
+func TestStreamUnsubscribeUserHandlerBranches(t *testing.T) {
+	const self, target = "self-1", "target-1"
+
+	t.Run("invalid payload", func(t *testing.T) {
+		_, err := StreamUnsubscribeUserHandler(stubSubscriptionRepo{})([]byte("{"), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty ids", func(t *testing.T) {
+		h := StreamUnsubscribeUserHandler(stubSubscriptionRepo{})
+		_, err := h(marshal(t, event.UnsubscribeUserEvent{TargetId: target}), nil)
+		require.Error(t, err)
+		_, err = h(marshal(t, event.UnsubscribeUserEvent{SelfId: self}), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("a store failure surfaces", func(t *testing.T) {
+		repoErr := errors.New("store down")
+		h := StreamUnsubscribeUserHandler(stubSubscriptionRepo{
+			unsubscribeFn: func(string, string) error { return repoErr },
+		})
+		_, err := h(marshal(t, event.UnsubscribeUserEvent{SelfId: self, TargetId: target}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		out, err := StreamUnsubscribeUserHandler(stubSubscriptionRepo{})(
+			marshal(t, event.UnsubscribeUserEvent{SelfId: self, TargetId: target}), nil)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+}
+
+type stubSubscriptionRepo struct {
+	subscribeFn   func(selfId, targetId string) error
+	unsubscribeFn func(selfId, targetId string) error
+}
+
+func (s stubSubscriptionRepo) Subscribe(selfId, targetId string) error {
+	if s.subscribeFn != nil {
+		return s.subscribeFn(selfId, targetId)
+	}
+	return nil
+}
+
+func (s stubSubscriptionRepo) Unsubscribe(selfId, targetId string) error {
+	if s.unsubscribeFn != nil {
+		return s.unsubscribeFn(selfId, targetId)
+	}
+	return nil
+}
+
+func TestForwardToOwnerBranches(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+	ev := event.GetTweetReactorsEvent{TweetId: "tweet-1", OwnerUserId: "author-1"}
+
+	t.Run("no owner or no streamer stays local", func(t *testing.T) {
+		_, ok, err := forwardToOwner("", &fakeEngagementStreamer{}, stubReactedUserFetcher{}, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.False(t, ok)
+
+		_, ok, err = forwardToOwner("author-1", nil, stubReactedUserFetcher{}, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("the owner is this node", func(t *testing.T) {
+		_, ok, err := forwardToOwner(selfInfo.OwnerId, &fakeEngagementStreamer{info: selfInfo},
+			stubReactedUserFetcher{}, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("an unknown owner stays local", func(t *testing.T) {
+		users := stubReactedUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		_, ok, err := forwardToOwner("author-1", &fakeEngagementStreamer{info: selfInfo},
+			users, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("a lookup failure surfaces", func(t *testing.T) {
+		lookupErr := errors.New("store down")
+		users := stubReactedUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, lookupErr
+		}}
+		_, _, err := forwardToOwner("author-1", &fakeEngagementStreamer{info: selfInfo},
+			users, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.ErrorIs(t, err, lookupErr)
+	})
+
+	t.Run("an owner hosted here stays local", func(t *testing.T) {
+		users := stubReactedUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		_, ok, err := forwardToOwner("author-1", &fakeEngagementStreamer{info: selfInfo},
+			users, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("a remote page is used", func(t *testing.T) {
+		users := stubReactedUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "other-node"}, nil
+		}}
+		body, err := json.Marshal(event.UsersResponse{Users: []domain.User{{Id: "reactor-1"}}})
+		require.NoError(t, err)
+
+		out, ok, err := forwardToOwner("author-1",
+			&fakeEngagementStreamer{info: selfInfo, response: body},
+			users, event.PUBLIC_GET_TWEET_REACTORS, ev)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Len(t, out.Users, 1)
+	})
+}
+
+func TestEngagementHandlersSurfaceStoreFailures(t *testing.T) {
+	repoErr := errors.New("index down")
+
+	_, err := StreamGetTweetReactorsHandler(
+		stubReactorsRepo{reactorsFn: func(string, *uint64, *string) ([]string, string, error) {
+			return nil, "", repoErr
+		}}, stubReactedUserFetcher{}, &fakeEngagementStreamer{},
+	)(marshal(t, event.GetTweetReactorsEvent{TweetId: "tweet-1"}), nil)
+	require.ErrorIs(t, err, repoErr)
+
+	_, err = StreamGetTweetRetweetersHandler(
+		stubRetweetersRepo{retweetersFn: func(string, *uint64, *string) ([]string, string, error) {
+			return nil, "", repoErr
+		}}, stubReactedUserFetcher{}, &fakeEngagementStreamer{},
+	)(marshal(t, event.GetTweetRetweetersEvent{TweetId: "tweet-1"}), nil)
+	require.ErrorIs(t, err, repoErr)
+}
+
+var _ = stream.WarpRoute("")

--- a/core/handler/poll_view_branches_test.go
+++ b/core/handler/poll_view_branches_test.go
@@ -1,0 +1,294 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalPoll(t *testing.T) {
+	t.Run("nil repo", func(t *testing.T) {
+		_, ok := localPoll(nil, "author", "tweet")
+		require.False(t, ok)
+	})
+
+	t.Run("tweet not found", func(t *testing.T) {
+		_, ok := localPoll(stubPollTweetRepo{}, "author", "tweet")
+		require.False(t, ok)
+	})
+
+	t.Run("tweet without a poll", func(t *testing.T) {
+		repo := stubPollTweetRepo{getFn: func(_, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id}, nil
+		}}
+		_, ok := localPoll(repo, "author", "tweet")
+		require.False(t, ok)
+	})
+
+	t.Run("poll with no options", func(t *testing.T) {
+		repo := stubPollTweetRepo{getFn: func(_, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, Poll: &domain.Poll{}}, nil
+		}}
+		_, ok := localPoll(repo, "author", "tweet")
+		require.False(t, ok)
+	})
+
+	t.Run("poll present", func(t *testing.T) {
+		poll, ok := localPoll(pollTweet("tweet", "author", time.Now().Add(time.Hour)), "author", "tweet")
+		require.True(t, ok)
+		require.Len(t, poll.Options, 2)
+	})
+}
+
+func TestLocalVotedOption(t *testing.T) {
+	t.Run("no user", func(t *testing.T) {
+		require.Nil(t, localVotedOption(stubPollRepo{}, "tweet", ""))
+	})
+
+	t.Run("lookup failure", func(t *testing.T) {
+		repo := stubPollRepo{votedFn: func(string, string) (int, bool, error) {
+			return 0, false, errors.New("down")
+		}}
+		require.Nil(t, localVotedOption(repo, "tweet", "user"))
+	})
+
+	t.Run("no vote recorded", func(t *testing.T) {
+		require.Nil(t, localVotedOption(stubPollRepo{}, "tweet", "user"))
+	})
+
+	t.Run("vote recorded", func(t *testing.T) {
+		repo := stubPollRepo{votedFn: func(string, string) (int, bool, error) {
+			return 1, true, nil
+		}}
+		got := localVotedOption(repo, "tweet", "user")
+		require.NotNil(t, got)
+		require.Equal(t, 1, *got)
+	})
+}
+
+func TestPollResults(t *testing.T) {
+	t.Run("rejects bad option counts", func(t *testing.T) {
+		_, err := pollResults(stubPollRepo{}, "tweet", "user", 0)
+		require.Error(t, err)
+		_, err = pollResults(stubPollRepo{}, "tweet", "user", 21)
+		require.Error(t, err)
+	})
+
+	t.Run("propagates the tally failure", func(t *testing.T) {
+		repoErr := errors.New("down")
+		repo := stubPollRepo{resultsFn: func(string, int) ([]uint64, error) { return nil, repoErr }}
+		_, err := pollResults(repo, "tweet", "user", 2)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("sums the votes", func(t *testing.T) {
+		repo := stubPollRepo{resultsFn: func(string, int) ([]uint64, error) {
+			return []uint64{2, 3}, nil
+		}}
+		out, err := pollResults(repo, "tweet", "user", 2)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), out.TotalVotes)
+	})
+}
+
+func TestPropagateVote(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+	ev := event.PollVoteEvent{TweetId: "tweet-1", UserId: "author-1", OwnerId: "voter-1"}
+
+	t.Run("author hosted here is skipped", func(t *testing.T) {
+		propagateVote(event.PollVoteEvent{UserId: selfInfo.OwnerId}, stubUserFetcher{}, stubStreamer{}, selfInfo)
+	})
+
+	t.Run("unknown author is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		propagateVote(ev, repo, stubStreamer{}, selfInfo)
+	})
+
+	t.Run("lookup failure is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, errors.New("down")
+		}}
+		propagateVote(ev, repo, stubStreamer{}, selfInfo)
+	})
+
+	t.Run("author on this node is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		propagateVote(ev, repo, stubStreamer{}, selfInfo)
+	})
+
+	otherNode := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: "other-node"}, nil
+	}}
+
+	t.Run("offline author is not a failure", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}}
+		propagateVote(ev, otherNode, streamer, selfInfo)
+	})
+
+	t.Run("stream failure is swallowed", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("boom")
+		}}
+		propagateVote(ev, otherNode, streamer, selfInfo)
+	})
+
+	t.Run("remote error response is swallowed", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "rejected"})
+		}}
+		propagateVote(ev, otherNode, streamer, selfInfo)
+	})
+}
+
+func TestForwardPollRead(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+	ev := event.GetPollEvent{TweetId: "tweet-1", UserId: "author-1", OwnerId: "reader-1"}
+
+	t.Run("own poll is read locally", func(t *testing.T) {
+		_, ok := forwardPollRead(event.GetPollEvent{UserId: selfInfo.OwnerId}, stubUserFetcher{}, stubStreamer{nodeInfo: selfInfo})
+		require.False(t, ok)
+	})
+
+	t.Run("unknown author is read locally", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		_, ok := forwardPollRead(ev, repo, stubStreamer{nodeInfo: selfInfo})
+		require.False(t, ok)
+	})
+
+	t.Run("author on this node is read locally", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		_, ok := forwardPollRead(ev, repo, stubStreamer{nodeInfo: selfInfo})
+		require.False(t, ok)
+	})
+
+	otherNode := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: "other-node"}, nil
+	}}
+
+	t.Run("offline author is read locally", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}}
+		_, ok := forwardPollRead(ev, otherNode, streamer)
+		require.False(t, ok)
+	})
+
+	t.Run("stream failure is read locally", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("boom")
+		}}
+		_, ok := forwardPollRead(ev, otherNode, streamer)
+		require.False(t, ok)
+	})
+
+	t.Run("error response is read locally", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "no poll"})
+		}}
+		_, ok := forwardPollRead(ev, otherNode, streamer)
+		require.False(t, ok)
+	})
+
+	t.Run("empty tally is read locally", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.PollResultsResponse{TweetId: "tweet-1"})
+		}}
+		_, ok := forwardPollRead(ev, otherNode, streamer)
+		require.False(t, ok)
+	})
+
+	t.Run("remote tally wins", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.PollResultsResponse{TweetId: "tweet-1", Votes: []uint64{1, 2}, TotalVotes: 3})
+		}}
+		out, ok := forwardPollRead(ev, otherNode, streamer)
+		require.True(t, ok)
+		require.Equal(t, uint64(3), out.TotalVotes)
+	})
+}
+
+func TestForwardViewToAuthor(t *testing.T) {
+	ev := event.ViewEvent{TweetId: "tweet-1", UserId: "author-1", ViewerId: "viewer-1"}
+
+	t.Run("unknown author counts nothing", func(t *testing.T) {
+		repo := stubReactionUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, repo, stubStreamer{}))
+	})
+
+	t.Run("lookup failure counts nothing", func(t *testing.T) {
+		repo := stubReactionUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, errors.New("down")
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, repo, stubStreamer{}))
+	})
+
+	t.Run("offline author counts nothing", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, stubReactionUserRepo{}, streamer))
+	})
+
+	t.Run("stream failure counts nothing", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("boom")
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, stubReactionUserRepo{}, streamer))
+	})
+
+	t.Run("error response counts nothing", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "nope"})
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, stubReactionUserRepo{}, streamer))
+	})
+
+	t.Run("garbage response counts nothing", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		require.Zero(t, forwardViewToAuthor(ev, stubReactionUserRepo{}, streamer))
+	})
+
+	t.Run("author's count is returned", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ViewsCountResponse{Count: 7})
+		}}
+		require.Equal(t, uint64(7), forwardViewToAuthor(ev, stubReactionUserRepo{}, streamer))
+	})
+}
+
+func TestStreamViewHandlerRecordFailure(t *testing.T) {
+	const author, viewer, tweetId = "author-1", "viewer-1", "tweet-1"
+
+	userRepo, s := actorStream(t, viewer, nil)
+	repoErr := errors.New("counter down")
+	repo := stubViewRepo{recordFn: func(string, string) (uint64, error) { return 0, repoErr }}
+
+	h := StreamViewHandler(repo, userRepo, stubStreamer{nodeInfo: warpnet.NodeInfo{OwnerId: author}})
+	_, err := h(marshal(t, event.ViewEvent{TweetId: tweetId, UserId: author, ViewerId: viewer}), s)
+	require.ErrorIs(t, err, repoErr)
+}

--- a/core/handler/retweet_test.go
+++ b/core/handler/retweet_test.go
@@ -80,10 +80,14 @@ func (s stubReTweetRepo) Retweeters(tweetId string, limit *uint64, cursor *strin
 }
 
 type stubTimelineRepo struct {
-	addFn func(userId string, tweet domain.Tweet) error
+	addFn    func(userId string, tweet domain.Tweet) error
+	deleteFn func(userID, tweetID string) error
 }
 
 func (s stubTimelineRepo) DeleteTweetFromTimeline(userID, tweetID string) error {
+	if s.deleteFn != nil {
+		return s.deleteFn(userID, tweetID)
+	}
 	return nil
 }
 

--- a/core/handler/tweet_branches_test.go
+++ b/core/handler/tweet_branches_test.go
@@ -1,0 +1,464 @@
+//nolint:all
+package handler
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeIdentity mints a real libp2p peer id plus a loopback stream whose remote
+// peer is that id, so handlers guarded by VerifyAuthorship accept the caller.
+func nodeIdentity(t *testing.T) (warpnet.WarpPeerID, warpnet.WarpStream) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	id, err := warpnet.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	_, server := stream.NewLoopbackStream(id, id, "/test/route/0.0.0")
+	return id, server
+}
+
+func TestStreamPinUnpinTweetHandler(t *testing.T) {
+	nodeId, s := nodeIdentity(t)
+	const userId, tweetId = "user-1", "tweet-1"
+
+	authorRepo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: nodeId.String()}, nil
+	}}
+
+	t.Run("pins", func(t *testing.T) {
+		out, err := StreamPinTweetHandler(stubTweetRepo{}, authorRepo)(
+			marshal(t, event.PinTweetEvent{UserId: userId, TweetId: tweetId}), s)
+		require.NoError(t, err)
+		require.True(t, out.(domain.Tweet).Pinned)
+	})
+
+	t.Run("unpins", func(t *testing.T) {
+		out, err := StreamUnpinTweetHandler(stubTweetRepo{}, authorRepo)(
+			marshal(t, event.PinTweetEvent{UserId: userId, TweetId: tweetId}), s)
+		require.NoError(t, err)
+		require.False(t, out.(domain.Tweet).Pinned)
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		_, err := StreamPinTweetHandler(stubTweetRepo{}, authorRepo)([]byte("{"), s)
+		require.Error(t, err)
+	})
+
+	t.Run("empty ids", func(t *testing.T) {
+		_, err := StreamPinTweetHandler(stubTweetRepo{}, authorRepo)(
+			marshal(t, event.PinTweetEvent{TweetId: tweetId}), s)
+		require.Error(t, err)
+
+		_, err = StreamUnpinTweetHandler(stubTweetRepo{}, authorRepo)(
+			marshal(t, event.PinTweetEvent{UserId: userId}), s)
+		require.Error(t, err)
+	})
+
+	t.Run("foreign author is rejected", func(t *testing.T) {
+		foreign := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "somebody-else"}, nil
+		}}
+		_, err := StreamPinTweetHandler(stubTweetRepo{}, foreign)(
+			marshal(t, event.PinTweetEvent{UserId: userId, TweetId: tweetId}), s)
+		require.ErrorIs(t, err, warpnet.ErrForeignAuthor)
+	})
+
+	t.Run("missing tweet", func(t *testing.T) {
+		repoErr := errors.New("gone")
+		_, err := StreamPinTweetHandler(stubTweetRepo{getFn: func(_, _ string) (domain.Tweet, error) {
+			return domain.Tweet{}, repoErr
+		}}, authorRepo)(marshal(t, event.PinTweetEvent{UserId: userId, TweetId: tweetId}), s)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("someone else's tweet", func(t *testing.T) {
+		_, err := StreamPinTweetHandler(stubTweetRepo{getFn: func(_, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, UserId: "another-user"}, nil
+		}}, authorRepo)(marshal(t, event.PinTweetEvent{UserId: userId, TweetId: tweetId}), s)
+		require.Error(t, err)
+	})
+}
+
+func TestStreamEditTweetHandlerBranches(t *testing.T) {
+	const userId, tweetId = "user-1", "tweet-1"
+
+	t.Run("no-op edit skips the revision", func(t *testing.T) {
+		repo := stubTweetRepo{getFn: func(u, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, UserId: u, Text: "same"}, nil
+		}}
+		out, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "same"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, "same", domain.Tweet(out.(event.EditTweetResponse)).Text)
+	})
+
+	t.Run("only the author may edit", func(t *testing.T) {
+		repo := stubTweetRepo{getFn: func(_, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, UserId: "another-user", Text: "old"}, nil
+		}}
+		_, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("missing tweet", func(t *testing.T) {
+		repoErr := errors.New("gone")
+		repo := stubTweetRepo{getFn: func(_, _ string) (domain.Tweet, error) {
+			return domain.Tweet{}, repoErr
+		}}
+		_, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.ErrorIs(t, err, repoErr)
+	})
+
+	t.Run("timeline refresh failure is tolerated", func(t *testing.T) {
+		repo := stubTweetRepo{getFn: func(u, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, UserId: u, Text: "old"}, nil
+		}}
+		timeline := stubTimelineRepo{addFn: func(_ string, _ domain.Tweet) error {
+			return errors.New("timeline down")
+		}}
+		_, err := StreamEditTweetHandler(repo, timeline)(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil timeline repo", func(t *testing.T) {
+		repo := stubTweetRepo{getFn: func(u, id string) (domain.Tweet, error) {
+			return domain.Tweet{Id: id, UserId: u, Text: "old"}, nil
+		}}
+		_, err := StreamEditTweetHandler(repo, nil)(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("cancels retweets of the edited tweet", func(t *testing.T) {
+		var cancelled []string
+		repo := stubTweetRepo{
+			getFn: func(u, id string) (domain.Tweet, error) {
+				return domain.Tweet{Id: id, UserId: u, Text: "old"}, nil
+			},
+			unRetweetFn: func(by, id string) error {
+				cancelled = append(cancelled, by)
+				return nil
+			},
+			retweetersFn: func(_ string, _ *uint64, _ *string) ([]string, string, error) {
+				return []string{"rt-1", "rt-2"}, "", nil
+			},
+		}
+		_, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"rt-1", "rt-2"}, cancelled)
+	})
+
+	t.Run("retweeter listing failure is tolerated", func(t *testing.T) {
+		repo := stubTweetRepo{
+			getFn: func(u, id string) (domain.Tweet, error) {
+				return domain.Tweet{Id: id, UserId: u, Text: "old"}, nil
+			},
+			retweetersFn: func(_ string, _ *uint64, _ *string) ([]string, string, error) {
+				return nil, "", errors.New("index down")
+			},
+		}
+		_, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("unretweet failure is tolerated", func(t *testing.T) {
+		repo := stubTweetRepo{
+			getFn: func(u, id string) (domain.Tweet, error) {
+				return domain.Tweet{Id: id, UserId: u, Text: "old"}, nil
+			},
+			unRetweetFn: func(_, _ string) error { return errors.New("stuck") },
+			retweetersFn: func(_ string, _ *uint64, _ *string) ([]string, string, error) {
+				return []string{"rt-1"}, "", nil
+			},
+		}
+		_, err := StreamEditTweetHandler(repo, stubTimelineRepo{})(
+			marshal(t, event.EditTweetEvent{UserId: userId, TweetId: tweetId, Text: "new"}), nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestOwnReaction(t *testing.T) {
+	t.Run("no owner", func(t *testing.T) {
+		require.Empty(t, ownReaction(stubTweetReactionRepo{}, "tweet-1", ""))
+	})
+
+	t.Run("lookup failure is empty", func(t *testing.T) {
+		repo := stubTweetReactionRepo{reactionFn: func(_, _ string) (string, error) {
+			return "", errors.New("down")
+		}}
+		require.Empty(t, ownReaction(repo, "tweet-1", "owner-1"))
+	})
+
+	t.Run("returns the emoji", func(t *testing.T) {
+		repo := stubTweetReactionRepo{reactionFn: func(_, _ string) (string, error) {
+			return "👍", nil
+		}}
+		require.Equal(t, "👍", ownReaction(repo, "tweet-1", "owner-1"))
+	})
+}
+
+func TestForwardThreadReplies(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId}
+
+	t.Run("no root user means handle locally", func(t *testing.T) {
+		_, ok := forwardThreadReplies(stubTweetUserRepo{}, stubStreamer{nodeInfo: selfInfo}, event.GetAllTweetsEvent{})
+		require.False(t, ok)
+	})
+
+	t.Run("unknown author means handle locally", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		_, ok := forwardThreadReplies(repo, stubStreamer{nodeInfo: selfInfo}, event.GetAllTweetsEvent{RootUserId: "u"})
+		require.False(t, ok)
+	})
+
+	t.Run("author on this node means handle locally", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		_, ok := forwardThreadReplies(repo, stubStreamer{nodeInfo: selfInfo}, event.GetAllTweetsEvent{RootUserId: "u"})
+		require.False(t, ok)
+	})
+
+	t.Run("stream failure means handle locally", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "other-node"}, nil
+		}}
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("offline")
+		}}
+		_, ok := forwardThreadReplies(repo, streamer, event.GetAllTweetsEvent{RootUserId: "u"})
+		require.False(t, ok)
+	})
+
+	t.Run("garbage response means handle locally", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "other-node"}, nil
+		}}
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		_, ok := forwardThreadReplies(repo, streamer, event.GetAllTweetsEvent{RootUserId: "u"})
+		require.False(t, ok)
+	})
+
+	t.Run("forwards", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "other-node"}, nil
+		}}
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.TweetsResponse{UserId: "u", Tweets: []domain.Tweet{{Id: "t1"}}})
+		}}
+		resp, ok := forwardThreadReplies(repo, streamer, event.GetAllTweetsEvent{RootUserId: "u"})
+		require.True(t, ok)
+		require.Len(t, resp.Tweets, 1)
+	})
+}
+
+func TestTweetsRefreshBackground(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+	ev := event.GetAllTweetsEvent{UserId: "other-user"}
+
+	t.Run("unknown user is skipped", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, repo, ev, stubStreamer{nodeInfo: selfInfo})
+	})
+
+	t.Run("lookup failure is skipped", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, errors.New("down")
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, repo, ev, stubStreamer{nodeInfo: selfInfo})
+	})
+
+	t.Run("own node is skipped", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, repo, ev, stubStreamer{nodeInfo: selfInfo})
+	})
+
+	otherNodeRepo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: "other-node"}, nil
+	}}
+
+	t.Run("stream failure is skipped", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("offline")
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, otherNodeRepo, ev, streamer)
+	})
+
+	t.Run("error response is skipped", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "boom"})
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, otherNodeRepo, ev, streamer)
+	})
+
+	t.Run("garbage response is skipped", func(t *testing.T) {
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		tweetsRefreshBackground(stubTweetRepo{}, otherNodeRepo, ev, streamer)
+	})
+
+	t.Run("caches fetched tweets and skips blocklisted ones", func(t *testing.T) {
+		var cached []string
+		repo := stubTweetRepo{
+			isBlocklistedFn: func(id string) bool { return id == "blocked" },
+			createWithTTLFn: func(_ string, tw domain.Tweet, _ time.Duration) (domain.Tweet, error) {
+				cached = append(cached, tw.Id)
+				return tw, nil
+			},
+		}
+		streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.TweetsResponse{Tweets: []domain.Tweet{
+				{Id: "ok", UserId: "other-user"},
+				{Id: "blocked", UserId: "other-user"},
+			}})
+		}}
+		tweetsRefreshBackground(repo, otherNodeRepo, ev, streamer)
+		require.Equal(t, []string{"ok"}, cached)
+	})
+}
+
+func TestStreamGetTweetsHandlerRefreshesWhenEmpty(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+
+	calls := 0
+	repo := stubTweetRepo{listFn: func(userId string, _ *uint64, _ *string) ([]domain.Tweet, string, error) {
+		calls++
+		if calls == 1 {
+			return nil, "", nil // cold cache forces the synchronous refresh
+		}
+		return []domain.Tweet{{Id: "t1", UserId: userId}}, "cursor-1", nil
+	}}
+	userRepo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: "other-node"}, nil
+	}}
+	streamer := stubStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+		return json.Marshal(event.TweetsResponse{Tweets: []domain.Tweet{{Id: "t1", UserId: "other-user"}}})
+	}}
+
+	out, err := StreamGetTweetsHandler(repo, userRepo, streamer)(
+		marshal(t, event.GetAllTweetsEvent{UserId: "other-user"}), nil)
+	require.NoError(t, err)
+
+	resp := out.(event.TweetsResponse)
+	require.Len(t, resp.Tweets, 1)
+	require.Equal(t, "cursor-1", resp.Cursor)
+}
+
+func TestStreamGetTweetHandlerFallsBackToLocal(t *testing.T) {
+	const owner, other = "owner-1", "other-user"
+	auth := stubAuth{owner: domain.Owner{UserId: owner}}
+	otherNodeRepo := stubTweetUserRepo{getFn: func(id string) (domain.User, error) {
+		return domain.User{Id: id, NodeId: "other-node"}, nil
+	}}
+	ev := event.GetTweetEvent{UserId: other, TweetId: "t1"}
+
+	t.Run("user lookup failure", func(t *testing.T) {
+		repo := stubTweetUserRepo{getFn: func(string) (domain.User, error) {
+			return domain.User{}, errors.New("down")
+		}}
+		_, err := StreamGetTweetHandler(stubTweetRepo{}, auth, repo, stubStreamer{})(marshal(t, ev), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("stream failure", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("boom")
+		}}
+		_, err := StreamGetTweetHandler(stubTweetRepo{}, auth, otherNodeRepo, streamer)(marshal(t, ev), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("garbage response falls back to the local copy", func(t *testing.T) {
+		streamer := stubStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		out, err := StreamGetTweetHandler(stubTweetRepo{}, auth, otherNodeRepo, streamer)(marshal(t, ev), nil)
+		require.NoError(t, err)
+		require.Equal(t, "cached", out.(domain.Tweet).Text)
+	})
+}
+
+func TestStreamDeleteTweetHandlerBranches(t *testing.T) {
+	const owner, tweetId = "owner-1", "tweet-1"
+
+	t.Run("unreact failure is tolerated", func(t *testing.T) {
+		reactions := stubTweetReactionRepo{unreactFn: func(_, _ string) (uint64, error) {
+			return 0, errors.New("down")
+		}}
+		out, err := StreamDeleteTweetHandler(
+			stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}},
+			stubTweetRepo{}, stubTimelineRepo{}, reactions, stubStreamer{},
+		)(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		require.NoError(t, err)
+		require.Equal(t, event.Accepted, out)
+	})
+
+	t.Run("retweet record is unwound", func(t *testing.T) {
+		by := "retweeter-1"
+		var unretweeted string
+		repo := stubTweetRepo{
+			getFn: func(_, id string) (domain.Tweet, error) {
+				return domain.Tweet{Id: id, RetweetedBy: &by}, nil
+			},
+			unRetweetFn: func(byUser, _ string) error {
+				unretweeted = byUser
+				return nil
+			},
+		}
+		_, err := StreamDeleteTweetHandler(
+			stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}},
+			repo, stubTimelineRepo{}, stubTweetReactionRepo{}, stubStreamer{},
+		)(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		require.NoError(t, err)
+		require.Equal(t, by, unretweeted)
+	})
+
+	t.Run("timeline delete failure is tolerated", func(t *testing.T) {
+		timeline := stubTimelineRepo{deleteFn: func(_, _ string) error { return errors.New("down") }}
+		_, err := StreamDeleteTweetHandler(
+			stubTweetBroadcaster{}, stubAuth{owner: domain.Owner{UserId: owner}},
+			stubTweetRepo{}, timeline, stubTweetReactionRepo{}, stubStreamer{},
+		)(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("broadcast failure is tolerated", func(t *testing.T) {
+		broadcaster := stubTweetBroadcaster{publishFn: func(_, _ string, _ []byte) error {
+			return errors.New("no followers channel")
+		}}
+		_, err := StreamDeleteTweetHandler(
+			broadcaster, stubAuth{owner: domain.Owner{UserId: owner}},
+			stubTweetRepo{}, stubTimelineRepo{}, stubTweetReactionRepo{}, stubStreamer{},
+		)(marshal(t, event.DeleteTweetEvent{UserId: owner, TweetId: tweetId}), nil)
+		require.NoError(t, err)
+	})
+}

--- a/core/handler/tweet_test.go
+++ b/core/handler/tweet_test.go
@@ -34,6 +34,7 @@ type stubTweetRepo struct {
 	getReplyFn      func(rootID, replyID string) (domain.Tweet, error)
 	deleteReplyFn   func(rootID, replyID string) (domain.Tweet, error)
 	repliesFn       func(parentID string, limit *uint64, cursor *string) ([]domain.Tweet, string, error)
+	retweetersFn    func(tweetId string, limit *uint64, cursor *string) ([]string, string, error)
 }
 
 func (s stubTweetRepo) TweetsCount(userId string) (uint64, error) {
@@ -92,6 +93,9 @@ func (s stubTweetRepo) UnRetweet(retweetedByUserID, tweetId string, _ bool) erro
 	return nil
 }
 func (s stubTweetRepo) Retweeters(tweetId string, limit *uint64, cursor *string) ([]string, string, error) {
+	if s.retweetersFn != nil {
+		return s.retweetersFn(tweetId, limit, cursor)
+	}
 	return nil, "", nil
 }
 func (s stubTweetRepo) CreateWithTTL(userId string, tweet domain.Tweet, duration time.Duration) (domain.Tweet, error) {

--- a/core/handler/user_branches_test.go
+++ b/core/handler/user_branches_test.go
@@ -1,0 +1,245 @@
+//nolint:all
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamGetUserHandlerBranches(t *testing.T) {
+	const owner = "owner-1"
+	auth := stubAuth{owner: domain.Owner{UserId: owner, NodeId: "own-node"}}
+
+	t.Run("own profile tolerates failing counters", func(t *testing.T) {
+		counterErr := errors.New("counter down")
+		follows := stubUserFollowsCounter{
+			getFollowersCountFn:  func(string) (uint64, error) { return 0, counterErr },
+			getFollowingsCountFn: func(string) (uint64, error) { return 0, counterErr },
+		}
+		tweets := stubUserTweetsCounter{tweetsCountFn: func(string) (uint64, error) {
+			return 0, counterErr
+		}}
+
+		out, err := StreamGetUserHandler(tweets, follows, stubUserFetcher{}, auth, stubUserStreamer{})(
+			marshal(t, event.GetUserEvent{UserId: owner}), nil)
+		require.NoError(t, err)
+		require.Equal(t, owner, out.(domain.User).Id)
+	})
+
+	t.Run("unknown user is fetched from its node and cached", func(t *testing.T) {
+		var created domain.User
+		repo := stubUserFetcher{
+			getFn: func(string) (domain.User, error) {
+				return domain.User{}, database.ErrUserNotFound
+			},
+			createFn: func(u domain.User) (domain.User, error) {
+				created = u
+				return u, nil
+			},
+		}
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{Id: "other-1", Username: "remote-name"})
+		}}
+
+		out, err := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, repo, auth, streamer)(
+			marshal(t, event.GetUserEvent{UserId: "other-1", NodeId: "other-node"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, "remote-name", out.(domain.User).Username)
+		require.Equal(t, "remote-name", created.Username)
+	})
+
+	t.Run("unknown and unreachable user is an error", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("offline")
+		}}
+
+		_, err := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, repo, auth, streamer)(
+			marshal(t, event.GetUserEvent{UserId: "other-1", NodeId: "other-node"}), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("user hosted on this node is returned as-is", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "own-node"}, nil
+		}}
+		out, err := StreamGetUserHandler(stubUserTweetsCounter{}, stubUserFollowsCounter{}, repo, auth, stubUserStreamer{})(
+			marshal(t, event.GetUserEvent{UserId: "other-1"}), nil)
+		require.NoError(t, err)
+		require.Equal(t, "own-node", out.(domain.User).NodeId)
+	})
+}
+
+func TestUpdateOtherUser(t *testing.T) {
+	base := domain.User{Id: "other-1", NodeId: "other-node", Username: "known"}
+	ev := event.GetUserEvent{UserId: base.Id}
+
+	t.Run("offline node marks the user offline", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, warpnet.ErrNodeIsOffline
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.True(t, got.IsOffline)
+	})
+
+	t.Run("stream failure returns the user untouched", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("boom")
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.False(t, got.IsOffline)
+		require.Equal(t, "known", got.Username)
+	})
+
+	t.Run("user-not-found response marks the user offline", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "user not found"})
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.True(t, got.IsOffline)
+	})
+
+	t.Run("other error responses leave the user alone", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "internal"})
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.False(t, got.IsOffline)
+	})
+
+	t.Run("garbage response leaves the user alone but stamps last-seen", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.NotNil(t, got.LastSeen)
+		require.False(t, got.IsOffline)
+	})
+
+	t.Run("valid response merges and stamps last-seen", func(t *testing.T) {
+		streamer := stubUserStreamer{genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(domain.User{Id: base.Id, Username: "fresh"})
+		}}
+		got := updateOtherUser(ev, base, streamer)
+		require.Equal(t, "fresh", got.Username)
+		require.NotNil(t, got.LastSeen)
+		require.False(t, got.IsOffline)
+	})
+}
+
+func TestRefreshUsers(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+	ev := event.GetAllUsersEvent{UserId: "other-user"}
+
+	t.Run("own owner id is skipped", func(t *testing.T) {
+		refreshUsers(stubUserFetcher{}, event.GetAllUsersEvent{UserId: selfInfo.OwnerId}, stubUserStreamer{nodeInfo: selfInfo})
+	})
+
+	t.Run("unknown user is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, database.ErrUserNotFound
+		}}
+		refreshUsers(repo, ev, stubUserStreamer{nodeInfo: selfInfo})
+	})
+
+	t.Run("lookup failure is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(string) (domain.User, error) {
+			return domain.User{}, errors.New("down")
+		}}
+		refreshUsers(repo, ev, stubUserStreamer{nodeInfo: selfInfo})
+	})
+
+	t.Run("own node is skipped", func(t *testing.T) {
+		repo := stubUserFetcher{getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: nodeId.String()}, nil
+		}}
+		refreshUsers(repo, ev, stubUserStreamer{nodeInfo: selfInfo})
+	})
+
+	otherNodeRepo := func(create func(domain.User) (domain.User, error)) stubUserFetcher {
+		return stubUserFetcher{
+			getFn: func(id string) (domain.User, error) {
+				return domain.User{Id: id, NodeId: "other-node"}, nil
+			},
+			createFn: create,
+		}
+	}
+
+	t.Run("stream failure is skipped", func(t *testing.T) {
+		streamer := stubUserStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return nil, errors.New("offline")
+		}}
+		refreshUsers(otherNodeRepo(nil), ev, streamer)
+	})
+
+	t.Run("error response is skipped", func(t *testing.T) {
+		streamer := stubUserStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.ResponseError{Message: "boom"})
+		}}
+		refreshUsers(otherNodeRepo(nil), ev, streamer)
+	})
+
+	t.Run("garbage response is skipped", func(t *testing.T) {
+		streamer := stubUserStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return []byte("{"), nil
+		}}
+		refreshUsers(otherNodeRepo(nil), ev, streamer)
+	})
+
+	t.Run("stores only foreign online users", func(t *testing.T) {
+		var stored []string
+		repo := otherNodeRepo(func(u domain.User) (domain.User, error) {
+			stored = append(stored, u.Id)
+			return u, nil
+		})
+		streamer := stubUserStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+			return json.Marshal(event.UsersResponse{Users: []domain.User{
+				{Id: "keep-me", NodeId: "far-node"},
+				{Id: "offline-one", NodeId: "far-node", IsOffline: true},
+				{Id: "loops-back", NodeId: nodeId.String()},
+				{Id: selfInfo.OwnerId, NodeId: "far-node"},
+			}})
+		}}
+		refreshUsers(repo, ev, streamer)
+		require.Equal(t, []string{"keep-me"}, stored)
+	})
+}
+
+func TestStreamGetUsersHandlerRefreshesWhenEmpty(t *testing.T) {
+	nodeId, _ := nodeIdentity(t)
+	selfInfo := warpnet.NodeInfo{ID: nodeId, OwnerId: "owner-1"}
+
+	calls := 0
+	repo := stubUserFetcher{
+		listFn: func(*uint64, *string) ([]domain.User, string, error) {
+			calls++
+			if calls == 1 {
+				return nil, "", nil
+			}
+			return []domain.User{{Id: "u1"}}, "cursor-1", nil
+		},
+		getFn: func(id string) (domain.User, error) {
+			return domain.User{Id: id, NodeId: "other-node"}, nil
+		},
+	}
+	streamer := stubUserStreamer{nodeInfo: selfInfo, genericStreamFn: func(string, stream.WarpRoute, any) ([]byte, error) {
+		return json.Marshal(event.UsersResponse{Users: []domain.User{{Id: "u1", NodeId: "far-node"}}})
+	}}
+
+	out, err := StreamGetUsersHandler(repo, streamer)(
+		marshal(t, event.GetAllUsersEvent{UserId: "other-user"}), nil)
+	require.NoError(t, err)
+	require.Len(t, out.(event.UsersResponse).Users, 1)
+	require.Equal(t, "cursor-1", out.(event.UsersResponse).Cursor)
+}

--- a/core/mastodon/mastodon_test.go
+++ b/core/mastodon/mastodon_test.go
@@ -1,0 +1,77 @@
+//nolint:all
+package mastodon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSeeder struct {
+	createErr error
+	created   []domain.User
+	updated   []domain.User
+}
+
+func (s *stubSeeder) Create(user domain.User) (domain.User, error) {
+	s.created = append(s.created, user)
+	return user, s.createErr
+}
+
+func (s *stubSeeder) Update(userId string, newUser domain.User) (domain.User, error) {
+	s.updated = append(s.updated, newUser)
+	return newUser, nil
+}
+
+func TestGatewayNodeID(t *testing.T) {
+	original := GatewayNodeID()
+	t.Cleanup(func() { gatewayNodeID = original })
+
+	require.Equal(t, DefaultGatewayNodeID, original)
+
+	SetGatewayNodeID("")
+	require.Equal(t, DefaultGatewayNodeID, GatewayNodeID(), "an empty id must not clear the default")
+
+	SetGatewayNodeID("12D3KooWCustomGateway")
+	require.Equal(t, "12D3KooWCustomGateway", GatewayNodeID())
+}
+
+func TestSeedEntryUser(t *testing.T) {
+	original := gatewayNodeID
+	t.Cleanup(func() { gatewayNodeID = original })
+
+	t.Run("creates the entry account", func(t *testing.T) {
+		repo := &stubSeeder{}
+		SeedEntryUser(repo)
+
+		require.Len(t, repo.created, 1)
+		require.Empty(t, repo.updated)
+
+		u := repo.created[0]
+		require.Equal(t, EntryHandle, u.Id)
+		require.Equal(t, Network, u.Network)
+		require.Equal(t, gatewayNodeID, u.NodeId)
+	})
+
+	t.Run("falls back to update when the account already exists", func(t *testing.T) {
+		repo := &stubSeeder{createErr: errors.New("already exists")}
+		SeedEntryUser(repo)
+
+		require.Len(t, repo.created, 1)
+		require.Len(t, repo.updated, 1)
+		require.Equal(t, EntryHandle, repo.updated[0].Id)
+	})
+
+	t.Run("uses the configured gateway", func(t *testing.T) {
+		SetGatewayNodeID("12D3KooWAnotherGateway")
+		repo := &stubSeeder{}
+		SeedEntryUser(repo)
+		require.Equal(t, "12D3KooWAnotherGateway", repo.created[0].NodeId)
+	})
+}
+
+func TestErrNotSupported(t *testing.T) {
+	require.EqualError(t, ErrNotSupported, "not supported functionality")
+}

--- a/core/mdns/mdns_test.go
+++ b/core/mdns/mdns_test.go
@@ -1,0 +1,116 @@
+//nolint:all
+package mdns
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/backoff"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+type stubNode struct {
+	host      warpnet.P2PNode
+	connectFn func(peer.AddrInfo) error
+	connected []peer.ID
+}
+
+func (s *stubNode) Node() warpnet.P2PNode { return s.host }
+
+func (s *stubNode) Connect(info peer.AddrInfo) error {
+	s.connected = append(s.connected, info.ID)
+	if s.connectFn != nil {
+		return s.connectFn(info)
+	}
+	return nil
+}
+
+func newStubNode(t *testing.T) *stubNode {
+	t.Helper()
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+	return &stubNode{host: h}
+}
+
+func TestHandlePeerFoundUsesTheConfiguredHandler(t *testing.T) {
+	var got []peer.ID
+	m := NewMulticastDNS(context.Background(), func(info warpnet.WarpAddrInfo) {
+		got = append(got, info.ID)
+	})
+
+	node := newStubNode(t)
+	m.service.node = node
+
+	m.service.HandlePeerFound(peer.AddrInfo{ID: "peer-1"})
+	require.Equal(t, []peer.ID{"peer-1"}, got)
+	require.Empty(t, node.connected, "a custom handler owns the connection decision")
+}
+
+func TestHandlePeerFoundFallsBackToConnecting(t *testing.T) {
+	t.Run("connects", func(t *testing.T) {
+		m := NewMulticastDNS(context.Background(), nil)
+		node := newStubNode(t)
+		m.service.node = node
+
+		m.service.HandlePeerFound(peer.AddrInfo{ID: "peer-1"})
+		require.Equal(t, []peer.ID{"peer-1"}, node.connected)
+	})
+
+	t.Run("a backoffed peer is skipped quietly", func(t *testing.T) {
+		m := NewMulticastDNS(context.Background(), nil)
+		node := newStubNode(t)
+		node.connectFn = func(peer.AddrInfo) error { return backoff.ErrBackoffEnabled }
+		m.service.node = node
+
+		require.NotPanics(t, func() { m.service.HandlePeerFound(peer.AddrInfo{ID: "peer-1"}) })
+	})
+
+	t.Run("a dial failure is logged", func(t *testing.T) {
+		m := NewMulticastDNS(context.Background(), nil)
+		node := newStubNode(t)
+		node.connectFn = func(peer.AddrInfo) error { return errors.New("unreachable") }
+		m.service.node = node
+
+		require.NotPanics(t, func() { m.service.HandlePeerFound(peer.AddrInfo{ID: "peer-1"}) })
+	})
+}
+
+func TestHandlePeerFoundGuards(t *testing.T) {
+	var svc *mdnsDiscoveryService
+	require.NotPanics(t, func() { svc.HandlePeerFound(peer.AddrInfo{ID: "peer-1"}) })
+
+	m := NewMulticastDNS(context.Background(), nil)
+	require.Panics(t, func() { m.service.HandlePeerFound(peer.AddrInfo{ID: "peer-1"}) },
+		"discovery before Start attached a node is a programming error")
+}
+
+func TestStartAndClose(t *testing.T) {
+	m := NewMulticastDNS(context.Background(), nil)
+	node := newStubNode(t)
+
+	m.Start(node)
+	// Start is idempotent: a second call must not swap the running service out.
+	m.Start(node)
+
+	// give the background start a moment so Close has something to close
+	time.Sleep(100 * time.Millisecond)
+
+	m.Close()
+	// Close is idempotent too.
+	m.Close()
+}
+
+func TestStartAndCloseAreNilSafe(t *testing.T) {
+	var m *MulticastDNS
+	require.NotPanics(t, func() { m.Start(nil) })
+	require.NotPanics(t, m.Close)
+
+	unstarted := NewMulticastDNS(context.Background(), nil)
+	require.NotPanics(t, unstarted.Close)
+}

--- a/core/media-meta/malformed_test.go
+++ b/core/media-meta/malformed_test.go
@@ -1,0 +1,141 @@
+//nolint:all
+package media_meta
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// isoBoxOf builds one ISO-BMFF box with the given 32-bit size field.
+func isoBoxOf(size uint32, boxType string, payload []byte) []byte {
+	out := make([]byte, 0, boxHeaderSize+len(payload))
+	out = binary.BigEndian.AppendUint32(out, size)
+	out = append(out, boxType...)
+	return append(out, payload...)
+}
+
+func TestBoxBoundsRejectsMalformedBoxes(t *testing.T) {
+	t.Run("a size smaller than the header", func(t *testing.T) {
+		_, _, err := boxBounds(isoBoxOf(4, "ftyp", nil), 0)
+		require.ErrorIs(t, err, ErrMalformedISO)
+	})
+
+	t.Run("a size past the end of the file", func(t *testing.T) {
+		_, _, err := boxBounds(isoBoxOf(1024, "ftyp", []byte("short")), 0)
+		require.ErrorIs(t, err, ErrMalformedISO)
+	})
+
+	t.Run("a truncated 64-bit largesize header", func(t *testing.T) {
+		_, _, err := boxBounds(isoBoxOf(1, "ftyp", nil), 0)
+		require.ErrorIs(t, err, ErrMalformedISO)
+	})
+
+	t.Run("a 64-bit largesize past the end of the file", func(t *testing.T) {
+		b := isoBoxOf(1, "ftyp", binary.BigEndian.AppendUint64(nil, 1<<40))
+		_, _, err := boxBounds(b, 0)
+		require.ErrorIs(t, err, ErrMalformedISO)
+	})
+
+	t.Run("a valid 64-bit largesize", func(t *testing.T) {
+		payload := binary.BigEndian.AppendUint64(nil, uint64(boxLargeHeadLen))
+		b := isoBoxOf(1, "ftyp", payload)
+
+		size, headerSize, err := boxBounds(b, 0)
+		require.NoError(t, err)
+		require.Equal(t, boxLargeHeadLen, size)
+		require.Equal(t, boxLargeHeadLen, headerSize)
+	})
+
+	t.Run("an open-ended box runs to the end", func(t *testing.T) {
+		b := isoBoxOf(0, "mdat", []byte("payload"))
+		size, headerSize, err := boxBounds(b, 0)
+		require.NoError(t, err)
+		require.Equal(t, len(b), size)
+		require.Equal(t, boxHeaderSize, headerSize)
+	})
+}
+
+func TestSplitVideoRejectsMalformedInput(t *testing.T) {
+	_, _, err := SplitVideo(isoBoxOf(1024, "ftyp", []byte("short")))
+	require.ErrorIs(t, err, ErrMalformedISO)
+}
+
+func TestVerifyVideoRejectsMalformedInput(t *testing.T) {
+	require.ErrorIs(t,
+		VerifyVideo(isoBoxOf(1024, "ftyp", []byte("short")), "node", "owner"),
+		ErrMalformedISO,
+	)
+}
+
+func TestCloseOpenEndedBoxEdgeCases(t *testing.T) {
+	t.Run("rejects malformed input", func(t *testing.T) {
+		_, err := CloseOpenEndedBox(isoBoxOf(1024, "ftyp", []byte("short")))
+		require.ErrorIs(t, err, ErrMalformedISO)
+	})
+
+	t.Run("passes an empty file through", func(t *testing.T) {
+		out, err := CloseOpenEndedBox(nil)
+		require.NoError(t, err)
+		require.Nil(t, out)
+	})
+
+	t.Run("leaves an already-sized last box alone", func(t *testing.T) {
+		in := minimalMP4()
+		out, err := CloseOpenEndedBox(in)
+		require.NoError(t, err)
+		require.Equal(t, in, out)
+	})
+
+	t.Run("writes the real size into an open-ended last box", func(t *testing.T) {
+		in := append(minimalMP4(), isoBoxOf(0, "mdat", []byte("streamed payload"))...)
+
+		out, err := CloseOpenEndedBox(in)
+		require.NoError(t, err)
+		require.Len(t, out, len(in))
+
+		last := len(minimalMP4())
+		require.Equal(t, uint32(len(in)-last), binary.BigEndian.Uint32(out[last:last+4]))
+	})
+}
+
+func TestStripJPEGExifRejectsMalformedInput(t *testing.T) {
+	t.Run("a segment size below the minimum", func(t *testing.T) {
+		b := []byte{jpegMarker, 0xD8, jpegMarker, 0xE1, 0x00, 0x01}
+		_, err := stripJPEGExif(b)
+		require.ErrorIs(t, err, ErrMalformedJPEG)
+	})
+
+	t.Run("a segment running past the end", func(t *testing.T) {
+		b := []byte{jpegMarker, 0xD8, jpegMarker, 0xE1, 0xFF, 0xFF, 0x00}
+		_, err := stripJPEGExif(b)
+		require.ErrorIs(t, err, ErrMalformedJPEG)
+	})
+
+	t.Run("standalone markers are copied verbatim", func(t *testing.T) {
+		b := []byte{jpegMarker, 0xD8, jpegMarker, jpegRST0, jpegMarker, jpegTEM, 0x00}
+		out, err := stripJPEGExif(b)
+		require.NoError(t, err)
+		require.NotEmpty(t, out)
+	})
+
+	t.Run("a non-marker byte ends the scan", func(t *testing.T) {
+		b := []byte{jpegMarker, 0xD8, 0x00, 0x11, 0x22, 0x33}
+		out, err := stripJPEGExif(b)
+		require.NoError(t, err)
+		require.NotEmpty(t, out)
+	})
+}
+
+func TestVerifyImageRejectsMalformedInput(t *testing.T) {
+	// extraction runs before the strip, so a file with no metadata is reported
+	// as such even when its segments are also malformed
+	err := VerifyImage([]byte{jpegMarker, 0xD8, jpegMarker, 0xE1, 0x00, 0x01}, "node", "owner")
+	require.ErrorIs(t, err, ErrNoMetadata)
+}
+
+func TestExtractFromJPEGWithoutMetadata(t *testing.T) {
+	_, err := extractFromJPEG(testJPEG(t, 0x20))
+	require.ErrorIs(t, err, ErrNoMetadata)
+}

--- a/core/middleware/middleware_branches_test.go
+++ b/core/middleware/middleware_branches_test.go
@@ -1,0 +1,317 @@
+//nolint:all
+package middleware
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/stream"
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/Warp-net/warpnet/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingMiddleware(t *testing.T) {
+	ownNodeId, _ := newRemotePeer(t)
+	mw := NewWarpMiddleware(ownNodeId, nil)
+	t.Cleanup(mw.Close)
+
+	client, server := stream.NewLoopbackStream(ownNodeId, ownNodeId, "/public/get/info/0.0.0")
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	t.Run("passes the response through", func(t *testing.T) {
+		out, err := mw.LoggingMiddleware(func([]byte, warpnet.WarpStream) (any, error) {
+			return "ok", nil
+		})(nil, server)
+		require.NoError(t, err)
+		require.Equal(t, "ok", out)
+	})
+
+	t.Run("passes the error through", func(t *testing.T) {
+		handlerErr := errors.New("boom")
+		_, err := mw.LoggingMiddleware(func([]byte, warpnet.WarpStream) (any, error) {
+			return nil, handlerErr
+		})(nil, server)
+		require.ErrorIs(t, err, handlerErr)
+	})
+}
+
+func TestIsCacheableResponse(t *testing.T) {
+	require.False(t, isCacheableResponse(nil, errors.New("boom")))
+	require.False(t, isCacheableResponse(nil, nil))
+	require.False(t, isCacheableResponse(event.ResponseError{Message: "nope"}, nil))
+	require.True(t, isCacheableResponse([]byte(`{"ok":true}`), nil))
+}
+
+// idempotencyCaller returns a caller bound to one loopback stream. The cache
+// key includes the remote peer, so every call in a scenario must share it.
+func idempotencyCaller(t *testing.T, mw *WarpMiddleware, route string) func(string, warpnet.WarpHandlerFunc) (any, error) {
+	t.Helper()
+
+	ownNodeId, _ := newRemotePeer(t)
+	client, server := stream.NewLoopbackStream(ownNodeId, ownNodeId, warpnet.WarpProtocolID(route))
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	return func(messageId string, next warpnet.WarpHandlerFunc) (any, error) {
+		body := &warpnet.WarpStreamBody{WarpStream: server, MessageId: messageId}
+		return mw.IdempotencyMiddleware(next)(nil, body)
+	}
+}
+
+func TestIdempotencyMiddleware(t *testing.T) {
+	ownNodeId, _ := newRemotePeer(t)
+
+	t.Run("a plain stream bypasses the cache", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		client, server := stream.NewLoopbackStream(ownNodeId, ownNodeId, "/private/post/tweet/0.0.0")
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return []byte(`{"id":1}`), nil
+		}
+		for range 2 {
+			_, err := mw.IdempotencyMiddleware(next)(nil, server)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 2, calls, "without a message id there is nothing to deduplicate")
+	})
+
+	t.Run("a missing message id bypasses the cache", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return []byte(`{"id":1}`), nil
+		}
+		call := idempotencyCaller(t, mw, "/private/post/tweet/0.0.0")
+		for range 2 {
+			_, err := call("", next)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("a non-post route bypasses the cache", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return []byte(`{"id":1}`), nil
+		}
+		call := idempotencyCaller(t, mw, "/public/get/info/0.0.0")
+		for range 2 {
+			_, err := call("msg-1", next)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("a replayed post is answered from the cache", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return []byte(`{"id":1}`), nil
+		}
+		call := idempotencyCaller(t, mw, "/private/post/tweet/0.0.0")
+		first, err := call("msg-1", next)
+		require.NoError(t, err)
+		second, err := call("msg-1", next)
+		require.NoError(t, err)
+
+		require.Equal(t, first, second)
+		require.Equal(t, 1, calls, "the replay must not re-run the handler")
+	})
+
+	t.Run("a failed post is not cached", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return nil, errors.New("write failed")
+		}
+		call := idempotencyCaller(t, mw, "/private/post/tweet/0.0.0")
+		for range 2 {
+			_, err := call("msg-err", next)
+			require.Error(t, err)
+		}
+		require.Equal(t, 2, calls, "a failure must be retryable")
+	})
+
+	t.Run("an error response is not cached", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		calls := 0
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			calls++
+			return event.ResponseError{Message: "nope"}, nil
+		}
+		call := idempotencyCaller(t, mw, "/private/post/tweet/0.0.0")
+		for range 2 {
+			_, err := call("msg-resp-err", next)
+			require.NoError(t, err)
+		}
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("concurrent replays share one execution", func(t *testing.T) {
+		mw := NewWarpMiddleware(ownNodeId, nil)
+		t.Cleanup(mw.Close)
+
+		var (
+			mu      sync.Mutex
+			calls   int
+			release = make(chan struct{})
+		)
+		next := func([]byte, warpnet.WarpStream) (any, error) {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			<-release
+			return []byte(`{"id":1}`), nil
+		}
+
+		call := idempotencyCaller(t, mw, "/private/post/tweet/0.0.0")
+
+		const followers = 4
+		var wg sync.WaitGroup
+		wg.Add(followers)
+		for range followers {
+			go func() {
+				defer wg.Done()
+				_, _ = call("msg-race", next)
+			}()
+		}
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Equal(t, 1, calls, "followers wait on the leader instead of re-running")
+	})
+}
+
+func TestAuthMiddlewareRejectsMalformedInput(t *testing.T) {
+	ownNodeId, key := newRemotePeer(t)
+	mw := NewWarpMiddleware(ownNodeId, nil)
+	t.Cleanup(mw.Close)
+
+	const route = "/public/post/tweet/0.0.0"
+	client, server := stream.NewLoopbackStream(ownNodeId, ownNodeId, route)
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	call := func(payload []byte, conn remoteConn) error {
+		_, err := mw.AuthMiddleware(func([]byte, warpnet.WarpStream) (any, error) {
+			return nil, nil
+		})(payload, remoteStream{WarpStream: server, conn: conn})
+		return err
+	}
+
+	live := remoteConn{local: ownNodeId, remote: ownNodeId}
+
+	t.Run("garbage payload", func(t *testing.T) {
+		require.ErrorIs(t, call([]byte("{"), live), ErrInternalNodeError)
+	})
+
+	t.Run("missing message id", func(t *testing.T) {
+		payload, err := json.Marshal(event.Message{Body: json.RawMessage(`{}`)})
+		require.NoError(t, err)
+		require.ErrorIs(t, call(payload, live), ErrInternalNodeError)
+	})
+
+	t.Run("missing signature", func(t *testing.T) {
+		payload, err := json.Marshal(event.Message{
+			Body: json.RawMessage(`{}`), MessageId: "msg-1", Timestamp: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		require.ErrorIs(t, call(payload, live), ErrInternalNodeError)
+	})
+
+	t.Run("empty remote peer", func(t *testing.T) {
+		msg := event.Message{
+			Body: json.RawMessage(`{}`), MessageId: "msg-1", Timestamp: time.Now().UTC(),
+		}
+		msg.Signature = security.Sign(key, msg.SigningBytes())
+		payload, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, call(payload, remoteConn{local: ownNodeId}), ErrInternalNodeError)
+	})
+
+	t.Run("stale message from a remote peer", func(t *testing.T) {
+		peer, peerKey := newRemotePeer(t)
+		msg := event.Message{
+			Body:        json.RawMessage(`{}`),
+			MessageId:   "msg-stale",
+			NodeId:      peer.String(),
+			Destination: route,
+			Timestamp:   time.Now().Add(-24 * time.Hour).UTC(),
+		}
+		msg.Signature = security.Sign(peerKey, msg.SigningBytes())
+		payload, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, call(payload, remoteConn{local: ownNodeId, remote: peer}), ErrStaleMessage)
+	})
+}
+
+func TestAuthMiddlewareRejectsAnUnreadyConnection(t *testing.T) {
+	ownNodeId, _ := newRemotePeer(t)
+	mw := NewWarpMiddleware(ownNodeId, nil)
+	t.Cleanup(mw.Close)
+
+	client, server := stream.NewLoopbackStream(ownNodeId, ownNodeId, "/public/post/tweet/0.0.0")
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	_, err := mw.AuthMiddleware(func([]byte, warpnet.WarpStream) (any, error) {
+		return nil, nil
+	})(nil, remoteStream{WarpStream: server, conn: nil})
+	require.ErrorIs(t, err, ErrInternalNodeError)
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	ownNodeId, _ := newRemotePeer(t)
+	mw := NewWarpMiddleware(ownNodeId, nil)
+	require.NotPanics(t, mw.Close)
+	require.NotPanics(t, mw.Close)
+}
+
+func TestCloseExpirableLRUIgnoresForeignValues(t *testing.T) {
+	require.NotPanics(t, func() { closeExpirableLRU(nil) })
+	require.NotPanics(t, func() { closeExpirableLRU("not a cache") })
+	require.NotPanics(t, func() { closeExpirableLRU((*idempotencyCache)(nil)) })
+	require.NotPanics(t, func() { closeExpirableLRU(&struct{ done int }{}) })
+}

--- a/core/node/holepunch_test.go
+++ b/core/node/holepunch_test.go
@@ -1,0 +1,75 @@
+//nolint:all
+package node
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHolePunchTracerCoversEveryEvent(t *testing.T) {
+	tr := holePunchTracer{}
+	remote := peer.ID("12D3KooWTracedPeer")
+
+	require.NotPanics(t, func() { tr.Trace(nil) })
+
+	events := []any{
+		&holepunch.StartHolePunchEvt{RTT: 10 * time.Millisecond, RemoteAddrs: []string{"/ip4/1.2.3.4/tcp/1"}},
+		&holepunch.HolePunchAttemptEvt{Attempt: 2},
+		&holepunch.EndHolePunchEvt{Success: true, EllapsedTime: time.Second},
+		&holepunch.EndHolePunchEvt{Success: false, EllapsedTime: time.Second, Error: "timeout"},
+		&holepunch.DirectDialEvt{Success: true, EllapsedTime: time.Second},
+		&holepunch.DirectDialEvt{Success: false, EllapsedTime: time.Second},
+		&holepunch.ProtocolErrorEvt{Error: "unsupported"},
+		// an event this tracer does not model must fall through silently
+		struct{}{},
+	}
+	for _, e := range events {
+		require.NotPanics(t, func() {
+			tr.Trace(&holepunch.Event{Remote: remote, Evt: e})
+		})
+	}
+}
+
+func TestConnTracerListenHooksAreInert(t *testing.T) {
+	tr := connTracer{}
+	require.NotPanics(t, func() {
+		tr.Listen(nil, nil)
+		tr.ListenClose(nil, nil)
+		tr.Connected(nil, nil)
+		tr.Disconnected(nil, nil)
+	})
+}
+
+// TestConnTracerOnLiveConnections drives the direct-connection paths against a
+// real dial, where the network can be asked for the peer's other connections.
+func TestConnTracerOnLiveConnections(t *testing.T) {
+	a, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	b, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, a.Connect(ctx, peer.AddrInfo{ID: b.ID(), Addrs: b.Addrs()}))
+
+	conns := a.Network().ConnsToPeer(b.ID())
+	require.NotEmpty(t, conns)
+
+	tr := connTracer{}
+	require.NotPanics(t, func() {
+		tr.Connected(a.Network(), conns[0])
+		tr.Disconnected(a.Network(), conns[0])
+	})
+}
+
+var _ network.Notifiee = connTracer{}

--- a/core/notifications/smtp_test.go
+++ b/core/notifications/smtp_test.go
@@ -1,0 +1,199 @@
+//nolint:all
+package notifications
+
+import (
+	"bufio"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSMTP speaks just enough SMTP for net/smtp to complete a plain,
+// unauthenticated delivery on loopback.
+type fakeSMTP struct {
+	host string
+	port int
+
+	mx       sync.Mutex
+	received []string
+	listener net.Listener
+}
+
+func newFakeSMTP(t *testing.T, failAt string) *fakeSMTP {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	s := &fakeSMTP{host: host, port: port, listener: ln}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go s.serve(conn, failAt)
+		}
+	}()
+	return s
+}
+
+func (s *fakeSMTP) serve(conn net.Conn, failAt string) {
+	defer func() { _ = conn.Close() }()
+
+	w := bufio.NewWriter(conn)
+	r := bufio.NewReader(conn)
+	say := func(line string) bool {
+		if _, err := w.WriteString(line + "\r\n"); err != nil {
+			return false
+		}
+		return w.Flush() == nil
+	}
+
+	if !say("220 fake ESMTP") {
+		return
+	}
+	inData := false
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		s.mx.Lock()
+		s.received = append(s.received, strings.TrimSpace(line))
+		s.mx.Unlock()
+
+		if inData {
+			if strings.TrimSpace(line) == "." {
+				inData = false
+				if !say("250 OK") {
+					return
+				}
+			}
+			continue
+		}
+
+		verb := strings.ToUpper(strings.Fields(strings.TrimSpace(line) + " ")[0])
+		if verb == failAt {
+			_ = say("550 rejected")
+			continue
+		}
+		switch verb {
+		case "EHLO", "HELO":
+			// no extensions advertised: no STARTTLS, no AUTH
+			if !say("250 fake") {
+				return
+			}
+		case "MAIL", "RCPT", "NOOP", "RSET":
+			if !say("250 OK") {
+				return
+			}
+		case "DATA":
+			inData = true
+			if !say("354 send it") {
+				return
+			}
+		case "QUIT":
+			_ = say("221 bye")
+			return
+		default:
+			if !say("250 OK") {
+				return
+			}
+		}
+	}
+}
+
+func (s *fakeSMTP) lines() []string {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	out := make([]string, len(s.received))
+	copy(out, s.received)
+	return out
+}
+
+func TestSMTPMailerValidation(t *testing.T) {
+	m := NewSMTPMailer()
+
+	require.ErrorIs(t, m.Send(domain.NotificationSettings{Recipient: "a@b.c"}, "s", "b"), ErrEmptySMTPHost)
+	require.ErrorIs(t, m.Send(domain.NotificationSettings{SMTPHost: "localhost"}, "s", "b"), ErrEmptyRecipient)
+}
+
+func TestSMTPMailerDelivers(t *testing.T) {
+	srv := newFakeSMTP(t, "")
+
+	err := NewSMTPMailer().Send(domain.NotificationSettings{
+		SMTPHost:  srv.host,
+		SMTPPort:  srv.port,
+		Recipient: "recipient@example.org",
+	}, "Warpnet: reply", "someone replied to you")
+	require.NoError(t, err)
+
+	conversation := strings.Join(srv.lines(), "\n")
+	require.Contains(t, conversation, "MAIL FROM:")
+	require.Contains(t, conversation, "RCPT TO:<recipient@example.org>")
+	require.Contains(t, conversation, "Subject: Warpnet: reply")
+	require.Contains(t, conversation, "someone replied to you")
+}
+
+func TestSMTPMailerUsesTheAuthenticatedAccountAsEnvelopeSender(t *testing.T) {
+	srv := newFakeSMTP(t, "")
+
+	require.NoError(t, NewSMTPMailer().Send(domain.NotificationSettings{
+		SMTPHost:     srv.host,
+		SMTPPort:     srv.port,
+		SMTPUsername: "sender@example.org",
+		SMTPPassword: "secret",
+		Recipient:    "recipient@example.org",
+	}, "s", "b"))
+
+	require.Contains(t, strings.Join(srv.lines(), "\n"), "MAIL FROM:<sender@example.org>")
+}
+
+func TestSMTPMailerReportsServerRejections(t *testing.T) {
+	for _, verb := range []string{"MAIL", "RCPT", "DATA"} {
+		t.Run(verb, func(t *testing.T) {
+			srv := newFakeSMTP(t, verb)
+			err := NewSMTPMailer().Send(domain.NotificationSettings{
+				SMTPHost:  srv.host,
+				SMTPPort:  srv.port,
+				Recipient: "recipient@example.org",
+			}, "s", "b")
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSMTPMailerReportsDialFailure(t *testing.T) {
+	// port 1 on loopback refuses connections
+	err := NewSMTPMailer().Send(domain.NotificationSettings{
+		SMTPHost:  "127.0.0.1",
+		SMTPPort:  1,
+		Recipient: "recipient@example.org",
+	}, "s", "b")
+	require.Error(t, err)
+}
+
+func TestSMTPMailerReportsTLSDialFailure(t *testing.T) {
+	srv := newFakeSMTP(t, "")
+	// the fake server speaks plain SMTP, so an implicit-TLS dial cannot complete
+	err := NewSMTPMailer().Send(domain.NotificationSettings{
+		SMTPHost:   srv.host,
+		SMTPPort:   srv.port,
+		SMTPUseTLS: true,
+		Recipient:  "recipient@example.org",
+	}, "s", "b")
+	require.Error(t, err)
+}

--- a/core/pubsub/gossip_branches_test.go
+++ b/core/pubsub/gossip_branches_test.go
@@ -1,0 +1,186 @@
+//nolint:all
+package pubsub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/event"
+	"github.com/Warp-net/warpnet/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribersAndNotSubscribers(t *testing.T) {
+	g, node := runningGossip(t)
+
+	t.Run("an unknown topic has nobody", func(t *testing.T) {
+		require.Empty(t, g.Subscribers("never-joined"))
+		require.Empty(t, g.NotSubscribers("never-joined"))
+	})
+
+	const topic = "peers-topic"
+	require.NoError(t, g.SubscribeRaw(topic, func([]byte) error { return nil }))
+
+	t.Run("an isolated node has no subscribers", func(t *testing.T) {
+		require.Empty(t, g.Subscribers(topic))
+	})
+
+	t.Run("known peers that never joined are reported", func(t *testing.T) {
+		other := newLiveNode(t)
+		node.host.Peerstore().AddAddrs(other.host.ID(), other.host.Addrs(), time.Hour)
+
+		ids := make([]warpnet.WarpPeerID, 0)
+		for _, info := range g.NotSubscribers(topic) {
+			ids = append(ids, info.ID)
+		}
+		require.Contains(t, ids, other.host.ID())
+	})
+}
+
+func TestPublishRaw(t *testing.T) {
+	g, _ := runningGossip(t)
+
+	t.Run("joins the topic on demand", func(t *testing.T) {
+		require.NoError(t, g.PublishRaw("fresh-topic", []byte("payload")))
+	})
+
+	t.Run("publishes to an already-joined topic", func(t *testing.T) {
+		require.NoError(t, g.SubscribeRaw("joined-topic", func([]byte) error { return nil }))
+		require.NoError(t, g.PublishRaw("joined-topic", []byte("payload")))
+	})
+
+	t.Run("refuses when the gossip is down", func(t *testing.T) {
+		down := NewGossip(context.Background())
+		require.ErrorIs(t, down.PublishRaw("topic", []byte("payload")), ErrPubsubNotInit)
+
+		var nilGossip *Gossip
+		require.ErrorIs(t, nilGossip.PublishRaw("topic", []byte("payload")), ErrPubsubNotInit)
+	})
+}
+
+func TestSubscribeAppliesEveryHandler(t *testing.T) {
+	g, _ := runningGossip(t)
+
+	require.NoError(t, g.Subscribe(
+		TopicHandler{TopicName: "topic-a", Handler: func([]byte) error { return nil }},
+		TopicHandler{TopicName: "topic-b", Handler: func([]byte) error { return nil }},
+	))
+
+	// an empty topic name is rejected, and the failure surfaces to the caller
+	require.Error(t, g.Subscribe(
+		TopicHandler{TopicName: "", Handler: func([]byte) error { return nil }},
+	))
+}
+
+func TestRunPreSubscribesHandlers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	node := newLiveNode(t)
+	g := NewGossip(ctx, TopicHandler{
+		TopicName: "preloaded-topic",
+		Handler:   func([]byte) error { return nil },
+	})
+	require.NoError(t, g.Run(node))
+	t.Cleanup(func() { _ = g.Close() })
+
+	require.True(t, g.IsGossipRunning())
+	// an isolated node has no peers on the topic, but the topic itself is joined
+	require.Empty(t, g.Subscribers("preloaded-topic"))
+	require.NoError(t, g.PublishRaw("preloaded-topic", []byte("payload")))
+}
+
+func TestRunRejectsAnInvalidPreSubscription(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	node := newLiveNode(t)
+	g := NewGossip(ctx, TopicHandler{TopicName: "", Handler: func([]byte) error { return nil }})
+
+	err := g.Run(node)
+	require.Error(t, err)
+	t.Cleanup(func() { _ = g.Close() })
+}
+
+func TestSelfPublish(t *testing.T) {
+	g, node := runningGossip(t)
+
+	t.Run("rejects a payload that is not an envelope", func(t *testing.T) {
+		require.Error(t, g.SelfPublish([]byte("{")))
+	})
+
+	t.Run("rejects an envelope with no destination", func(t *testing.T) {
+		payload, err := json.Marshal(event.Message{MessageId: "msg-1"})
+		require.NoError(t, err)
+		require.ErrorIs(t, g.SelfPublish(payload), ErrPubsubNoPathFound)
+	})
+
+	t.Run("a read route is stored without a self stream", func(t *testing.T) {
+		before := len(node.calls())
+		payload, err := json.Marshal(event.Message{
+			MessageId: "msg-2", Destination: event.PUBLIC_GET_INFO,
+		})
+		require.NoError(t, err)
+		require.NoError(t, g.SelfPublish(payload))
+		require.Len(t, node.calls(), before)
+	})
+
+	t.Run("a write route reaches the node", func(t *testing.T) {
+		before := len(node.calls())
+		payload, err := json.Marshal(event.Message{
+			MessageId: "msg-3", Destination: event.PUBLIC_POST_TIMELINE, NodeId: "node-1",
+		})
+		require.NoError(t, err)
+		require.NoError(t, g.SelfPublish(payload))
+		require.Greater(t, len(node.calls()), before)
+	})
+}
+
+func TestRoundTripThroughAHandler(t *testing.T) {
+	g, _ := runningGossip(t)
+
+	got := make(chan []byte, 1)
+	require.NoError(t, g.SubscribeRaw("loop-topic", func(data []byte) error {
+		select {
+		case got <- data:
+		default:
+		}
+		return nil
+	}))
+
+	require.NoError(t, g.Publish(event.Message{
+		Body:      []byte(`{"a":1}`),
+		MessageId: "msg-1",
+		NodeId:    "node-1",
+		Timestamp: time.Now(),
+	}, "loop-topic"))
+
+	select {
+	case data := <-got:
+		require.NotEmpty(t, data)
+	case <-time.After(15 * time.Second):
+		t.Fatal("the published message never reached the topic handler")
+	}
+}
+
+func TestRunListenerFallsBackToSelfPublish(t *testing.T) {
+	g, node := runningGossip(t)
+
+	// Relay-only subscription: no handler is registered for this topic, so the
+	// listener must hand the message to the node itself.
+	require.NoError(t, g.SubscribeRaw("relayed-topic", nil))
+
+	require.NoError(t, g.Publish(event.Message{
+		Body:        []byte(`{"a":1}`),
+		MessageId:   "msg-2",
+		NodeId:      "node-1",
+		Destination: event.PUBLIC_POST_TIMELINE,
+		Timestamp:   time.Now(),
+	}, "relayed-topic"))
+
+	require.Eventually(t, func() bool {
+		return len(node.calls()) > 0
+	}, 15*time.Second, 100*time.Millisecond)
+}

--- a/core/selfupdate/lifecycle_test.go
+++ b/core/selfupdate/lifecycle_test.go
@@ -1,0 +1,222 @@
+//go:build !windows
+
+//nolint:all
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayArtifact(t *testing.T) {
+	a := RelayArtifact()
+	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+		require.True(t, a.isSupported())
+		require.Equal(t, "relay", a.BinaryName)
+		return
+	}
+	require.False(t, a.isSupported(), "only linux/amd64 publishes a relay asset")
+}
+
+func TestArtifactIsSupported(t *testing.T) {
+	require.False(t, Artifact{}.isSupported())
+	require.False(t, Artifact{AssetName: "a"}.isSupported())
+	require.False(t, Artifact{AssetName: "a", ChecksumName: "c"}.isSupported())
+	require.True(t, Artifact{AssetName: "a", ChecksumName: "c", BinaryName: "b"}.isSupported())
+}
+
+func TestRunIsDisabledWithoutPrerequisites(t *testing.T) {
+	supported := Artifact{AssetName: "a", ChecksumName: "c", BinaryName: "b"}
+
+	t.Run("nil updater", func(t *testing.T) {
+		var u *SelfUpdater
+		require.NotPanics(t, func() { u.Run(nil) })
+		require.NotPanics(t, u.Close)
+	})
+
+	t.Run("unknown current version", func(t *testing.T) {
+		u := &SelfUpdater{ctx: context.Background(), artifact: supported, stopChan: make(chan struct{})}
+		u.Run(nil)
+		u.Close()
+	})
+
+	t.Run("unsupported platform", func(t *testing.T) {
+		u := &SelfUpdater{
+			ctx: context.Background(), current: semver.MustParse("1.0.0"),
+			stopChan: make(chan struct{}),
+		}
+		u.Run(nil)
+		u.Close()
+	})
+
+	t.Run("no binary to replace", func(t *testing.T) {
+		u := &SelfUpdater{
+			ctx: context.Background(), current: semver.MustParse("1.0.0"),
+			artifact: supported, stopChan: make(chan struct{}),
+		}
+		u.Run(nil)
+		u.Close()
+	})
+}
+
+func TestRunTicksAndStops(t *testing.T) {
+	archive := tarGz(t, testBinary, []byte("new binary"))
+	u, _ := updaterFixture(t, testVersion, archive, sumsFor(archive))
+
+	// The release equals the current version, so the tick is a no-op check —
+	// enough to prove the loop runs and then shuts down cleanly.
+	u.interval = 10 * time.Millisecond
+	u.Run(nil)
+
+	time.Sleep(50 * time.Millisecond)
+	u.Close()
+
+	// Close is guarded against a double close by its own recover.
+	require.NotPanics(t, u.Close)
+}
+
+func TestRunStopsWithContext(t *testing.T) {
+	archive := tarGz(t, testBinary, []byte("new binary"))
+	u, _ := updaterFixture(t, testVersion, archive, sumsFor(archive))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	u.ctx = ctx
+	u.interval = 10 * time.Millisecond
+	u.Run(nil)
+
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	u.Close()
+}
+
+func TestTickLogsOrdinaryFailures(t *testing.T) {
+	u, _ := updaterFixture(t, "not-a-version", nil, nil)
+	// A malformed tag makes Latest fail; tick must swallow it rather than
+	// escalating to a fatal restart failure.
+	require.NotPanics(t, func() { u.tick(nil) })
+}
+
+func TestNewSelfUpdaterResolvesItsOwnBinary(t *testing.T) {
+	u := NewSelfUpdater(context.Background(), semver.MustParse("1.0.0"), RelayArtifact())
+	require.NotNil(t, u)
+	require.NotNil(t, u.binary)
+	require.NotNil(t, u.failures)
+	require.Equal(t, checkInterval, u.interval)
+}
+
+func TestCurrentExecutable(t *testing.T) {
+	e, err := currentExecutable()
+	require.NoError(t, err)
+	require.NotEmpty(t, e.Path())
+	require.Equal(t, filepath.Join(filepath.Dir(e.Path()), "asset"), e.StagePath("asset"))
+}
+
+func TestInstallRollsBackWhenTheNewBinaryIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "warpnet")
+	require.NoError(t, os.WriteFile(path, []byte("current"), 0o755))
+
+	e := &executable{path: path}
+	_, err := e.Install(filepath.Join(dir, "does-not-exist"))
+	require.Error(t, err)
+
+	// the previous binary must be back in place
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "current", string(data))
+}
+
+func TestInstallFailsWhenTheCurrentBinaryIsGone(t *testing.T) {
+	e := &executable{path: filepath.Join(t.TempDir(), "absent", "warpnet")}
+	_, err := e.Install(filepath.Join(t.TempDir(), "new"))
+	require.Error(t, err)
+}
+
+func TestInstallRollbackRestoresPreviousBinary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "warpnet")
+	require.NoError(t, os.WriteFile(path, []byte("current"), 0o755))
+
+	staged := filepath.Join(dir, "warpnet.new")
+	require.NoError(t, os.WriteFile(staged, []byte("next"), 0o755))
+
+	e := &executable{path: path}
+	rollback, err := e.Install(staged)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "next", string(data))
+
+	rollback()
+	data, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "current", string(data))
+
+	// a second rollback has nothing left to move and only logs
+	require.NotPanics(t, rollback)
+}
+
+func TestRestartReportsExecFailure(t *testing.T) {
+	e := &executable{path: filepath.Join(t.TempDir(), "not-an-executable")}
+
+	stopped := false
+	err := e.Restart(func() { stopped = true })
+	require.Error(t, err)
+	require.True(t, stopped, "the node is released before the process is replaced")
+}
+
+func TestFailureMarkerRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "warpnet")
+	m := newFailureMarker(path)
+	v := semver.MustParse("1.2.3")
+
+	require.False(t, m.Has(v), "no marker yet")
+
+	m.Set(v)
+	require.True(t, m.Has(v))
+	require.False(t, m.Has(semver.MustParse("1.2.4")))
+
+	m.Clear()
+	require.False(t, m.Has(v))
+	// clearing twice is not an error
+	require.NotPanics(t, m.Clear)
+}
+
+func TestFailureMarkerDiscardsGarbage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "warpnet")
+	m := newFailureMarker(path)
+	require.NoError(t, os.WriteFile(m.path, []byte("not-a-version"), markerMode))
+
+	require.False(t, m.Has(semver.MustParse("1.2.3")))
+	require.NoFileExists(t, m.path, "a malformed marker is dropped so updates resume")
+}
+
+func TestFailureMarkerSetOnAnUnwritablePathIsLogged(t *testing.T) {
+	m := newFailureMarker(filepath.Join(t.TempDir(), "absent-dir", "warpnet"))
+	require.NotPanics(t, func() { m.Set(semver.MustParse("1.2.3")) })
+}
+
+func TestWriteBinaryRejectsUnwritableDestination(t *testing.T) {
+	dir := t.TempDir()
+	// a directory where the file should go makes the create fail
+	dst := filepath.Join(dir, "blocked")
+	require.NoError(t, os.Mkdir(dst, 0o755))
+
+	require.Error(t, writeBinary(errReader{}, dst))
+
+	// a read failure mid-copy surfaces too
+	require.Error(t, writeBinary(errReader{}, filepath.Join(dir, "binary")))
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }

--- a/core/stream/loopback-stream_branches_test.go
+++ b/core/stream/loopback-stream_branches_test.go
@@ -1,0 +1,125 @@
+//nolint:all
+package stream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoopbackConnSurface(t *testing.T) {
+	client, server := NewLoopbackStream("node-a", "node-b", "/public/get/info/0.0.0")
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	const local, remote = warpnet.WarpPeerID("node-a"), warpnet.WarpPeerID("node-b")
+
+	conn := server.Conn()
+	require.Equal(t, local.String(), conn.LocalPeer().String())
+	require.Equal(t, remote.String(), conn.RemotePeer().String())
+	require.Nil(t, conn.RemotePublicKey())
+	require.False(t, conn.As(nil))
+	require.Equal(t, local.String(), conn.ID())
+	require.Nil(t, conn.Scope())
+	require.NotNil(t, conn.LocalMultiaddr())
+	require.NotNil(t, conn.RemoteMultiaddr())
+	require.Equal(t, "loopback", conn.ConnState().Transport)
+	require.Equal(t, network.DirInbound, conn.Stat().Direction)
+	require.Len(t, conn.GetStreams(), 1)
+
+	newStream, err := conn.NewStream(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, newStream)
+
+	require.False(t, conn.IsClosed())
+	require.NoError(t, conn.Close())
+	require.True(t, conn.IsClosed())
+
+	// closing again, and via the error-carrying variant, must stay a no-op
+	require.NoError(t, conn.Close())
+	require.NoError(t, conn.CloseWithError(network.ConnErrorCode(1)))
+}
+
+func TestLoopbackStreamSurface(t *testing.T) {
+	client, server := NewLoopbackStream("node-a", "node-b", "/public/get/info/0.0.0")
+
+	require.Equal(t, "loopback", server.ID())
+	require.Nil(t, server.Scope())
+	require.Equal(t, warpnet.WarpProtocolID("/public/get/info/0.0.0"), server.Protocol())
+	require.NoError(t, server.SetProtocol("/public/get/tweets/0.0.0"))
+	require.Equal(t, warpnet.WarpProtocolID("/public/get/tweets/0.0.0"), server.Protocol())
+	require.Equal(t, network.DirInbound, server.Stat().Direction)
+
+	deadline := time.Now().Add(time.Minute)
+	require.NoError(t, server.SetDeadline(deadline))
+	require.NoError(t, server.SetReadDeadline(deadline))
+	require.NoError(t, server.SetWriteDeadline(deadline))
+
+	// a live pair moves bytes end to end
+	go func() {
+		_, _ = client.Write([]byte("ping"))
+		_ = client.CloseWrite()
+	}()
+	buf := make([]byte, 4)
+	n, err := server.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "ping", string(buf[:n]))
+
+	// ResetWithError only reports; Reset closes both halves
+	require.NoError(t, server.ResetWithError(network.StreamErrorCode(1)))
+	require.NoError(t, server.Reset())
+
+	// reads and writes on a closed stream are silent no-ops
+	n, err = server.Read(buf)
+	require.NoError(t, err)
+	require.Zero(t, n)
+	n, err = server.Write([]byte("pong"))
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	require.NoError(t, server.CloseRead())
+	require.NoError(t, server.CloseWrite())
+	require.NoError(t, server.Close())
+	require.NoError(t, client.Close())
+}
+
+func TestReadRequestLimits(t *testing.T) {
+	t.Run("control route", func(t *testing.T) {
+		client, server := NewLoopbackStream("node-a", "node-b", "/public/get/info/0.0.0")
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+
+		go func() {
+			_, _ = client.Write([]byte(`{"a":1}`))
+			_ = client.CloseWrite()
+		}()
+
+		data, err := ReadRequest(server)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"a":1}`, string(data))
+	})
+
+	t.Run("media route", func(t *testing.T) {
+		client, server := NewLoopbackStream("node-a", "node-b", warpnet.WarpProtocolID("/public/get/image/0.0.0"))
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+
+		go func() {
+			_, _ = client.Write([]byte("binary-ish"))
+			_ = client.CloseWrite()
+		}()
+
+		data, err := ReadRequest(server)
+		require.NoError(t, err)
+		require.Equal(t, "binary-ish", string(data))
+	})
+}

--- a/core/warpnet/constructors_test.go
+++ b/core/warpnet/constructors_test.go
@@ -1,0 +1,136 @@
+//nolint:all
+package warpnet
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/boxo/blockstore"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p"
+	p2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewP2PNode(t *testing.T) {
+	node, err := NewP2PNode(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Close() })
+	require.NotEmpty(t, node.ID())
+}
+
+func TestNewNoise(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := p2pCrypto.UnmarshalEd25519PrivateKey(priv)
+	require.NoError(t, err)
+
+	tr, err := NewNoise("/noise", key, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+}
+
+func TestNewLimiterAndManagers(t *testing.T) {
+	limiter := NewConfigurableLimiter(nil)
+	require.NotNil(t, limiter)
+
+	fromJSON := NewConfigurableLimiter(strings.NewReader(`{}`))
+	require.NotNil(t, fromJSON)
+
+	// malformed config falls back to the defaults rather than failing startup
+	fallback := NewConfigurableLimiter(strings.NewReader(`{`))
+	require.NotNil(t, fallback)
+
+	cm, err := NewConnManager(limiter)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cm.Close() })
+
+	rm, err := NewResourceManager(limiter)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rm.Close() })
+
+	require.NotNil(t, rm)
+}
+
+func TestNewPeerstore(t *testing.T) {
+	store, err := NewPeerstore(context.Background(), dssync.MutexWrap(ds.NewMapDatastore()))
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.Close() })
+}
+
+func TestBitswapStack(t *testing.T) {
+	node, err := NewP2PNode(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = node.Close() })
+
+	net := NewBitswapNetwork(node)
+	require.NotNil(t, net)
+
+	bstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
+	exchange := NewBitswapExchange(context.Background(), net, nil, bstore)
+	require.NotNil(t, exchange)
+	t.Cleanup(func() { _ = exchange.Close() })
+
+	bserv := NewBlockService(bstore, exchange)
+	require.NotNil(t, bserv)
+	t.Cleanup(func() { _ = bserv.Close() })
+
+	require.NotNil(t, NewDAGService(bserv))
+}
+
+func TestVerifyAuthorship(t *testing.T) {
+	local, remote := WarpPeerID("node-local"), WarpPeerID("node-remote")
+
+	t.Run("rejects an unknown author", func(t *testing.T) {
+		require.ErrorIs(t, VerifyAuthorship(nil, ""), ErrForeignAuthor)
+		require.ErrorIs(t, VerifyAuthorship(nil, remote.String()), ErrForeignAuthor)
+		require.ErrorIs(t, VerifyAuthorship(stubStream{}, remote.String()), ErrForeignAuthor)
+	})
+
+	t.Run("accepts the sending peer", func(t *testing.T) {
+		s := stubStream{conn: stubConn{local: local, remote: remote}}
+		require.NoError(t, VerifyAuthorship(s, remote.String()))
+	})
+
+	t.Run("rejects a third party", func(t *testing.T) {
+		s := stubStream{conn: stubConn{local: local, remote: remote}}
+		require.ErrorIs(t, VerifyAuthorship(s, WarpPeerID("someone-else").String()), ErrForeignAuthor)
+	})
+
+	t.Run("accepts a paired alias acting as the local node", func(t *testing.T) {
+		s := &WarpStreamBody{
+			WarpStream:  stubStream{conn: stubConn{local: local, remote: remote}},
+			PairedAlias: true,
+		}
+		require.True(t, s.IsPairedAlias())
+		require.NoError(t, VerifyAuthorship(s, local.String()))
+	})
+
+	t.Run("rejects an unpaired alias acting as the local node", func(t *testing.T) {
+		s := &WarpStreamBody{WarpStream: stubStream{conn: stubConn{local: local, remote: remote}}}
+		require.False(t, s.IsPairedAlias())
+		require.ErrorIs(t, VerifyAuthorship(s, local.String()), ErrForeignAuthor)
+	})
+}
+
+type stubConn struct {
+	network.Conn
+	local, remote WarpPeerID
+}
+
+func (c stubConn) LocalPeer() peer.ID  { return c.local }
+func (c stubConn) RemotePeer() peer.ID { return c.remote }
+
+type stubStream struct {
+	WarpStream
+	conn network.Conn
+}
+
+func (s stubStream) Conn() network.Conn { return s.conn }

--- a/database/datastore/datastore_test.go
+++ b/database/datastore/datastore_test.go
@@ -1,0 +1,120 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKey(t *testing.T) {
+	require.Equal(t, ds.NewKey("/a/b"), NewKey("/a/b"))
+}
+
+func TestResultsHelpers(t *testing.T) {
+	ctx := context.Background()
+
+	base := dsq.ResultsWithEntries(dsq.Query{}, []dsq.Entry{
+		{Key: "/b", Value: []byte("b")},
+		{Key: "/a", Value: []byte("a")},
+	})
+
+	t.Run("ResultsReplaceQuery", func(t *testing.T) {
+		q := Query{Prefix: "/", Orders: []dsq.Order{dsq.OrderByKey{}}}
+		replaced := ResultsReplaceQuery(base, q)
+		require.Equal(t, q, replaced.Query())
+		require.NoError(t, replaced.Close())
+	})
+
+	t.Run("NaiveQueryApply", func(t *testing.T) {
+		src := dsq.ResultsWithEntries(dsq.Query{}, []dsq.Entry{
+			{Key: "/b", Value: []byte("b")},
+			{Key: "/a", Value: []byte("a")},
+		})
+		out := NaiveQueryApply(Query{Orders: []dsq.Order{dsq.OrderByKey{}}}, src)
+		entries, err := out.Rest()
+		require.NoError(t, err)
+		require.Equal(t, []string{"/a", "/b"}, []string{entries[0].Key, entries[1].Key})
+	})
+
+	t.Run("ResultsWithContext", func(t *testing.T) {
+		res := ResultsWithContext(Query{}, func(_ context.Context, out chan<- Result) {
+			out <- Result{Entry: DsEntry{Key: "/x", Value: []byte("x")}}
+		})
+		entries, err := res.Rest()
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		require.Equal(t, "/x", entries[0].Key)
+	})
+
+	_ = ctx
+}
+
+func TestMutexWrap(t *testing.T) {
+	ctx := context.Background()
+
+	wrapped := MutexWrap(ds.NewMapDatastore())
+	require.IsType(t, &dssync.MutexDatastore{}, wrapped)
+
+	require.NoError(t, wrapped.Put(ctx, NewKey("/k"), []byte("v")))
+	got, err := wrapped.Get(ctx, NewKey("/k"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), got)
+
+	_, err = wrapped.Get(ctx, NewKey("/absent"))
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestBlockstoreHelpers(t *testing.T) {
+	ctx := context.Background()
+
+	backing := MutexWrap(ds.NewMapDatastore())
+	bs := NewBlockstore(backing, WriteThrough(true))
+	require.NotNil(t, bs)
+
+	block := blocks.NewBlock([]byte("hello warpnet"))
+	require.NoError(t, bs.Put(ctx, block))
+
+	got, err := bs.Get(ctx, block.Cid())
+	require.NoError(t, err)
+	require.Equal(t, block.RawData(), got.RawData())
+
+	idStore := NewIdStore(bs)
+	require.NotNil(t, idStore)
+
+	got, err = idStore.Get(ctx, block.Cid())
+	require.NoError(t, err)
+	require.Equal(t, block.RawData(), got.RawData())
+}

--- a/database/errorpaths2_test.go
+++ b/database/errorpaths2_test.go
@@ -1,0 +1,789 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"testing"
+	"time"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterRepoErrorPaths(t *testing.T) {
+	const userId = "filter-user"
+	filter := domain.Filter{Id: "filter-1", Title: "spoilers", Keywords: []domain.FilterKeyword{{Id: "kw-1", Keyword: "ending"}}}
+
+	seedFilter := func(t *testing.T, s *faultStore) {
+		_, err := NewFilterRepo(s).Create(userId, filter)
+		require.NoError(t, err)
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Create",
+			run: func(s *faultStore) error {
+				_, err := NewFilterRepo(s).Create(userId, filter)
+				return err
+			},
+			ops: []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "Get",
+			seed: seedFilter,
+			run: func(s *faultStore) error {
+				_, err := NewFilterRepo(s).Get(userId, filter.Id)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "Update",
+			seed: seedFilter,
+			run: func(s *faultStore) error {
+				_, err := NewFilterRepo(s).Update(userId, domain.Filter{Id: filter.Id, Title: "renamed"})
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Set"), opN("Commit", 2)},
+		},
+		{
+			name: "Delete",
+			seed: seedFilter,
+			run:  func(s *faultStore) error { return NewFilterRepo(s).Delete(userId, filter.Id) },
+			ops:  []faultOp{op("Delete"), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedFilter,
+			run: func(s *faultStore) error {
+				_, _, err := NewFilterRepo(s).List(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "AddKeyword",
+			seed: seedFilter,
+			run: func(s *faultStore) error {
+				_, err := NewFilterRepo(s).AddKeyword(userId, filter.Id, domain.FilterKeyword{Keyword: "twist"})
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Set"), opN("Commit", 2)},
+		},
+		{
+			name: "UpdateKeyword",
+			seed: seedFilter,
+			run: func(s *faultStore) error {
+				_, err := NewFilterRepo(s).UpdateKeyword(userId, domain.FilterKeyword{Id: "kw-1", Keyword: "finale"})
+				return err
+			},
+			ops: []faultOp{op("List"), op("Set"), opN("Commit", 2)},
+		},
+		{
+			name: "DeleteKeyword",
+			seed: seedFilter,
+			run:  func(s *faultStore) error { return NewFilterRepo(s).DeleteKeyword(userId, "kw-1") },
+			ops:  []faultOp{op("List"), op("Set"), opN("Commit", 2)},
+		},
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewFilterRepo(newFaultStore(t))
+
+		_, err := repo.Create("", filter)
+		require.Error(t, err)
+		_, err = repo.Create(userId, domain.Filter{})
+		require.Error(t, err)
+
+		_, err = repo.Get("", filter.Id)
+		require.ErrorIs(t, err, ErrFilterNotFound)
+		_, err = repo.Get(userId, "")
+		require.ErrorIs(t, err, ErrFilterNotFound)
+		_, err = repo.Get(userId, "absent")
+		require.ErrorIs(t, err, ErrFilterNotFound)
+
+		_, err = repo.Update(userId, domain.Filter{Id: "absent"})
+		require.ErrorIs(t, err, ErrFilterNotFound)
+
+		_, err = repo.AddKeyword(userId, filter.Id, domain.FilterKeyword{})
+		require.Error(t, err)
+		_, err = repo.UpdateKeyword(userId, domain.FilterKeyword{})
+		require.Error(t, err)
+		require.Error(t, repo.DeleteKeyword(userId, ""))
+
+		_, _, err = repo.List("", nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("KeywordOnAbsentFilter", func(t *testing.T) {
+		repo := NewFilterRepo(newFaultStore(t))
+		_, err := repo.UpdateKeyword(userId, domain.FilterKeyword{Id: "nope"})
+		require.ErrorIs(t, err, ErrFilterNotFound)
+		// deleting a keyword nobody owns is idempotent
+		require.NoError(t, repo.DeleteKeyword(userId, "nope"))
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedFilter(t, s)
+		require.NoError(t, s.db.Set(filterKey(userId, filter.Id), []byte("{not-json")))
+
+		repo := NewFilterRepo(s)
+		_, err := repo.Get(userId, filter.Id)
+		require.Error(t, err)
+		_, _, err = repo.List(userId, nil, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestPollRepoErrorPaths(t *testing.T) {
+	const tweetId, userId = "poll-tweet", "poll-voter"
+
+	t.Run("VoteFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Set"), op("Increment"), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t).arm(o.method, o.nth)
+				require.ErrorIs(t, NewPollRepo(s, nil).Vote(tweetId, userId, 0, false), errFault)
+			})
+		}
+	})
+
+	t.Run("VoteNewTxn", func(t *testing.T) {
+		s := newFaultStore(t).failNewTxn(errFault)
+		require.ErrorIs(t, NewPollRepo(s, nil).Vote(tweetId, userId, 0, false), errFault)
+	})
+
+	t.Run("VoteTwice", func(t *testing.T) {
+		repo := NewPollRepo(newFaultStore(t), nil)
+		require.NoError(t, repo.Vote(tweetId, userId, 1, false))
+		require.ErrorIs(t, repo.Vote(tweetId, userId, 1, false), ErrPollAlreadyVoted)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewPollRepo(newFaultStore(t), nil)
+		require.Error(t, repo.Vote("", userId, 0, false))
+		require.Error(t, repo.Vote(tweetId, "", 0, false))
+		require.Error(t, repo.Vote(tweetId, userId, -1, false))
+
+		_, _, err := repo.Voted("", userId)
+		require.Error(t, err)
+		_, _, err = repo.Voted(tweetId, "")
+		require.Error(t, err)
+
+		_, err = repo.Results("", 2)
+		require.Error(t, err)
+		_, err = repo.Results(tweetId, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("VotedReadsBack", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewPollRepo(s, nil)
+		require.NoError(t, repo.Vote(tweetId, userId, 2, false))
+
+		option, ok, err := repo.Voted(tweetId, userId)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, 2, option)
+
+		_, ok, err = repo.Voted(tweetId, "other-voter")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("VotedStoreFails", func(t *testing.T) {
+		s := newFaultStore(t).arm("db.Get", 1)
+		_, _, err := NewPollRepo(s, nil).Voted(tweetId, userId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("VotedCorruptOption", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, s.db.Set(pollVoterKey(tweetId, userId), []byte("not-a-number")))
+		_, _, err := NewPollRepo(s, nil).Voted(tweetId, userId)
+		require.Error(t, err)
+	})
+
+	t.Run("ResultsCountsVotes", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewPollRepo(s, nil)
+		require.NoError(t, repo.Vote(tweetId, "voter-a", 0, false))
+		require.NoError(t, repo.Vote(tweetId, "voter-b", 0, false))
+		require.NoError(t, repo.Vote(tweetId, "voter-c", 1, false))
+
+		votes, err := repo.Results(tweetId, 3)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{2, 1, 0}, votes)
+	})
+
+	t.Run("ResultsStoreFails", func(t *testing.T) {
+		s := newFaultStore(t).arm("db.Get", 1)
+		_, err := NewPollRepo(s, nil).Results(tweetId, 2)
+		require.ErrorIs(t, err, errFault)
+	})
+}
+
+func TestOutboxRepoErrorPaths(t *testing.T) {
+	const nodeId = "dest-node"
+	seedMessage := func(t *testing.T, s *faultStore) {
+		_, err := NewOutboxRepo(s).Enqueue(nodeId, "/private/post/tweet", []byte(`{"a":1}`))
+		require.NoError(t, err)
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Enqueue",
+			run: func(s *faultStore) error {
+				_, err := NewOutboxRepo(s).Enqueue(nodeId, "/route", []byte("{}"))
+				return err
+			},
+			ops: []faultOp{op("SetWithTTL"), op("Commit")},
+		},
+		{
+			name: "ListByNode",
+			seed: seedMessage,
+			run: func(s *faultStore) error {
+				_, err := NewOutboxRepo(s).ListByNode(nodeId)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "Delete",
+			seed: seedMessage,
+			run:  func(s *faultStore) error { return NewOutboxRepo(s).Delete(nodeId, "some-id") },
+			ops:  []faultOp{op("Delete"), op("Commit")},
+		},
+		{
+			name: "ListNodes",
+			seed: seedMessage,
+			run: func(s *faultStore) error {
+				_, err := NewOutboxRepo(s).ListNodes()
+				return err
+			},
+			ops: []faultOp{op("IterateKeys"), op("Commit")},
+		},
+	})
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewOutboxRepo(s)
+
+		msg, err := repo.Enqueue(nodeId, "/private/post/tweet", []byte(`{"a":1}`))
+		require.NoError(t, err)
+		require.NotEmpty(t, msg.MessageId)
+
+		msgs, err := repo.ListByNode(nodeId)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+
+		nodes, err := repo.ListNodes()
+		require.NoError(t, err)
+		require.Equal(t, []string{nodeId}, nodes)
+
+		require.NoError(t, repo.Delete(nodeId, string(msg.MessageId)))
+		msgs, err = repo.ListByNode(nodeId)
+		require.NoError(t, err)
+		require.Empty(t, msgs)
+	})
+}
+
+func TestNotificationsRepoErrorPaths(t *testing.T) {
+	const userId = "notif-user"
+	notification := domain.Notification{
+		Id:          "notif-1",
+		RecepientId: userId,
+		Type:        domain.NotificationFollowType,
+		Text:        "followed you",
+		CreatedAt:   time.Now(),
+	}
+	seedNotification := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewNotificationsRepo(s).Add(notification))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Add",
+			run:  func(s *faultStore) error { return NewNotificationsRepo(s).Add(notification) },
+			ops:  []faultOp{op("SetWithTTL"), op("Commit")},
+		},
+		{
+			name: "MarkRead",
+			seed: seedNotification,
+			run:  func(s *faultStore) error { return NewNotificationsRepo(s).MarkRead(userId, notification.Id) },
+			ops:  []faultOp{op("List"), op("Get"), op("SetWithTTL"), op("Commit")},
+		},
+		{
+			name: "MarkAllRead",
+			seed: seedNotification,
+			run:  func(s *faultStore) error { return NewNotificationsRepo(s).MarkAllRead(userId) },
+			ops:  []faultOp{op("List"), op("Get"), op("SetWithTTL"), op("Commit")},
+		},
+		{
+			name: "Get",
+			seed: seedNotification,
+			run: func(s *faultStore) error {
+				_, err := NewNotificationsRepo(s).Get(userId, notification.Id)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedNotification,
+			run: func(s *faultStore) error {
+				_, _, err := NewNotificationsRepo(s).List(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "ReverseList",
+			seed: seedNotification,
+			run: func(s *faultStore) error {
+				_, _, err := NewNotificationsRepo(s).ReverseList(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+		{
+			name: "UnreadCount",
+			seed: seedNotification,
+			run: func(s *faultStore) error {
+				_, err := NewNotificationsRepo(s).UnreadCount(userId)
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewNotificationsRepo(newFaultStore(t))
+		require.Error(t, repo.Add(domain.Notification{}))
+		require.Error(t, repo.MarkRead("", notification.Id))
+		require.Error(t, repo.MarkRead(userId, ""))
+		require.Error(t, repo.MarkAllRead(""))
+
+		_, err := repo.Get("", notification.Id)
+		require.Error(t, err)
+		_, err = repo.Get(userId, "")
+		require.Error(t, err)
+		_, _, err = repo.List("", nil, nil)
+		require.Error(t, err)
+		_, _, err = repo.ReverseList("", nil, nil)
+		require.Error(t, err)
+		_, err = repo.UnreadCount("")
+		require.Error(t, err)
+	})
+
+	t.Run("AbsentNotification", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewNotificationsRepo(s)
+		seedNotification(t, s)
+
+		_, err := repo.Get(userId, "absent")
+		require.Error(t, err)
+		require.Error(t, repo.MarkRead(userId, "absent"))
+	})
+
+	t.Run("MarkReadFlow", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewNotificationsRepo(s)
+		seedNotification(t, s)
+
+		count, err := repo.UnreadCount(userId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+
+		require.NoError(t, repo.MarkRead(userId, notification.Id))
+		got, err := repo.Get(userId, notification.Id)
+		require.NoError(t, err)
+		require.True(t, got.IsRead)
+
+		count, err = repo.UnreadCount(userId)
+		require.NoError(t, err)
+		require.Zero(t, count)
+
+		// marking an already-read notification again is a no-op, not an error
+		require.NoError(t, repo.MarkAllRead(userId))
+	})
+}
+
+func TestFollowRepoErrorPaths(t *testing.T) {
+	const from, to = "follower-user", "followee-user"
+	seedFollow := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewFollowRepo(s).Follow(from, to))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Follow",
+			run:  func(s *faultStore) error { return NewFollowRepo(s).Follow(from, to) },
+			ops: []faultOp{
+				op("Set"), opN("Set", 2), opN("Set", 3), opN("Set", 4),
+				op("Increment"), opN("Increment", 2), op("Commit"),
+			},
+		},
+		{
+			name: "GetFollowersCount",
+			seed: seedFollow,
+			run: func(s *faultStore) error {
+				_, err := NewFollowRepo(s).GetFollowersCount(to)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "GetFollowingsCount",
+			seed: seedFollow,
+			run: func(s *faultStore) error {
+				_, err := NewFollowRepo(s).GetFollowingsCount(from)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "GetFollowers",
+			seed: seedFollow,
+			run: func(s *faultStore) error {
+				_, _, err := NewFollowRepo(s).GetFollowers(to, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("ListKeys"), op("Commit")},
+		},
+		{
+			name: "GetFollowings",
+			seed: seedFollow,
+			run: func(s *faultStore) error {
+				_, _, err := NewFollowRepo(s).GetFollowings(from, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("ListKeys"), op("Commit")},
+		},
+		{
+			name: "AddFollowRequest",
+			run:  func(s *faultStore) error { return NewFollowRepo(s).AddFollowRequest(to, from) },
+			ops:  []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "RemoveFollowRequest",
+			run:  func(s *faultStore) error { return NewFollowRepo(s).RemoveFollowRequest(to, from) },
+			ops:  []faultOp{op("Delete"), op("Commit")},
+		},
+		{
+			name: "HasFollowRequest",
+			run: func(s *faultStore) error {
+				_, err := NewFollowRepo(s).HasFollowRequest(to, from)
+				return err
+			},
+			ops: []faultOp{op("Commit")},
+		},
+		{
+			name: "ListFollowRequests",
+			run: func(s *faultStore) error {
+				_, _, err := NewFollowRepo(s).ListFollowRequests(to, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("UnfollowFaults", func(t *testing.T) {
+		for _, o := range []faultOp{
+			op("Delete"), opN("Delete", 2), opN("Delete", 3), opN("Delete", 4),
+			op("Decrement"), opN("Decrement", 2), op("Commit"),
+		} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				seedFollow(t, s)
+				s.arm(o.method, o.nth)
+				require.ErrorIs(t, NewFollowRepo(s).Unfollow(from, to), errFault)
+			})
+		}
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewFollowRepo(newFaultStore(t))
+		require.Error(t, repo.Follow("", to))
+		require.Error(t, repo.Follow(from, ""))
+		require.Error(t, repo.Follow(from, from))
+		require.Error(t, repo.Unfollow("", to))
+		require.Error(t, repo.Unfollow(from, ""))
+
+		_, err := repo.GetFollowersCount("")
+		require.Error(t, err)
+		_, err = repo.GetFollowingsCount("")
+		require.Error(t, err)
+
+		require.Error(t, repo.AddFollowRequest("", from))
+		require.Error(t, repo.AddFollowRequest(to, ""))
+		require.Error(t, repo.RemoveFollowRequest("", from))
+		require.Error(t, repo.RemoveFollowRequest(to, ""))
+		_, _, err = repo.ListFollowRequests("", nil, nil)
+		require.Error(t, err)
+
+		// an empty id pair is "no request", not an error
+		has, err := repo.HasFollowRequest("", from)
+		require.NoError(t, err)
+		require.False(t, has)
+		has, err = repo.HasFollowRequest(to, "")
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+
+	t.Run("FollowRequestRoundTrip", func(t *testing.T) {
+		repo := NewFollowRepo(newFaultStore(t))
+
+		has, err := repo.HasFollowRequest(to, from)
+		require.NoError(t, err)
+		require.False(t, has)
+
+		require.NoError(t, repo.AddFollowRequest(to, from))
+		has, err = repo.HasFollowRequest(to, from)
+		require.NoError(t, err)
+		require.True(t, has)
+
+		ids, _, err := repo.ListFollowRequests(to, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{from}, ids)
+
+		require.NoError(t, repo.RemoveFollowRequest(to, from))
+		has, err = repo.HasFollowRequest(to, from)
+		require.NoError(t, err)
+		require.False(t, has)
+		// removing twice is idempotent
+		require.NoError(t, repo.RemoveFollowRequest(to, from))
+	})
+
+	t.Run("IsFollowingStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedFollow(t, s)
+
+		repo := NewFollowRepo(s)
+		require.True(t, repo.IsFollowing(from, to))
+		require.True(t, repo.IsFollower(to, from))
+		require.False(t, repo.IsFollowing(from, "stranger"))
+		require.False(t, repo.IsFollower(to, "stranger"))
+
+		s.arm("db.Get", 1)
+		require.False(t, repo.IsFollowing(from, to))
+	})
+
+	t.Run("HasFollowRequestGetFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, NewFollowRepo(s).AddFollowRequest(to, from))
+		s.arm("Get", 1)
+		_, err := NewFollowRepo(s).HasFollowRequest(to, from)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("UnfollowLookupFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedFollow(t, s)
+		s.arm("db.Get", 1)
+		require.ErrorIs(t, NewFollowRepo(s).Unfollow(from, to), errFault)
+	})
+}
+
+func TestReactionRepoErrorPaths(t *testing.T) {
+	const tweetId, userId, ownerId, emoji = "react-tweet", "react-user", "react-owner", "👍"
+	seedReaction := func(t *testing.T, s *faultStore) {
+		_, err := NewReactionRepo(s, nil).React(tweetId, userId, emoji, false)
+		require.NoError(t, err)
+	}
+
+	t.Run("ReactFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Set"), op("Increment"), opN("Increment", 2), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t).arm(o.method, o.nth)
+				_, err := NewReactionRepo(s, nil).React(tweetId, userId, emoji, false)
+				require.ErrorIs(t, err, errFault)
+			})
+		}
+	})
+
+	t.Run("SwitchReactionFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Set"), op("Decrement"), op("Increment"), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				seedReaction(t, s)
+				s.arm(o.method, o.nth)
+				_, err := NewReactionRepo(s, nil).React(tweetId, userId, "🎉", false)
+				require.ErrorIs(t, err, errFault)
+			})
+		}
+	})
+
+	t.Run("SwitchToSameEmojiIsNoop", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedReaction(t, s)
+		count, err := NewReactionRepo(s, nil).React(tweetId, userId, emoji, false)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+	})
+
+	t.Run("UnreactFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Delete"), op("Decrement"), opN("Decrement", 2), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				seedReaction(t, s)
+				s.arm(o.method, o.nth)
+				_, err := NewReactionRepo(s, nil).Unreact(tweetId, userId, false)
+				require.ErrorIs(t, err, errFault)
+			})
+		}
+	})
+
+	t.Run("UnreactWithoutReaction", func(t *testing.T) {
+		s := newFaultStore(t)
+		// nothing reacted at all: the tweet has no counter to report
+		_, err := NewReactionRepo(s, nil).Unreact(tweetId, "never-reacted", false)
+		require.ErrorIs(t, err, ErrReactionsNotFound)
+
+		// someone else reacted: unreacting a non-reactor leaves their count alone
+		seedReaction(t, s)
+		count, err := NewReactionRepo(s, nil).Unreact(tweetId, "never-reacted", false)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+	})
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Reactions",
+			seed: seedReaction,
+			run: func(s *faultStore) error {
+				_, err := NewReactionRepo(s, nil).Reactions(tweetId)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "Reactors",
+			seed: seedReaction,
+			run: func(s *faultStore) error {
+				_, _, err := NewReactionRepo(s, nil).Reactors(tweetId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "SetReacted",
+			run:  func(s *faultStore) error { return NewReactionRepo(s, nil).SetReacted(userId, tweetId, ownerId) },
+			ops:  []faultOp{op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "Reacted",
+			run: func(s *faultStore) error {
+				_, _, err := NewReactionRepo(s, nil).Reacted(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("RemoveReactedFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				require.NoError(t, NewReactionRepo(s, nil).SetReacted(userId, tweetId, ownerId))
+				s.arm(o.method, o.nth)
+				require.ErrorIs(t, NewReactionRepo(s, nil).RemoveReacted(userId, tweetId), errFault)
+			})
+		}
+	})
+
+	t.Run("ReactionAndCountStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedReaction(t, s)
+		repo := NewReactionRepo(s, nil)
+
+		got, err := repo.Reaction(tweetId, userId)
+		require.NoError(t, err)
+		require.Equal(t, emoji, got)
+
+		s.arm("db.Get", 1)
+		_, err = repo.Reaction(tweetId, userId)
+		require.ErrorIs(t, err, errFault)
+
+		s.arm("db.Get", 1)
+		_, err = repo.ReactionsCount(tweetId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewReactionRepo(newFaultStore(t), nil)
+
+		_, err := repo.React("", userId, emoji, false)
+		require.Error(t, err)
+		_, err = repo.React(tweetId, "", emoji, false)
+		require.Error(t, err)
+
+		_, err = repo.Unreact("", userId, false)
+		require.Error(t, err)
+		_, err = repo.Unreact(tweetId, "", false)
+		require.Error(t, err)
+
+		_, err = repo.Reactions("")
+		require.Error(t, err)
+		_, err = repo.Reaction("", userId)
+		require.Error(t, err)
+		_, err = repo.Reaction(tweetId, "")
+		require.Error(t, err)
+		_, err = repo.ReactionsCount("")
+		require.Error(t, err)
+		_, _, err = repo.Reactors("", nil, nil)
+		require.Error(t, err)
+
+		require.Error(t, repo.SetReacted("", tweetId, ownerId))
+		require.Error(t, repo.SetReacted(userId, "", ownerId))
+		require.Error(t, repo.SetReacted(userId, tweetId, ""))
+		require.Error(t, repo.RemoveReacted("", tweetId))
+		require.Error(t, repo.RemoveReacted(userId, ""))
+		_, _, err = repo.Reacted("", nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("CorruptReactedPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, NewReactionRepo(s, nil).SetReacted(userId, tweetId, ownerId))
+
+		sortable, err := s.db.Get(local_store.NewPrefixBuilder(ReactionRepoName).
+			AddSubPrefix(ReactedSubNamespace).
+			AddRootID(userId).
+			AddRange(local_store.FixedRangeKey).
+			AddParentId(tweetId).
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortable), []byte("{not-json")))
+
+		_, _, err = NewReactionRepo(s, nil).Reacted(userId, nil, nil)
+		require.Error(t, err)
+	})
+}

--- a/database/errorpaths3_test.go
+++ b/database/errorpaths3_test.go
@@ -1,0 +1,386 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"testing"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatRepoErrorPaths(t *testing.T) {
+	// composeChatId slices the id at byte 14, so the participants must be ULIDs.
+	ownerId, otherId := ulid.Make().String(), ulid.Make().String()
+	chatId := NewChatRepo(nil).composeChatId(ownerId, otherId)
+
+	seedChat := func(t *testing.T, s *faultStore) {
+		_, err := NewChatRepo(s).CreateChat(nil, ownerId, otherId)
+		require.NoError(t, err)
+	}
+	message := func() domain.ChatMessage {
+		return domain.ChatMessage{
+			ChatId:     chatId,
+			Id:         "msg-1",
+			SenderId:   ownerId,
+			ReceiverId: otherId,
+			Text:       "hi",
+		}
+	}
+	seedMessage := func(t *testing.T, s *faultStore) {
+		seedChat(t, s)
+		_, err := NewChatRepo(s).CreateMessage(message())
+		require.NoError(t, err)
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "CreateChat",
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).CreateChat(nil, ownerId, otherId)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "CreateChatExisting",
+			seed: seedChat,
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).CreateChat(&chatId, ownerId, otherId)
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Commit")},
+		},
+		{
+			name: "DeleteChat",
+			seed: seedChat,
+			run:  func(s *faultStore) error { return NewChatRepo(s).DeleteChat(chatId) },
+			ops:  []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+		{
+			name: "GetChat",
+			seed: seedChat,
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).GetChat(chatId)
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Commit")},
+		},
+		{
+			name: "GetUserChats",
+			seed: seedChat,
+			run: func(s *faultStore) error {
+				_, _, err := NewChatRepo(s).GetUserChats(ownerId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "CreateMessage",
+			seed: seedChat,
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).CreateMessage(message())
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Set"), opN("Set", 2), opN("Get", 2), opN("Get", 3), op("Commit")},
+		},
+		{
+			name: "CreateMessageExisting",
+			seed: seedMessage,
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).CreateMessage(message())
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Commit")},
+		},
+		{
+			name: "ListMessages",
+			seed: seedMessage,
+			run: func(s *faultStore) error {
+				_, _, err := NewChatRepo(s).ListMessages(chatId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "GetMessage",
+			seed: seedMessage,
+			run: func(s *faultStore) error {
+				_, err := NewChatRepo(s).GetMessage(chatId, "msg-1")
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Commit")},
+		},
+		{
+			name: "DeleteMessage",
+			seed: seedMessage,
+			run:  func(s *faultStore) error { return NewChatRepo(s).DeleteMessage(chatId, "msg-1") },
+			ops:  []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewChatRepo(newFaultStore(t))
+
+		_, err := repo.CreateChat(nil, "", otherId)
+		require.Error(t, err)
+		_, err = repo.CreateChat(nil, ownerId, "")
+		require.Error(t, err)
+		require.Error(t, repo.DeleteChat(""))
+		_, err = repo.GetChat("")
+		require.Error(t, err)
+		_, _, err = repo.GetUserChats("", nil, nil)
+		require.Error(t, err)
+
+		_, err = repo.CreateMessage(domain.ChatMessage{})
+		require.Error(t, err)
+		_, err = repo.CreateMessage(domain.ChatMessage{Text: "no chat id"})
+		require.Error(t, err)
+
+		_, _, err = repo.ListMessages("", nil, nil)
+		require.Error(t, err)
+		_, err = repo.GetMessage("", "msg-1")
+		require.Error(t, err)
+		_, err = repo.GetMessage(chatId, "")
+		require.Error(t, err)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		repo := NewChatRepo(newFaultStore(t))
+		_, err := repo.GetChat("absent-chat")
+		require.ErrorIs(t, err, ErrChatNotFound)
+		require.ErrorIs(t, repo.DeleteChat("absent-chat"), ErrChatNotFound)
+
+		_, err = repo.GetMessage(chatId, "absent-msg")
+		require.ErrorIs(t, err, ErrMessageNotFound)
+		require.ErrorIs(t, repo.DeleteMessage(chatId, "absent-msg"), ErrMessageNotFound)
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedMessage(t, s)
+
+		sortableChat, err := s.db.Get(local_store.NewPrefixBuilder(ChatNamespace).
+			AddRootID(chatId).
+			AddRange(local_store.FixedRangeKey).
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortableChat), []byte("{not-json")))
+
+		repo := NewChatRepo(s)
+		_, err = repo.GetChat(chatId)
+		require.Error(t, err)
+		_, _, err = repo.GetUserChats(ownerId, nil, nil)
+		require.Error(t, err)
+		// a corrupt chat record also fails the preview bump on the next message
+		_, err = repo.CreateMessage(domain.ChatMessage{ChatId: chatId, Id: "msg-2", Text: "second"})
+		require.Error(t, err)
+
+		sortableMsg, err := s.db.Get(local_store.NewPrefixBuilder(MessageNamespace).
+			AddRootID(chatId).
+			AddRange(local_store.FixedRangeKey).
+			AddParentId("msg-1").
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortableMsg), []byte("{not-json")))
+
+		_, err = repo.GetMessage(chatId, "msg-1")
+		require.Error(t, err)
+		_, _, err = repo.ListMessages(chatId, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("MessageWithoutChatSkipsPreview", func(t *testing.T) {
+		repo := NewChatRepo(newFaultStore(t))
+		msg, err := repo.CreateMessage(domain.ChatMessage{ChatId: "orphan-chat", Id: "orphan-msg", Text: "hi"})
+		require.NoError(t, err)
+		require.Equal(t, "orphan-msg", msg.Id)
+	})
+
+	t.Run("AttachmentPreview", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedChat(t, s)
+		repo := NewChatRepo(s)
+
+		_, err := repo.CreateMessage(domain.ChatMessage{
+			ChatId:    chatId,
+			Id:        "msg-image",
+			ImageKeys: []string{"img-key"},
+		})
+		require.NoError(t, err)
+
+		chat, err := repo.GetChat(chatId)
+		require.NoError(t, err)
+		require.Equal(t, "Attachment", chat.LastMessage)
+	})
+
+	t.Run("LongPreviewIsTruncated", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedChat(t, s)
+		repo := NewChatRepo(s)
+
+		long := make([]rune, lastMessagePreviewLimit*2)
+		for i := range long {
+			long[i] = 'ы'
+		}
+		_, err := repo.CreateMessage(domain.ChatMessage{ChatId: chatId, Id: "msg-long", Text: string(long)})
+		require.NoError(t, err)
+
+		chat, err := repo.GetChat(chatId)
+		require.NoError(t, err)
+		require.Len(t, []rune(chat.LastMessage), lastMessagePreviewLimit)
+	})
+
+	t.Run("CreateMessageIsIdempotent", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedChat(t, s)
+		repo := NewChatRepo(s)
+
+		first, err := repo.CreateMessage(message())
+		require.NoError(t, err)
+		second, err := repo.CreateMessage(message())
+		require.NoError(t, err)
+		require.Equal(t, first.Id, second.Id)
+
+		msgs, _, err := repo.ListMessages(chatId, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+	})
+
+	t.Run("CreateChatIsIdempotent", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewChatRepo(s)
+
+		first, err := repo.CreateChat(nil, ownerId, otherId)
+		require.NoError(t, err)
+		second, err := repo.CreateChat(nil, ownerId, otherId)
+		require.NoError(t, err)
+		require.Equal(t, first.Id, second.Id)
+		require.Equal(t, first.CreatedAt.UnixNano(), second.CreatedAt.UnixNano())
+	})
+}
+
+func TestAuthRepoErrorPaths(t *testing.T) {
+	t.Run("NilRepo", func(t *testing.T) {
+		var repo *AuthRepo
+		require.ErrorIs(t, repo.Authenticate("user", "pass"), ErrNilAuthRepo)
+		require.Nil(t, repo.PrivateKey())
+		require.Panics(t, func() { repo.GetOwner() })
+	})
+
+	t.Run("NilStore", func(t *testing.T) {
+		repo := NewAuthRepo(nil, "testnet")
+		require.ErrorIs(t, repo.Authenticate("user", "pass"), local_store.ErrNotRunning)
+	})
+
+	t.Run("EmptyCredentials", func(t *testing.T) {
+		repo := NewAuthRepo(newFaultStore(t), "testnet")
+		require.Error(t, repo.Authenticate("", ""))
+	})
+
+	t.Run("PrivateKeyBeforeAuthPanics", func(t *testing.T) {
+		repo := NewAuthRepo(newFaultStore(t), "testnet")
+		require.Panics(t, func() { repo.PrivateKey() })
+	})
+
+	t.Run("SessionTokenIsStableAcrossReauth", func(t *testing.T) {
+		repo := NewAuthRepo(newFaultStore(t), "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		token := repo.SessionToken()
+		require.NotEmpty(t, token)
+		require.NotNil(t, repo.PrivateKey())
+
+		require.NoError(t, repo.Authenticate("test", "test"))
+		require.Equal(t, token, repo.SessionToken())
+	})
+
+	t.Run("OwnerRoundTrip", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewAuthRepo(s, "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		require.Equal(t, domain.Owner{}, repo.GetOwner())
+
+		owner, err := repo.SetOwner(domain.Owner{UserId: "owner-1", Username: "owner"})
+		require.NoError(t, err)
+		require.False(t, owner.CreatedAt.IsZero())
+		require.Equal(t, "owner-1", repo.GetOwner().UserId)
+
+		// a cold repo reads the owner back from storage and backfills the
+		// redundant id
+		cold := NewAuthRepo(s, "testnet")
+		got := cold.GetOwner()
+		require.Equal(t, "owner-1", got.UserId)
+		require.Equal(t, "owner-1", got.RedundantUserID)
+	})
+
+	t.Run("SetOwnerStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewAuthRepo(s, "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		s.arm("db.Set", 1)
+		_, err := repo.SetOwner(domain.Owner{UserId: "owner-1"})
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("GetOwnerStoreFailsPanics", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewAuthRepo(s, "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		s.arm("db.Get", 1)
+		require.Panics(t, func() { repo.GetOwner() })
+	})
+
+	t.Run("GetOwnerCorruptPayloadPanics", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewAuthRepo(s, "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		ownerKey := local_store.NewPrefixBuilder(AuthRepoName).
+			AddRootID(DefaultOwnerKey).
+			Build()
+		require.NoError(t, s.db.Set(ownerKey, []byte("{not-json")))
+
+		require.Panics(t, func() { repo.GetOwner() })
+	})
+
+	t.Run("Logout", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewAuthRepo(s, "testnet")
+		require.NoError(t, repo.Authenticate("test", "test"))
+
+		repo.Logout()
+		require.True(t, s.IsClosed())
+	})
+}

--- a/database/errorpaths4_test.go
+++ b/database/errorpaths4_test.go
@@ -1,0 +1,518 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"math"
+	"testing"
+
+	local "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// brokenStats fails every call, exercising the "CRDT store unavailable, fall
+// back to the local counter" branches.
+type brokenStats struct{}
+
+func (brokenStats) GetAggregatedStat(ds.Key) (uint64, error) { return 0, errFault }
+func (brokenStats) Increment(ds.Key) error                   { return errFault }
+func (brokenStats) Decrement(ds.Key) error                   { return errFault }
+
+func TestTweetRepoErrorPaths(t *testing.T) {
+	userId := ulid.Make().String()
+	tweetId := ulid.Make().String()
+	tweet := func() domain.Tweet {
+		return domain.Tweet{Id: tweetId, UserId: userId, Text: "hello"}
+	}
+	seedTweet := func(t *testing.T, s *faultStore) {
+		_, err := NewTweetRepo(s, nil).Create(userId, tweet())
+		require.NoError(t, err)
+	}
+
+	parentId := ulid.Make().String()
+	replyId := ulid.Make().String()
+	reply := func() domain.Tweet {
+		p := parentId
+		return domain.Tweet{Id: replyId, UserId: userId, Text: "re", ParentId: &p}
+	}
+	seedReply := func(t *testing.T, s *faultStore) {
+		_, err := NewTweetRepo(s, nil).AddReply(reply(), false)
+		require.NoError(t, err)
+	}
+
+	retweeterId := ulid.Make().String()
+	retweet := func() domain.Tweet {
+		by := retweeterId
+		return domain.Tweet{Id: tweetId, UserId: userId, Text: "rt", RetweetedBy: &by}
+	}
+	seedRetweet := func(t *testing.T, s *faultStore) {
+		_, err := NewTweetRepo(s, nil).NewRetweet(retweet(), false)
+		require.NoError(t, err)
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "CreateWithTTL",
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).Create(userId, tweet())
+				return err
+			},
+			ops: []faultOp{op("SetWithTTL"), opN("SetWithTTL", 2), op("Increment"), op("Commit")},
+		},
+		{
+			name: "Update",
+			seed: seedTweet,
+			run: func(s *faultStore) error {
+				return NewTweetRepo(s, nil).Update(domain.Tweet{Id: tweetId, UserId: userId, Text: "edited"})
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("SetWithTTL"), opN("SetWithTTL", 2), op("Commit")},
+		},
+		{
+			name: "AppendEdit",
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).AppendEdit(domain.TweetEdit{
+					OriginalTweetId: tweetId, UserId: userId, Text: "edited",
+				})
+				return err
+			},
+			ops: []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "Pin",
+			seed: seedTweet,
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).Pin(userId, tweetId)
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("SetWithTTL"), op("Commit")},
+		},
+		{
+			name: "TweetsCount",
+			seed: seedTweet,
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).TweetsCount(userId)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "Delete",
+			seed: seedTweet,
+			run:  func(s *faultStore) error { return NewTweetRepo(s, nil).Delete(userId, tweetId) },
+			ops:  []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Decrement"), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedTweet,
+			run: func(s *faultStore) error {
+				_, _, err := NewTweetRepo(s, nil).List(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "AddReply",
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).AddReply(reply(), false)
+				return err
+			},
+			ops: []faultOp{op("SetWithTTL"), op("Increment"), op("Commit")},
+		},
+		{
+			name: "DeleteReply",
+			seed: seedReply,
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).DeleteReply(parentId, replyId, false)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Delete"), op("Decrement"), op("Commit")},
+		},
+		{
+			name: "NewRetweet",
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).NewRetweet(retweet(), false)
+				return err
+			},
+			ops: []faultOp{op("Set"), op("SetWithTTL"), op("Increment"), op("Commit")},
+		},
+		{
+			name: "UnRetweet",
+			seed: seedRetweet,
+			run: func(s *faultStore) error {
+				return NewTweetRepo(s, nil).UnRetweet(retweeterId, tweetId, false)
+			},
+			ops: []faultOp{op("Delete"), op("Get"), op("Decrement"), op("Commit")},
+		},
+		{
+			name: "Retweeters",
+			seed: seedRetweet,
+			run: func(s *faultStore) error {
+				_, _, err := NewTweetRepo(s, nil).Retweeters(tweetId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "RecordView",
+			run: func(s *faultStore) error {
+				_, err := NewTweetRepo(s, nil).RecordView(tweetId, "viewer-1")
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Set"), op("Increment"), op("Commit")},
+		},
+	})
+
+	t.Run("GetStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedTweet(t, s)
+		repo := NewTweetRepo(s, nil)
+
+		s.arm("db.Get", 1)
+		_, err := repo.Get(userId, tweetId)
+		require.ErrorIs(t, err, errFault)
+
+		s.arm("db.Get", 2)
+		_, err = repo.Get(userId, tweetId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("GetNotFound", func(t *testing.T) {
+		repo := NewTweetRepo(newFaultStore(t), nil)
+		_, err := repo.Get(userId, "absent")
+		require.ErrorIs(t, err, ErrTweetNotFound)
+	})
+
+	t.Run("GetCorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedTweet(t, s)
+
+		sortable, err := s.db.Get(local.NewPrefixBuilder(TweetsNamespace).
+			AddRootID(userId).
+			AddRange(local.FixedRangeKey).
+			AddParentId(tweetId).
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local.DatabaseKey(sortable), []byte("{not-json")))
+
+		repo := NewTweetRepo(s, nil)
+		_, err = repo.Get(userId, tweetId)
+		require.Error(t, err)
+		_, _, err = repo.List(userId, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewTweetRepo(newFaultStore(t), nil)
+
+		_, err := repo.Create(userId, domain.Tweet{})
+		require.Error(t, err)
+		require.Error(t, repo.Update(domain.Tweet{UserId: userId}))
+		require.Error(t, repo.Update(domain.Tweet{Id: tweetId}))
+
+		_, err = repo.AppendEdit(domain.TweetEdit{UserId: userId, Text: "t"})
+		require.Error(t, err)
+		_, err = repo.AppendEdit(domain.TweetEdit{OriginalTweetId: tweetId, Text: "t"})
+		require.Error(t, err)
+		_, err = repo.AppendEdit(domain.TweetEdit{OriginalTweetId: tweetId, UserId: userId})
+		require.Error(t, err)
+
+		_, err = repo.Pin("", tweetId)
+		require.Error(t, err)
+		_, err = repo.Pin(userId, "")
+		require.Error(t, err)
+
+		_, err = repo.Get("", tweetId)
+		require.Error(t, err)
+		_, err = repo.Get(userId, "")
+		require.Error(t, err)
+
+		_, err = repo.TweetsCount("")
+		require.Error(t, err)
+		_, _, err = repo.List("", nil, nil)
+		require.Error(t, err)
+
+		_, err = repo.AddReply(domain.Tweet{}, false)
+		require.Error(t, err)
+		_, err = repo.AddReply(domain.Tweet{Text: "no parent"}, false)
+		require.Error(t, err)
+
+		_, err = repo.GetReply("", replyId)
+		require.Error(t, err)
+		_, err = repo.GetReply(parentId, "")
+		require.Error(t, err)
+		_, err = repo.RepliesCount("")
+		require.Error(t, err)
+		_, err = repo.DeleteReply("", replyId, false)
+		require.Error(t, err)
+		_, err = repo.DeleteReply(parentId, "", false)
+		require.Error(t, err)
+		_, _, err = repo.GetReplies("", nil, nil)
+		require.Error(t, err)
+
+		_, err = repo.NewRetweet(domain.Tweet{Id: tweetId}, false)
+		require.Error(t, err)
+		require.Error(t, repo.UnRetweet("", tweetId, false))
+		require.Error(t, repo.UnRetweet(retweeterId, "", false))
+		_, err = repo.RetweetsCount("")
+		require.Error(t, err)
+		_, _, err = repo.Retweeters("", nil, nil)
+		require.Error(t, err)
+
+		_, err = repo.RecordView("", "viewer")
+		require.Error(t, err)
+		_, err = repo.RecordView(tweetId, "")
+		require.Error(t, err)
+		_, err = repo.GetViewsCount("")
+		require.Error(t, err)
+	})
+
+	t.Run("Blocklist", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+
+		require.NoError(t, repo.Blocklist(""))
+		require.False(t, repo.IsBlocklisted(""))
+		require.False(t, repo.IsBlocklisted(tweetId))
+
+		require.NoError(t, repo.Blocklist(tweetId))
+		require.True(t, repo.IsBlocklisted(tweetId))
+
+		s.arm("db.Set", 1)
+		require.ErrorIs(t, repo.Blocklist("other"), errFault)
+	})
+
+	t.Run("PinIsIdempotent", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedTweet(t, s)
+		repo := NewTweetRepo(s, nil)
+
+		pinned, err := repo.Pin(userId, tweetId)
+		require.NoError(t, err)
+		require.True(t, pinned.Pinned)
+
+		again, err := repo.Pin(userId, tweetId)
+		require.NoError(t, err)
+		require.True(t, again.Pinned)
+
+		unpinned, err := repo.Unpin(userId, tweetId)
+		require.NoError(t, err)
+		require.False(t, unpinned.Pinned)
+	})
+
+	t.Run("PinAlreadyPinnedCommitFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedTweet(t, s)
+		_, err := NewTweetRepo(s, nil).Pin(userId, tweetId)
+		require.NoError(t, err)
+
+		s.arm("Commit", 1)
+		_, err = NewTweetRepo(s, nil).Pin(userId, tweetId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("UpdateAbsentTweet", func(t *testing.T) {
+		repo := NewTweetRepo(newFaultStore(t), nil)
+		require.ErrorIs(t, repo.Update(domain.Tweet{Id: "absent", UserId: userId, Text: "x"}), ErrTweetNotFound)
+	})
+
+	t.Run("UpdateExpiredTweetClampsTTL", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+
+		// A tweet stored with the maximum TTL has an expiration far in the
+		// future; one with no TTL record clamps to zero on update.
+		_, err := repo.CreateWithTTL(userId, tweet(), math.MaxInt64)
+		require.NoError(t, err)
+		require.NoError(t, repo.Update(domain.Tweet{Id: tweetId, UserId: userId, Text: "edited"}))
+
+		got, err := repo.Get(userId, tweetId)
+		require.NoError(t, err)
+		require.Equal(t, "edited", got.Text)
+		require.NotNil(t, got.UpdatedAt)
+	})
+
+	t.Run("UpdateModeration", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedTweet(t, s)
+		repo := NewTweetRepo(s, nil)
+
+		verdict := domain.TweetModeration{IsOk: domain.OK}
+		require.NoError(t, repo.Update(domain.Tweet{Id: tweetId, UserId: userId, Moderation: &verdict}))
+
+		got, err := repo.Get(userId, tweetId)
+		require.NoError(t, err)
+		require.NotNil(t, got.Moderation)
+	})
+
+	t.Run("DeleteAbsentTweet", func(t *testing.T) {
+		repo := NewTweetRepo(newFaultStore(t), nil)
+		require.Error(t, repo.Delete(userId, "absent"))
+	})
+
+	t.Run("RepliesCountFallsBackToLocal", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedReply(t, s)
+
+		count, err := NewTweetRepo(s, brokenStats{}).RepliesCount(parentId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+	})
+
+	t.Run("RetweetsCount", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedRetweet(t, s)
+
+		repo := NewTweetRepo(s, nil)
+		count, err := repo.RetweetsCount(tweetId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+
+		_, err = repo.RetweetsCount("never-retweeted")
+		require.ErrorIs(t, err, ErrTweetNotFound)
+
+		// with a broken CRDT store the local counter still answers
+		count, err = NewTweetRepo(s, brokenStats{}).RetweetsCount(tweetId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+
+		s.arm("db.Get", 1)
+		_, err = repo.RetweetsCount(tweetId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("QuoteRetweetGetsFreshId", func(t *testing.T) {
+		s := newFaultStore(t)
+		quoted := tweetId
+		by := retweeterId
+		stored, err := NewTweetRepo(s, nil).NewRetweet(domain.Tweet{
+			Id: tweetId, UserId: userId, Text: "look at this", RetweetedBy: &by, QuotedTweetId: &quoted,
+		}, false)
+		require.NoError(t, err)
+		require.NotEqual(t, tweetId, stored.Id)
+	})
+
+	t.Run("SelfRetweetGetsPrefix", func(t *testing.T) {
+		s := newFaultStore(t)
+		by := userId
+		stored, err := NewTweetRepo(s, nil).NewRetweet(domain.Tweet{
+			Id: tweetId, UserId: userId, Text: "rt", RetweetedBy: &by,
+		}, false)
+		require.NoError(t, err)
+		require.Equal(t, domain.RetweetPrefix+tweetId, stored.Id)
+	})
+
+	t.Run("UnRetweetWithoutCounter", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+		by := retweeterId
+		_, err := repo.NewRetweet(domain.Tweet{Id: tweetId, UserId: userId, Text: "rt", RetweetedBy: &by}, false)
+		require.NoError(t, err)
+
+		// drop the counter so UnRetweet takes the "nothing to decrement" path
+		require.NoError(t, s.db.Delete(local.NewPrefixBuilder(TweetsNamespace).
+			AddSubPrefix(reTweetsCountSubspace).
+			AddRootID(tweetId).
+			Build()))
+
+		require.NoError(t, repo.UnRetweet(retweeterId, tweetId, false))
+	})
+
+	t.Run("RecordViewIsOncePerViewer", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+
+		first, err := repo.RecordView(tweetId, "viewer-1")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), first)
+
+		second, err := repo.RecordView(tweetId, "viewer-1")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), second)
+
+		third, err := repo.RecordView(tweetId, "viewer-2")
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), third)
+	})
+
+	t.Run("RecordViewRepeatCommitFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+		_, err := repo.RecordView(tweetId, "viewer-1")
+		require.NoError(t, err)
+
+		s.arm("Commit", 1)
+		_, err = repo.RecordView(tweetId, "viewer-1")
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("RecordViewWithBrokenStats", func(t *testing.T) {
+		s := newFaultStore(t)
+		count, err := NewTweetRepo(s, brokenStats{}).RecordView(tweetId, "viewer-1")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+	})
+
+	t.Run("GetViewsCount", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, nil)
+
+		_, err := repo.GetViewsCount(tweetId)
+		require.ErrorIs(t, err, ErrViewsNotFound)
+
+		_, err = repo.RecordView(tweetId, "viewer-1")
+		require.NoError(t, err)
+
+		count, err := repo.GetViewsCount(tweetId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+
+		s.arm("db.Get", 1)
+		_, err = repo.GetViewsCount(tweetId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("StatsFailuresAreTolerated", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewTweetRepo(s, brokenStats{})
+
+		// each of these logs the stats error and still succeeds locally
+		_, err := repo.AddReply(reply(), true)
+		require.NoError(t, err)
+		_, err = repo.DeleteReply(parentId, replyId, true)
+		require.NoError(t, err)
+
+		by := retweeterId
+		_, err = repo.NewRetweet(domain.Tweet{Id: tweetId, UserId: userId, Text: "rt", RetweetedBy: &by}, true)
+		require.NoError(t, err)
+		require.NoError(t, repo.UnRetweet(retweeterId, tweetId, true))
+	})
+}

--- a/database/errorpaths5_test.go
+++ b/database/errorpaths5_test.go
@@ -1,0 +1,376 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"testing"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// failingNotifier stands in for the notifications repo when the "new user
+// discovered" write fails; the user write must still succeed.
+type failingNotifier struct{}
+
+func (failingNotifier) Add(domain.Notification) error { return errFault }
+
+func TestUserRepoErrorPaths(t *testing.T) {
+	userId := ulid.Make().String()
+	nodeId := "12D3KooWTestNodeIdentifier"
+	user := func() domain.User {
+		return domain.User{Id: userId, Username: "alice", NodeId: nodeId}
+	}
+	seedUser := func(t *testing.T, s *faultStore) {
+		_, err := NewUserRepo(s).Create(user())
+		require.NoError(t, err)
+	}
+
+	userKey := local_store.NewPrefixBuilder(UsersRepoName).
+		AddSubPrefix(userSubNamespace).
+		AddRootID("None").
+		AddRange(local_store.FixedRangeKey).
+		AddParentId(userId).
+		Build()
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "CreateWithTTL",
+			run: func(s *faultStore) error {
+				_, err := NewUserRepo(s).Create(user())
+				return err
+			},
+			ops: []faultOp{op("SetWithTTL"), opN("SetWithTTL", 2), opN("SetWithTTL", 3), op("Commit")},
+		},
+		{
+			name: "Update",
+			seed: seedUser,
+			run: func(s *faultStore) error {
+				_, err := NewUserRepo(s).Update(userId, domain.User{Bio: "updated"})
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Set"), op("Commit")},
+		},
+		{
+			name: "Delete",
+			seed: seedUser,
+			run:  func(s *faultStore) error { return NewUserRepo(s).Delete(userId) },
+			ops: []faultOp{
+				op("Get"), opN("Get", 2), op("Delete"), opN("Delete", 2), opN("Delete", 3), op("Commit"),
+			},
+		},
+		{
+			name: "List",
+			seed: seedUser,
+			run: func(s *faultStore) error {
+				_, _, err := NewUserRepo(s).List(nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+		{
+			name: "Search",
+			seed: seedUser,
+			run: func(s *faultStore) error {
+				_, _, err := NewUserRepo(s).Search("alice", nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+		{
+			name: "WhoToFollow",
+			seed: seedUser,
+			run: func(s *faultStore) error {
+				_, _, err := NewUserRepo(s).WhoToFollow(nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+		{
+			name: "GetBatch",
+			seed: seedUser,
+			run: func(s *faultStore) error {
+				_, err := NewUserRepo(s).GetBatch(userId)
+				return err
+			},
+			ops: []faultOp{op("Get"), opN("Get", 2), op("Commit")},
+		},
+	})
+
+	t.Run("CreateStoreLookupFails", func(t *testing.T) {
+		s := newFaultStore(t).arm("db.Get", 1)
+		_, err := NewUserRepo(s).Create(user())
+		// a failed existence probe is indistinguishable from "found"
+		require.ErrorIs(t, err, ErrUserAlreadyExists)
+	})
+
+	t.Run("CreateTwice", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedUser(t, s)
+		_, err := NewUserRepo(s).Create(user())
+		require.ErrorIs(t, err, ErrUserAlreadyExists)
+	})
+
+	t.Run("CreateWithoutNodeId", func(t *testing.T) {
+		s := newFaultStore(t)
+		stored, err := NewUserRepo(s).Create(domain.User{Id: ulid.Make().String(), Username: "bob"})
+		require.NoError(t, err)
+		require.Equal(t, DefaultWarpnetUserNetwork, stored.Network)
+		require.Equal(t, int64(defaultAverageRTT), stored.RoundTripTime)
+	})
+
+	t.Run("Validation", func(t *testing.T) {
+		repo := NewUserRepo(newFaultStore(t))
+
+		_, err := repo.Create(domain.User{})
+		require.Error(t, err)
+
+		_, err = repo.Get("")
+		require.ErrorIs(t, err, ErrUserNotFound)
+		_, err = repo.Get("absent")
+		require.ErrorIs(t, err, ErrUserNotFound)
+
+		_, err = repo.GetByNodeID("")
+		require.ErrorIs(t, err, ErrUserNotFound)
+		_, err = repo.GetByNodeID("absent")
+		require.ErrorIs(t, err, ErrUserNotFound)
+
+		_, _, err = repo.Search("", nil, nil)
+		require.Error(t, err)
+		_, _, err = repo.Search("   ", nil, nil)
+		require.Error(t, err)
+
+		users, err := repo.GetBatch()
+		require.NoError(t, err)
+		require.Empty(t, users)
+	})
+
+	t.Run("GetStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedUser(t, s)
+		repo := NewUserRepo(s)
+
+		s.arm("db.Get", 1)
+		_, err := repo.Get(userId)
+		require.ErrorIs(t, err, errFault)
+
+		s.arm("db.Get", 2)
+		_, err = repo.Get(userId)
+		require.ErrorIs(t, err, errFault)
+
+		s.arm("db.Get", 1)
+		_, err = repo.GetByNodeID(nodeId)
+		require.ErrorIs(t, err, errFault)
+
+		s.arm("db.Get", 2)
+		_, err = repo.GetByNodeID(nodeId)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedUser(t, s)
+
+		sortable, err := s.db.Get(userKey)
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortable), []byte("{not-json")))
+
+		repo := NewUserRepo(s)
+		_, err = repo.Get(userId)
+		require.Error(t, err)
+		_, err = repo.GetByNodeID(nodeId)
+		require.Error(t, err)
+		_, _, err = repo.List(nil, nil)
+		require.Error(t, err)
+		_, _, err = repo.Search("alice", nil, nil)
+		require.Error(t, err)
+		_, _, err = repo.WhoToFollow(nil, nil)
+		require.Error(t, err)
+		_, err = repo.GetBatch(userId)
+		require.Error(t, err)
+		_, err = repo.Update(userId, domain.User{Bio: "x"})
+		require.Error(t, err)
+		require.Error(t, repo.Delete(userId))
+	})
+
+	t.Run("DeleteAbsentIsNoop", func(t *testing.T) {
+		require.NoError(t, NewUserRepo(newFaultStore(t)).Delete("absent"))
+	})
+
+	t.Run("UpdateAbsent", func(t *testing.T) {
+		repo := NewUserRepo(newFaultStore(t))
+		_, err := repo.Update("absent", domain.User{Bio: "x"})
+		require.Error(t, err)
+	})
+
+	t.Run("UpdateMergesFields", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedUser(t, s)
+		repo := NewUserRepo(s)
+
+		site := "https://example.org"
+		reason := "spam"
+		updated, err := repo.Update(userId, domain.User{
+			Bio:                "new bio",
+			Birthdate:          "2000-01-01",
+			AvatarKey:          "avatar-key",
+			Username:           "alice2",
+			BackgroundImageKey: "bg-key",
+			Website:            &site,
+			NodeId:             "other-node",
+			Network:            "warpnet",
+			Metadata:           map[string]string{"a": "1"},
+			Moderation:         &domain.UserModeration{Strikes: 1, Reason: &reason},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "new bio", updated.Bio)
+		require.Equal(t, "alice2", updated.Username)
+		require.Equal(t, &site, updated.Website)
+		require.Equal(t, map[string]string{"a": "1"}, updated.Metadata)
+		require.NotNil(t, updated.UpdatedAt)
+
+		// a second moderation update accumulates strikes on the existing record
+		updated, err = repo.Update(userId, domain.User{
+			Moderation: &domain.UserModeration{Strikes: 2},
+			Metadata:   map[string]string{"b": "2"},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 3, updated.Moderation.Strikes)
+		require.Equal(t, map[string]string{"a": "1", "b": "2"}, updated.Metadata)
+	})
+
+	t.Run("SearchMatchesEveryIndexedField", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewUserRepo(s)
+
+		id := ulid.Make().String()
+		_, err := repo.Create(domain.User{Id: id, Username: "Charlie", Bio: "loves GARDENING", NodeId: "12D3NodeXyz"})
+		require.NoError(t, err)
+
+		for _, q := range []string{"charlie", "gardening", "12d3nodexyz", id[:6]} {
+			hits, _, err := repo.Search(q, nil, nil)
+			require.NoError(t, err, q)
+			require.NotEmpty(t, hits, q)
+		}
+
+		hits, _, err := repo.Search("nobody-matches-this", nil, nil)
+		require.NoError(t, err)
+		require.Empty(t, hits)
+	})
+
+	t.Run("SearchStopsAtLimit", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewUserRepo(s)
+		for range 5 {
+			_, err := repo.Create(domain.User{Id: ulid.Make().String(), Username: "shared-name"})
+			require.NoError(t, err)
+		}
+
+		limit := uint64(2)
+		hits, _, err := repo.Search("shared-name", &limit, nil)
+		require.NoError(t, err)
+		require.Len(t, hits, 2)
+	})
+
+	t.Run("WhoToFollowPrefersNativeAndSkipsOffline", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewUserRepo(s)
+
+		nativeId := ulid.Make().String()
+		_, err := repo.Create(domain.User{Id: nativeId, Username: "native"})
+		require.NoError(t, err)
+		_, err = repo.Create(domain.User{Id: "not-a-ulid", Username: "foreign"})
+		require.NoError(t, err)
+		_, err = repo.Create(domain.User{Id: ulid.Make().String(), Username: "gone", IsOffline: true})
+		require.NoError(t, err)
+
+		limit := uint64(10)
+		recommended, cur, err := repo.WhoToFollow(&limit, nil)
+		require.NoError(t, err)
+		require.Equal(t, local_store.EndCursor, cur)
+
+		ids := make([]string, 0, len(recommended))
+		for _, u := range recommended {
+			ids = append(ids, u.Id)
+		}
+		require.Contains(t, ids, nativeId)
+		require.Contains(t, ids, "not-a-ulid")
+		require.Equal(t, nativeId, recommended[0].Id)
+		for _, u := range recommended {
+			require.False(t, u.IsOffline)
+		}
+	})
+
+	t.Run("GetBatchSkipsMissing", func(t *testing.T) {
+		s := newFaultStore(t)
+		seedUser(t, s)
+
+		users, err := NewUserRepo(s).GetBatch(userId, "absent")
+		require.NoError(t, err)
+		require.Len(t, users, 1)
+		require.Equal(t, userId, users[0].Id)
+	})
+
+	t.Run("NotifiesOnNewUser", func(t *testing.T) {
+		s := newFaultStore(t)
+		notifications := NewNotificationsRepo(s)
+		ownerId := ulid.Make().String()
+		repo := NewUserRepoNotifying(s, notifications, ownerId)
+
+		// the owner's own record is not announced
+		_, err := repo.Create(domain.User{Id: ownerId, Username: "owner"})
+		require.NoError(t, err)
+		count, err := notifications.UnreadCount(ownerId)
+		require.NoError(t, err)
+		require.Zero(t, count)
+
+		_, err = repo.Create(domain.User{Id: ulid.Make().String(), Username: "newcomer"})
+		require.NoError(t, err)
+		count, err = notifications.UnreadCount(ownerId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), count)
+
+		// a user with no username falls back to the id in the notification text
+		_, err = repo.Create(domain.User{Id: ulid.Make().String()})
+		require.NoError(t, err)
+		count, err = notifications.UnreadCount(ownerId)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), count)
+	})
+
+	t.Run("NotifierFailureDoesNotFailCreate", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewUserRepoNotifying(s, failingNotifier{}, ulid.Make().String())
+
+		_, err := repo.Create(domain.User{Id: ulid.Make().String(), Username: "newcomer"})
+		require.NoError(t, err)
+	})
+}

--- a/database/errorpaths_test.go
+++ b/database/errorpaths_test.go
@@ -1,0 +1,491 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/stretchr/testify/require"
+)
+
+// faultOp names a transaction method and which call of it should fail.
+type faultOp struct {
+	method string
+	nth    int
+}
+
+func op(method string) faultOp         { return faultOp{method, 1} }
+func opN(method string, n int) faultOp { return faultOp{method, n} }
+
+func (o faultOp) String() string { return fmt.Sprintf("%s#%d", o.method, o.nth) }
+
+// faultCase drives one repo method through NewTxn failure and through each
+// listed storage fault, requiring every one of them to surface to the caller.
+type faultCase struct {
+	name string
+	// seed runs before the fault is armed, so fixtures don't consume call counts.
+	seed func(t *testing.T, s *faultStore)
+	run  func(s *faultStore) error
+	ops  []faultOp
+	// skipNewTxn is set for methods that never open a transaction themselves.
+	skipNewTxn bool
+}
+
+func runFaultCases(t *testing.T, cases []faultCase) {
+	t.Helper()
+	for _, c := range cases {
+		if !c.skipNewTxn {
+			t.Run(c.name+"/NewTxn", func(t *testing.T) {
+				s := newFaultStore(t)
+				if c.seed != nil {
+					c.seed(t, s)
+				}
+				s.failNewTxn(errFault)
+				require.ErrorIs(t, c.run(s), errFault)
+			})
+		}
+		for _, o := range c.ops {
+			t.Run(c.name+"/"+o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				if c.seed != nil {
+					c.seed(t, s)
+				}
+				s.arm(o.method, o.nth)
+				require.ErrorIs(t, c.run(s), errFault)
+			})
+		}
+	}
+}
+
+func TestBlocksRepoErrorPaths(t *testing.T) {
+	const blocker, blockee = "blocker-1", "blockee-1"
+	seedBlock := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewBlocksRepo(s).Block(blocker, blockee))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Block",
+			run:  func(s *faultStore) error { return NewBlocksRepo(s).Block(blocker, blockee) },
+			ops:  []faultOp{op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "Unblock",
+			seed: seedBlock,
+			run:  func(s *faultStore) error { return NewBlocksRepo(s).Unblock(blocker, blockee) },
+			ops:  []faultOp{op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+		{
+			name: "IsBlocked",
+			seed: seedBlock,
+			run: func(s *faultStore) error {
+				_, err := NewBlocksRepo(s).IsBlocked(blocker, blockee)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedBlock,
+			run: func(s *faultStore) error {
+				_, _, err := NewBlocksRepo(s).List(blocker, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("IsBlockedCommitWhenAbsent", func(t *testing.T) {
+		s := newFaultStore(t).arm("Commit", 1)
+		_, err := NewBlocksRepo(s).IsBlocked(blocker, "never-blocked")
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("EmptyIDs", func(t *testing.T) {
+		repo := NewBlocksRepo(newFaultStore(t))
+		require.Error(t, repo.Block("", blockee))
+		require.Error(t, repo.Block(blocker, ""))
+		require.Error(t, repo.Unblock("", blockee))
+		require.Error(t, repo.Unblock(blocker, ""))
+		_, _, err := repo.List("", nil, nil)
+		require.Error(t, err)
+
+		blocked, err := repo.IsBlocked("", blockee)
+		require.NoError(t, err)
+		require.False(t, blocked)
+		blocked, err = repo.IsBlocked(blocker, "")
+		require.NoError(t, err)
+		require.False(t, blocked)
+	})
+}
+
+func TestMutesRepoErrorPaths(t *testing.T) {
+	const muter, mutee = "muter-1", "mutee-1"
+	seedMute := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewMutesRepo(s).Mute(muter, mutee))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Mute",
+			run:  func(s *faultStore) error { return NewMutesRepo(s).Mute(muter, mutee) },
+			ops:  []faultOp{op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "Unmute",
+			seed: seedMute,
+			run:  func(s *faultStore) error { return NewMutesRepo(s).Unmute(muter, mutee) },
+			ops:  []faultOp{op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+		{
+			name: "IsMuted",
+			seed: seedMute,
+			run: func(s *faultStore) error {
+				_, err := NewMutesRepo(s).IsMuted(muter, mutee)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedMute,
+			run: func(s *faultStore) error {
+				_, _, err := NewMutesRepo(s).List(muter, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("EmptyIDs", func(t *testing.T) {
+		repo := NewMutesRepo(newFaultStore(t))
+		require.Error(t, repo.Mute("", mutee))
+		require.Error(t, repo.Mute(muter, ""))
+		require.Error(t, repo.Unmute("", mutee))
+		require.Error(t, repo.Unmute(muter, ""))
+		_, _, err := repo.List("", nil, nil)
+		require.Error(t, err)
+
+		muted, err := repo.IsMuted("", mutee)
+		require.NoError(t, err)
+		require.False(t, muted)
+	})
+}
+
+func TestSettingsRepoErrorPaths(t *testing.T) {
+	const userId = "settings-user"
+	seedSettings := func(t *testing.T, s *faultStore) {
+		repo := NewSettingsRepo(s)
+		require.NoError(t, repo.SetNotificationSettings(userId, domain.NotificationSettings{Recipient: "a@b.c"}))
+		require.NoError(t, repo.SetGatewaySettings(userId, domain.GatewaySettings{NodeID: "node-1"}))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "SetNotificationSettings",
+			run: func(s *faultStore) error {
+				return NewSettingsRepo(s).SetNotificationSettings(userId, domain.NotificationSettings{})
+			},
+			ops: []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "GetNotificationSettings",
+			seed: seedSettings,
+			run: func(s *faultStore) error {
+				_, err := NewSettingsRepo(s).GetNotificationSettings(userId)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+		{
+			name: "SetGatewaySettings",
+			run: func(s *faultStore) error {
+				return NewSettingsRepo(s).SetGatewaySettings(userId, domain.GatewaySettings{})
+			},
+			ops: []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "GetGatewaySettings",
+			seed: seedSettings,
+			run: func(s *faultStore) error {
+				_, err := NewSettingsRepo(s).GetGatewaySettings(userId)
+				return err
+			},
+			ops: []faultOp{op("Get"), op("Commit")},
+		},
+	})
+
+	t.Run("EmptyUserId", func(t *testing.T) {
+		repo := NewSettingsRepo(newFaultStore(t))
+		_, err := repo.GetNotificationSettings("")
+		require.Error(t, err)
+		require.Error(t, repo.SetNotificationSettings("", domain.NotificationSettings{}))
+		_, err = repo.GetGatewaySettings("")
+		require.Error(t, err)
+		require.Error(t, repo.SetGatewaySettings("", domain.GatewaySettings{}))
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, s.db.Set(settingsKey(userId), []byte("{not-json")))
+		require.NoError(t, s.db.Set(gatewaySettingsKey(userId), []byte("{not-json")))
+
+		repo := NewSettingsRepo(s)
+		_, err := repo.GetNotificationSettings(userId)
+		require.Error(t, err)
+		_, err = repo.GetGatewaySettings(userId)
+		require.Error(t, err)
+	})
+
+	t.Run("MissingReturnsZeroValue", func(t *testing.T) {
+		repo := NewSettingsRepo(newFaultStore(t))
+		ns, err := repo.GetNotificationSettings("absent-user")
+		require.NoError(t, err)
+		require.Equal(t, domain.NotificationSettings{}, ns)
+
+		gs, err := repo.GetGatewaySettings("absent-user")
+		require.NoError(t, err)
+		require.Equal(t, domain.GatewaySettings{}, gs)
+	})
+}
+
+func TestBookmarkRepoErrorPaths(t *testing.T) {
+	const userId, tweetId, ownerId = "bm-user", "bm-tweet", "bm-owner"
+	seedBookmark := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewBookmarkRepo(s).Bookmark(userId, tweetId, ownerId))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Bookmark",
+			run:  func(s *faultStore) error { return NewBookmarkRepo(s).Bookmark(userId, tweetId, ownerId) },
+			ops:  []faultOp{op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "BookmarkAlreadyPresent",
+			seed: seedBookmark,
+			run:  func(s *faultStore) error { return NewBookmarkRepo(s).Bookmark(userId, tweetId, ownerId) },
+			ops:  []faultOp{op("Commit")},
+		},
+		{
+			name: "Unbookmark",
+			seed: seedBookmark,
+			run:  func(s *faultStore) error { return NewBookmarkRepo(s).Unbookmark(userId, tweetId) },
+			ops:  []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+		{
+			name: "List",
+			seed: seedBookmark,
+			run: func(s *faultStore) error {
+				_, _, err := NewBookmarkRepo(s).List(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("UnbookmarkAbsentIsNoop", func(t *testing.T) {
+		require.NoError(t, NewBookmarkRepo(newFaultStore(t)).Unbookmark(userId, "never-bookmarked"))
+	})
+
+	t.Run("EmptyIDs", func(t *testing.T) {
+		repo := NewBookmarkRepo(newFaultStore(t))
+		require.Error(t, repo.Bookmark("", tweetId, ownerId))
+		require.Error(t, repo.Bookmark(userId, "", ownerId))
+		require.Error(t, repo.Bookmark(userId, tweetId, ""))
+		require.Error(t, repo.Unbookmark("", tweetId))
+		require.Error(t, repo.Unbookmark(userId, ""))
+		_, _, err := repo.List("", nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, NewBookmarkRepo(s).Bookmark(userId, tweetId, ownerId))
+
+		sortable, err := s.db.Get(local_store.NewPrefixBuilder(BookmarkRepoName).
+			AddRootID(userId).
+			AddRange(local_store.FixedRangeKey).
+			AddParentId(tweetId).
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortable), []byte("{not-json")))
+
+		_, _, err = NewBookmarkRepo(s).List(userId, nil, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestTimelineRepoErrorPaths(t *testing.T) {
+	const userId, tweetId = "tl-user", "tl-tweet"
+	tweet := domain.Tweet{Id: tweetId, UserId: userId, Text: "hello"}
+	seedTimeline := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewTimelineRepo(s).AddTweetToTimeline(userId, tweet))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "AddTweetToTimeline",
+			run:  func(s *faultStore) error { return NewTimelineRepo(s).AddTweetToTimeline(userId, tweet) },
+			ops:  []faultOp{op("Set"), opN("Set", 2), op("Commit")},
+		},
+		{
+			name: "DeleteTweetFromTimeline",
+			seed: seedTimeline,
+			run:  func(s *faultStore) error { return NewTimelineRepo(s).DeleteTweetFromTimeline(userId, tweetId) },
+			ops:  []faultOp{op("Get"), op("Delete"), opN("Delete", 2), op("Commit")},
+		},
+		{
+			name: "GetTimeline",
+			seed: seedTimeline,
+			run: func(s *faultStore) error {
+				_, _, err := NewTimelineRepo(s).GetTimeline(userId, nil, nil)
+				return err
+			},
+			ops: []faultOp{op("List"), op("Commit")},
+		},
+	})
+
+	t.Run("DeleteAbsentIsNoop", func(t *testing.T) {
+		require.NoError(t, NewTimelineRepo(newFaultStore(t)).DeleteTweetFromTimeline(userId, "absent"))
+	})
+
+	t.Run("EmptyIDs", func(t *testing.T) {
+		repo := NewTimelineRepo(newFaultStore(t))
+		require.Error(t, repo.AddTweetToTimeline("", tweet))
+		require.Error(t, repo.AddTweetToTimeline(userId, domain.Tweet{}))
+		require.Error(t, repo.DeleteTweetFromTimeline("", tweetId))
+		_, _, err := repo.GetTimeline("", nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, NewTimelineRepo(s).AddTweetToTimeline(userId, tweet))
+
+		sortable, err := s.db.Get(local_store.NewPrefixBuilder(TimelineRepoName).
+			AddRootID(userId).
+			AddRange(local_store.FixedRangeKey).
+			AddParentId(tweetId).
+			Build())
+		require.NoError(t, err)
+		require.NoError(t, s.db.Set(local_store.DatabaseKey(sortable), []byte("{not-json")))
+
+		_, _, err = NewTimelineRepo(s).GetTimeline(userId, nil, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestSubscriptionsRepoErrorPaths(t *testing.T) {
+	const selfId, targetId = "sub-self", "sub-target"
+	seedSub := func(t *testing.T, s *faultStore) {
+		require.NoError(t, NewSubscriptionsRepo(s).Subscribe(selfId, targetId))
+	}
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "Subscribe",
+			run:  func(s *faultStore) error { return NewSubscriptionsRepo(s).Subscribe(selfId, targetId) },
+			ops:  []faultOp{op("Set"), op("Commit")},
+		},
+		{
+			name: "Unsubscribe",
+			seed: seedSub,
+			run:  func(s *faultStore) error { return NewSubscriptionsRepo(s).Unsubscribe(selfId, targetId) },
+			ops:  []faultOp{op("Delete"), op("Commit")},
+		},
+		{
+			name: "IsSubscribed",
+			seed: seedSub,
+			run: func(s *faultStore) error {
+				_, err := NewSubscriptionsRepo(s).IsSubscribed(selfId, targetId)
+				return err
+			},
+			ops: []faultOp{op("Get")},
+		},
+	})
+}
+
+func TestAliasesRepoErrorPaths(t *testing.T) {
+	alias := domain.Alias{NodeId: "node-1"}
+
+	t.Run("NilRepo", func(t *testing.T) {
+		repo := NewAliasesRepo(nil)
+		_, err := repo.GetAliases()
+		require.ErrorIs(t, err, ErrNilAliasesRepo)
+		require.ErrorIs(t, repo.SetAlias(alias), ErrNilAliasesRepo)
+		_, err = repo.GetNodeIDs()
+		require.ErrorIs(t, err, ErrNilAliasesRepo)
+	})
+
+	t.Run("SetAliasStoreFails", func(t *testing.T) {
+		s := newFaultStore(t).arm("db.SetWithTTL", 1)
+		require.ErrorIs(t, NewAliasesRepo(s).SetAlias(alias), errFault)
+	})
+
+	runFaultCases(t, []faultCase{
+		{
+			name: "GetAliases",
+			run: func(s *faultStore) error {
+				_, err := NewAliasesRepo(s).GetAliases()
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+		{
+			name: "GetNodeIDs",
+			run: func(s *faultStore) error {
+				_, err := NewAliasesRepo(s).GetNodeIDs()
+				return err
+			},
+			ops: []faultOp{op("List")},
+		},
+	})
+
+	t.Run("CorruptPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, s.db.Set(local_store.NewPrefixBuilder(AliasesRepoName).
+			AddRootID("None").
+			AddRange(local_store.NoneRangeKey).
+			AddParentId("broken").
+			Build(), []byte("{not-json")))
+
+		_, err := NewAliasesRepo(s).GetAliases()
+		require.Error(t, err)
+	})
+
+	t.Run("EmptySetIsNotAnError", func(t *testing.T) {
+		aliases, err := NewAliasesRepo(newFaultStore(t)).GetAliases()
+		require.NoError(t, err)
+		require.Empty(t, aliases)
+	})
+}

--- a/database/faultstore_test.go
+++ b/database/faultstore_test.go
@@ -1,0 +1,282 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+)
+
+// errFault is the error every injected failure returns. It is deliberately a
+// plain DBError so local_store.IsNotFoundError reports false for it — repos
+// swallow not-found errors, and a fault must not be mistaken for one.
+const errFault = local_store.DBError("injected fault")
+
+// faultStore wraps a real in-memory DB and fails a chosen operation on its Nth
+// call, so a repo's error branches run against otherwise-genuine storage.
+type faultStore struct {
+	db     *local_store.DB
+	newErr error
+	failOn map[string]int
+	counts map[string]int
+	mx     sync.Mutex
+}
+
+func newFaultStore(t *testing.T) *faultStore {
+	t.Helper()
+	db, err := local_store.New("", local_store.DefaultOptions().WithInMemory(true))
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	if err := db.Run("test", "test"); err != nil {
+		t.Fatalf("run db: %v", err)
+	}
+	t.Cleanup(db.Close)
+	return &faultStore{db: db, failOn: map[string]int{}, counts: map[string]int{}}
+}
+
+// failNewTxn makes NewTxn / NewReadTxn return err instead of a transaction.
+func (s *faultStore) failNewTxn(err error) *faultStore {
+	s.newErr = err
+	return s
+}
+
+// arm schedules the nth (1-based) call of the named method to fail and forgets
+// any calls made so far, so a test can seed state first and still count from 1.
+func (s *faultStore) arm(method string, nth int) *faultStore {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.counts = map[string]int{}
+	s.failOn = map[string]int{method: nth}
+	return s
+}
+
+func (s *faultStore) shouldFail(method string) error {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.counts[method]++
+	if nth, ok := s.failOn[method]; ok && nth == s.counts[method] {
+		return errFault
+	}
+	return nil
+}
+
+func (s *faultStore) NewTxn() (local_store.WarpTransactioner, error) {
+	if s.newErr != nil {
+		return nil, s.newErr
+	}
+	txn, err := s.db.NewTxn()
+	if err != nil {
+		return nil, err
+	}
+	return &faultTxn{WarpTransactioner: txn, store: s}, nil
+}
+
+func (s *faultStore) NewReadTxn() (local_store.WarpTransactioner, error) {
+	if s.newErr != nil {
+		return nil, s.newErr
+	}
+	txn, err := s.db.NewReadTxn()
+	if err != nil {
+		return nil, err
+	}
+	return &faultTxn{WarpTransactioner: txn, store: s}, nil
+}
+
+// The remaining methods satisfy the wider *Storer interfaces (user, node,
+// follower, timeline, aliases, media) and honour the same injection table.
+
+func (s *faultStore) Set(key local_store.DatabaseKey, value []byte) error {
+	if err := s.shouldFail("db.Set"); err != nil {
+		return err
+	}
+	return s.db.Set(key, value)
+}
+
+func (s *faultStore) SetWithTTL(key local_store.DatabaseKey, value []byte, ttl time.Duration) error {
+	if err := s.shouldFail("db.SetWithTTL"); err != nil {
+		return err
+	}
+	return s.db.SetWithTTL(key, value, ttl)
+}
+
+func (s *faultStore) Get(key local_store.DatabaseKey) ([]byte, error) {
+	if err := s.shouldFail("db.Get"); err != nil {
+		return nil, err
+	}
+	return s.db.Get(key)
+}
+
+func (s *faultStore) Delete(key local_store.DatabaseKey) error {
+	if err := s.shouldFail("db.Delete"); err != nil {
+		return err
+	}
+	return s.db.Delete(key)
+}
+
+func (s *faultStore) GetExpiration(key local_store.DatabaseKey) (uint64, error) {
+	if err := s.shouldFail("db.GetExpiration"); err != nil {
+		return 0, err
+	}
+	return s.db.GetExpiration(key)
+}
+
+func (s *faultStore) GetSize(key local_store.DatabaseKey) (int64, error) {
+	if err := s.shouldFail("db.GetSize"); err != nil {
+		return 0, err
+	}
+	return s.db.GetSize(key)
+}
+
+func (s *faultStore) Sync() error {
+	if err := s.shouldFail("db.Sync"); err != nil {
+		return err
+	}
+	return s.db.Sync()
+}
+
+func (s *faultStore) IsClosed() bool                      { return s.db.IsClosed() }
+func (s *faultStore) InnerDB() *local_store.WarpDB        { return s.db.InnerDB() }
+func (s *faultStore) Close()                              { s.db.Close() }
+func (s *faultStore) Run(username, password string) error { return s.db.Run(username, password) }
+
+// faultTxn delegates to a real transaction unless the store has scheduled the
+// current call to fail.
+type faultTxn struct {
+	local_store.WarpTransactioner
+	store *faultStore
+}
+
+func (t *faultTxn) Set(key local_store.DatabaseKey, value []byte) error {
+	if err := t.store.shouldFail("Set"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.Set(key, value)
+}
+
+func (t *faultTxn) SetWithTTL(key local_store.DatabaseKey, value []byte, ttl time.Duration) error {
+	if err := t.store.shouldFail("SetWithTTL"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.SetWithTTL(key, value, ttl)
+}
+
+func (t *faultTxn) Get(key local_store.DatabaseKey) ([]byte, error) {
+	if err := t.store.shouldFail("Get"); err != nil {
+		return nil, err
+	}
+	return t.WarpTransactioner.Get(key)
+}
+
+func (t *faultTxn) GetExpiration(key local_store.DatabaseKey) (uint64, error) {
+	if err := t.store.shouldFail("GetExpiration"); err != nil {
+		return 0, err
+	}
+	return t.WarpTransactioner.GetExpiration(key)
+}
+
+func (t *faultTxn) Delete(key local_store.DatabaseKey) error {
+	if err := t.store.shouldFail("Delete"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.Delete(key)
+}
+
+func (t *faultTxn) BatchSet(data []local_store.ListItem) error {
+	if err := t.store.shouldFail("BatchSet"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.BatchSet(data)
+}
+
+func (t *faultTxn) BatchGet(keys ...local_store.DatabaseKey) ([]local_store.ListItem, error) {
+	if err := t.store.shouldFail("BatchGet"); err != nil {
+		return nil, err
+	}
+	return t.WarpTransactioner.BatchGet(keys...)
+}
+
+func (t *faultTxn) Increment(key local_store.DatabaseKey) (uint64, error) {
+	if err := t.store.shouldFail("Increment"); err != nil {
+		return 0, err
+	}
+	return t.WarpTransactioner.Increment(key)
+}
+
+func (t *faultTxn) Decrement(key local_store.DatabaseKey) (uint64, error) {
+	if err := t.store.shouldFail("Decrement"); err != nil {
+		return 0, err
+	}
+	return t.WarpTransactioner.Decrement(key)
+}
+
+func (t *faultTxn) Commit() error {
+	if err := t.store.shouldFail("Commit"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.Commit()
+}
+
+func (t *faultTxn) List(prefix local_store.DatabaseKey, limit *uint64, cursor *string) ([]local_store.ListItem, string, error) {
+	if err := t.store.shouldFail("List"); err != nil {
+		return nil, "", err
+	}
+	return t.WarpTransactioner.List(prefix, limit, cursor)
+}
+
+func (t *faultTxn) ReverseList(prefix local_store.DatabaseKey, limit *uint64, cursor *string) ([]local_store.ListItem, string, error) {
+	if err := t.store.shouldFail("ReverseList"); err != nil {
+		return nil, "", err
+	}
+	return t.WarpTransactioner.ReverseList(prefix, limit, cursor)
+}
+
+func (t *faultTxn) ListKeys(prefix local_store.DatabaseKey, limit *uint64, cursor *string) ([]string, string, error) {
+	if err := t.store.shouldFail("ListKeys"); err != nil {
+		return nil, "", err
+	}
+	return t.WarpTransactioner.ListKeys(prefix, limit, cursor)
+}
+
+func (t *faultTxn) IterateKeys(prefix local_store.DatabaseKey, handler local_store.IterKeysFunc) error {
+	if err := t.store.shouldFail("IterateKeys"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.IterateKeys(prefix, handler)
+}
+
+func (t *faultTxn) ReverseIterateKeys(prefix local_store.DatabaseKey, handler local_store.IterKeysFunc) error {
+	if err := t.store.shouldFail("ReverseIterateKeys"); err != nil {
+		return err
+	}
+	return t.WarpTransactioner.ReverseIterateKeys(prefix, handler)
+}

--- a/database/local-store/db_firstrun_unix_test.go
+++ b/database/local-store/db_firstrun_unix_test.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+//nolint:all
+package local_store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRefusesAnUnstattableDirectory(t *testing.T) {
+	// a regular file where the database directory should go: the first-run
+	// probe cannot tell whether the store was initialised, so it refuses loudly
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blocked, nil, 0o600))
+
+	require.Panics(t, func() { _, _ = New(blocked, DefaultOptions()) })
+}

--- a/database/local-store/db_guards_test.go
+++ b/database/local-store/db_guards_test.go
@@ -1,0 +1,143 @@
+//nolint:all
+package local_store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func runningDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := New("", DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	require.NoError(t, db.Run("user", "pass"))
+	t.Cleanup(db.Close)
+	return db
+}
+
+func TestRunRefusesADirectoryHeldByAnotherStore(t *testing.T) {
+	dir := t.TempDir()
+
+	held, err := New(dir, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, held.Run("user", "pass"))
+	t.Cleanup(held.Close)
+
+	second, err := New(dir, DefaultOptions())
+	require.NoError(t, err)
+
+	err = second.Run("user", "pass")
+	require.Error(t, err, "badger holds a directory lock; a second store must not steal it")
+	require.NotErrorIs(t, err, ErrWrongPassword)
+}
+
+func TestNilReceiverGuards(t *testing.T) {
+	var db *DB
+
+	_, err := db.GetExpiration("key")
+	require.ErrorIs(t, err, ErrNotRunning)
+
+	_, err = db.GetSize("key")
+	require.ErrorIs(t, err, ErrNotRunning)
+
+	_, err = db.NextSequence()
+	require.ErrorIs(t, err, ErrNotRunning)
+
+	require.NotPanics(t, db.Close)
+}
+
+func TestCloseOnAnUnstartedStore(t *testing.T) {
+	db, err := New("", DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	// never Run: Close must return before touching badger
+	require.NotPanics(t, db.Close)
+}
+
+func TestIterateKeysPropagatesHandlerFailures(t *testing.T) {
+	db := runningDB(t)
+
+	prefix := NewPrefixBuilder("/ITER").AddRootID("root").Build()
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+	require.NoError(t, txn.Set(NewPrefixBuilder("/ITER").AddRootID("root").AddParentId("a").Build(), []byte("a")))
+	require.NoError(t, txn.Commit())
+
+	handlerErr := errors.New("handler gave up")
+
+	read, err := db.NewReadTxn()
+	require.NoError(t, err)
+	defer read.Rollback()
+
+	require.ErrorIs(t, read.IterateKeys(prefix, func(string) error { return handlerErr }), handlerErr)
+	require.ErrorIs(t, read.ReverseIterateKeys(prefix, func(string) error { return handlerErr }), handlerErr)
+}
+
+func TestListingAtTheEndCursor(t *testing.T) {
+	db := runningDB(t)
+	prefix := NewPrefixBuilder("/PAGED").AddRootID("root").Build()
+
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+	defer txn.Rollback()
+
+	end := EndCursor
+
+	keys, cur, err := txn.ListKeys(prefix, nil, &end)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+	require.Equal(t, EndCursor, cur)
+
+	items, cur, err := txn.List(prefix, nil, &end)
+	require.NoError(t, err)
+	require.Empty(t, items)
+	require.Equal(t, EndCursor, cur)
+}
+
+func TestListRejectsAFixedKeyPrefix(t *testing.T) {
+	db := runningDB(t)
+
+	fixed := NewPrefixBuilder("/FIXED").
+		AddRootID("root").
+		AddRange(FixedRangeKey).
+		Build()
+
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+	defer txn.Rollback()
+
+	_, _, err = txn.List(fixed, nil, nil)
+	require.Error(t, err)
+
+	_, _, err = txn.ListKeys(fixed, nil, nil)
+	require.Error(t, err)
+}
+
+func TestListSkipsFixedKeysUnderAScannedPrefix(t *testing.T) {
+	db := runningDB(t)
+	root := NewPrefixBuilder("/MIXED").AddRootID("root").Build()
+
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+	require.NoError(t, txn.Set(
+		NewPrefixBuilder("/MIXED").AddRootID("root").AddRange(FixedRangeKey).AddParentId("a").Build(),
+		[]byte("pointer"),
+	))
+	require.NoError(t, txn.Set(
+		NewPrefixBuilder("/MIXED").AddRootID("root").AddParentId("b").Build(),
+		[]byte("value"),
+	))
+	require.NoError(t, txn.Commit())
+
+	read, err := db.NewReadTxn()
+	require.NoError(t, err)
+	defer read.Rollback()
+
+	items, _, err := read.List(root, nil, nil)
+	require.NoError(t, err)
+	for _, item := range items {
+		require.NotContains(t, item.Key, FixedKey, "fixed pointer rows are skipped by a scan")
+	}
+	require.Len(t, items, 1)
+}

--- a/database/local-store/db_ondisk_test.go
+++ b/database/local-store/db_ondisk_test.go
@@ -1,0 +1,201 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package local_store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewOnDiskLifecycle drives the on-disk branch of New/Run/Close that the
+// in-memory suite never reaches: the first-run lock file, the background GC
+// loop, a real Sync, and reopening the same directory.
+func TestNewOnDiskLifecycle(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := New(dir, DefaultOptions().
+		WithIntervalGC(10*time.Millisecond).
+		WithSleepGC(time.Millisecond).
+		WithDiscardRatioGC(0.5))
+	require.NoError(t, err)
+	require.True(t, db.IsFirstRun())
+	require.NotEmpty(t, db.Path())
+
+	require.NoError(t, db.Run("user", "pass"))
+	require.False(t, db.IsClosed())
+	require.False(t, db.IsFirstRun(), "the lock file marks the store as already initialised")
+
+	key := NewPrefixBuilder("/DISK").AddRootID("k").Build()
+	require.NoError(t, db.Set(key, []byte("v")))
+	require.NoError(t, db.Sync())
+
+	got, err := db.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), got)
+
+	// let the GC ticker fire at least once
+	time.Sleep(40 * time.Millisecond)
+	db.GC()
+
+	require.NotNil(t, db.InnerDB())
+	require.NotEmpty(t, db.Stats())
+
+	db.Close()
+	require.True(t, db.IsClosed())
+
+	// a second store over the same directory sees the first-run flag
+	reopened, err := New(dir, DefaultOptions())
+	require.NoError(t, err)
+	require.False(t, reopened.IsFirstRun())
+
+	require.NoError(t, reopened.Run("user", "pass"))
+	defer reopened.Close()
+
+	got, err = reopened.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), got)
+}
+
+func TestRunRejectsWrongPassword(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := New(dir, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, db.Run("user", "pass"))
+	db.Close()
+
+	wrong, err := New(dir, DefaultOptions())
+	require.NoError(t, err)
+	require.ErrorIs(t, wrong.Run("user", "not-the-password"), ErrWrongPassword)
+}
+
+func TestNewFillsInZeroGCOptions(t *testing.T) {
+	db, err := New("", &Options{isInMemory: true})
+	require.NoError(t, err)
+	require.Equal(t, defaultIntervalGC, db.intervalGC)
+	require.Equal(t, defaultDiscardRatioGC, db.discardRatioGC)
+	require.Equal(t, defaultSleepGC, db.sleepGC)
+}
+
+func TestGCOnDeadStore(t *testing.T) {
+	db, err := New("", DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	// not running yet: GC returns rather than touching a nil badger handle
+	db.GC()
+
+	var nilDB *DB
+	require.Panics(t, func() { nilDB.GC() })
+	require.Panics(t, func() { nilDB.InnerDB() })
+	require.Empty(t, nilDB.Path())
+	require.True(t, nilDB.IsClosed())
+}
+
+func TestPageLimitClamps(t *testing.T) {
+	require.Equal(t, defaultLimit, *pageLimit(nil))
+
+	zero := uint64(0)
+	require.Equal(t, defaultLimit, *pageLimit(&zero))
+
+	over := MaxPageLimit + 1
+	require.Equal(t, MaxPageLimit, *pageLimit(&over))
+
+	exact := uint64(7)
+	require.Equal(t, exact, *pageLimit(&exact))
+}
+
+func TestTxnBatchSet(t *testing.T) {
+	db, err := New("", DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	require.NoError(t, db.Run("user", "pass"))
+	defer db.Close()
+
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+
+	items := make([]ListItem, 0, 3)
+	for _, id := range []string{"a", "b", "c"} {
+		items = append(items, ListItem{
+			Key:   NewPrefixBuilder("/BATCH").AddRootID(id).Build().String(),
+			Value: []byte(id),
+		})
+	}
+	require.NoError(t, txn.BatchSet(items))
+	require.NoError(t, txn.Commit())
+
+	read, err := db.NewReadTxn()
+	require.NoError(t, err)
+	defer read.Rollback()
+
+	got, err := read.BatchGet(
+		DatabaseKey(items[0].Key),
+		DatabaseKey(items[1].Key),
+		NewPrefixBuilder("/BATCH").AddRootID("absent").Build(),
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "missing keys are skipped, not reported")
+
+	require.NoError(t, txn.BatchSet(nil))
+}
+
+func TestTxnMissingKeyErrors(t *testing.T) {
+	db, err := New("", DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	require.NoError(t, db.Run("user", "pass"))
+	defer db.Close()
+
+	txn, err := db.NewTxn()
+	require.NoError(t, err)
+	defer txn.Rollback()
+
+	absent := NewPrefixBuilder("/MISS").AddRootID("nope").Build()
+
+	_, err = txn.Get(absent)
+	require.True(t, IsNotFoundError(err))
+
+	_, err = txn.GetExpiration(absent)
+	require.True(t, IsNotFoundError(err))
+
+	_, err = db.GetExpiration(absent)
+	require.True(t, IsNotFoundError(err))
+
+	_, err = db.GetSize(absent)
+	require.True(t, IsNotFoundError(err))
+
+	// deleting a key that was never written is not an error
+	require.NoError(t, txn.Delete(absent))
+	require.NoError(t, db.Delete(absent))
+}
+
+func TestNewPrefixBuilderRejectsBadNamespace(t *testing.T) {
+	require.Panics(t, func() { NewPrefixBuilder("") })
+	require.Panics(t, func() { NewPrefixBuilder("NO-LEADING-SLASH") })
+	require.NotPanics(t, func() { NewPrefixBuilder("/OK") })
+}

--- a/database/local-store/db_test.go
+++ b/database/local-store/db_test.go
@@ -347,7 +347,10 @@ func (s *DBTestSuite) TestRun_EmptyCredentials() {
 }
 
 func TestDBTestSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	// IgnoreCurrent snapshots at test start: badger leaks a cache monitor when
+	// Open rejects a wrong encryption key, and that earlier test's goroutine
+	// would otherwise be blamed on this suite.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	suite.Run(t, new(DBTestSuite))
 }
 

--- a/database/node-repo-errorpaths_test.go
+++ b/database/node-repo-errorpaths_test.go
@@ -1,0 +1,394 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	datastore "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeRepoNilGuards(t *testing.T) {
+	ctx := context.Background()
+	key := datastore.NewKey("/a")
+
+	for _, repo := range []*NodeRepo{nil, NewNodeRepo(nil)} {
+		require.ErrorIs(t, repo.Put(ctx, key, nil), ErrNilNodeRepo)
+		require.ErrorIs(t, repo.Sync(ctx, key), ErrNilNodeRepo)
+		require.ErrorIs(t, repo.PutWithTTL(ctx, key, nil, time.Minute), ErrNilNodeRepo)
+		require.ErrorIs(t, repo.SetTTL(ctx, key, time.Minute), ErrNilNodeRepo)
+		require.ErrorIs(t, repo.Delete(ctx, key), ErrNilNodeRepo)
+
+		_, err := repo.GetExpiration(ctx, key)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.Get(ctx, key)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.Has(ctx, key)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.GetSize(ctx, key)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.DiskUsage(ctx)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.Query(ctx, dsq.Query{})
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+		_, err = repo.Batch(ctx)
+		require.ErrorIs(t, err, ErrNilNodeRepo)
+
+		require.NoError(t, repo.Close())
+	}
+
+	var nilRepo *NodeRepo
+	require.ErrorIs(t, nilRepo.BlocklistExponential("peer"), ErrNilNodeRepo)
+	require.ErrorIs(t, nilRepo.BlocklistPermanent("peer"), ErrNilNodeRepo)
+	require.False(t, nilRepo.IsBlocklisted("peer"))
+	_, err := nilRepo.BlocklistTerm("peer")
+	require.ErrorIs(t, err, ErrNilNodeRepo)
+	require.NoError(t, nilRepo.BlocklistRemove("peer"))
+}
+
+func TestNodeRepoCancelledContext(t *testing.T) {
+	repo := NewNodeRepo(newFaultStore(t))
+	key := datastore.NewKey("/a")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, repo.Put(ctx, key, nil), context.Canceled)
+	require.ErrorIs(t, repo.Sync(ctx, key), context.Canceled)
+	require.ErrorIs(t, repo.PutWithTTL(ctx, key, nil, time.Minute), context.Canceled)
+	require.ErrorIs(t, repo.SetTTL(ctx, key, time.Minute), context.Canceled)
+	require.ErrorIs(t, repo.Delete(ctx, key), context.Canceled)
+
+	_, err := repo.GetExpiration(ctx, key)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.Get(ctx, key)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.Has(ctx, key)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.GetSize(ctx, key)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.DiskUsage(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.Query(ctx, dsq.Query{})
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = repo.Batch(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestNodeRepoClosedStore(t *testing.T) {
+	ctx := context.Background()
+	key := datastore.NewKey("/a")
+
+	s := newFaultStore(t)
+	repo := NewNodeRepo(s)
+
+	b, err := repo.Batch(ctx)
+	require.NoError(t, err)
+
+	s.Close()
+
+	require.ErrorIs(t, repo.Put(ctx, key, nil), local_store.ErrNotRunning)
+	require.ErrorIs(t, repo.Sync(ctx, key), local_store.ErrNotRunning)
+	require.ErrorIs(t, repo.PutWithTTL(ctx, key, nil, time.Minute), local_store.ErrNotRunning)
+	require.ErrorIs(t, repo.SetTTL(ctx, key, time.Minute), local_store.ErrNotRunning)
+	require.ErrorIs(t, repo.Delete(ctx, key), local_store.ErrNotRunning)
+
+	_, err = repo.GetExpiration(ctx, key)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.Get(ctx, key)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.Has(ctx, key)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.GetSize(ctx, key)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.DiskUsage(ctx)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.Query(ctx, dsq.Query{})
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+	_, err = repo.Batch(ctx)
+	require.ErrorIs(t, err, local_store.ErrNotRunning)
+
+	// a batch opened before the close refuses every write and commits as a no-op
+	require.ErrorIs(t, b.Put(ctx, key, nil), local_store.ErrNotRunning)
+	require.ErrorIs(t, b.Delete(ctx, key), local_store.ErrNotRunning)
+	require.NoError(t, b.Commit(ctx))
+
+	// closing an already-closed repo is a no-op
+	require.NoError(t, repo.Close())
+}
+
+func TestNodeRepoBatch(t *testing.T) {
+	ctx := context.Background()
+	s := newFaultStore(t)
+	repo := NewNodeRepo(s)
+
+	b, err := repo.Batch(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put(ctx, datastore.NewKey("/batch/a"), []byte("a")))
+	require.NoError(t, b.Put(ctx, datastore.NewKey("/batch/b"), []byte("b")))
+	require.NoError(t, b.Delete(ctx, datastore.NewKey("/batch/b")))
+	require.NoError(t, b.Commit(ctx))
+
+	got, err := repo.Get(ctx, datastore.NewKey("/batch/a"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("a"), got)
+
+	_, err = repo.Get(ctx, datastore.NewKey("/batch/b"))
+	require.ErrorIs(t, err, datastore.ErrNotFound)
+
+	t.Run("PutWithTTL", func(t *testing.T) {
+		raw, err := repo.Batch(ctx)
+		require.NoError(t, err)
+		ttlBatch, ok := raw.(*batch)
+		require.True(t, ok)
+
+		require.NoError(t, ttlBatch.putWithTTL(datastore.NewKey("/batch/ttl"), []byte("v"), time.Hour))
+		require.NoError(t, ttlBatch.Commit(ctx))
+
+		exp, err := repo.GetExpiration(ctx, datastore.NewKey("/batch/ttl"))
+		require.NoError(t, err)
+		require.False(t, exp.IsZero())
+	})
+
+	t.Run("CancelledContext", func(t *testing.T) {
+		raw, err := repo.Batch(ctx)
+		require.NoError(t, err)
+
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		require.ErrorIs(t, raw.Put(cancelledCtx, datastore.NewKey("/batch/x"), []byte("x")), context.Canceled)
+		require.ErrorIs(t, raw.Delete(cancelledCtx, datastore.NewKey("/batch/x")), context.Canceled)
+		require.ErrorIs(t, raw.Commit(cancelledCtx), context.Canceled)
+	})
+
+	t.Run("NilBatch", func(t *testing.T) {
+		var b *batch
+		require.ErrorIs(t, b.put(datastore.NewKey("/a"), nil), ErrNilNodeRepo)
+		require.ErrorIs(t, b.putWithTTL(datastore.NewKey("/a"), nil, time.Minute), ErrNilNodeRepo)
+		require.ErrorIs(t, b.Delete(ctx, datastore.NewKey("/a")), ErrNilNodeRepo)
+		require.ErrorIs(t, b.Commit(ctx), ErrNilNodeRepo)
+		require.NoError(t, b.Cancel())
+	})
+
+	t.Run("ClosedStore", func(t *testing.T) {
+		closed := newFaultStore(t)
+		raw, err := NewNodeRepo(closed).Batch(ctx)
+		require.NoError(t, err)
+		ttlBatch, ok := raw.(*batch)
+		require.True(t, ok)
+		closed.Close()
+
+		require.ErrorIs(t, ttlBatch.putWithTTL(datastore.NewKey("/a"), nil, time.Minute), local_store.ErrNotRunning)
+	})
+}
+
+func TestNodeRepoQueryOptions(t *testing.T) {
+	ctx := context.Background()
+	repo := NewNodeRepo(newFaultStore(t))
+
+	for _, k := range []string{"/q/a", "/q/b", "/q/c", "/q/d"} {
+		require.NoError(t, repo.Put(ctx, datastore.NewKey(k), []byte(k)))
+	}
+
+	collect := func(t *testing.T, q dsq.Query) []dsq.Entry {
+		t.Helper()
+		res, err := repo.Query(ctx, q)
+		require.NoError(t, err)
+		defer res.Close()
+		entries, err := res.Rest()
+		require.NoError(t, err)
+		return entries
+	}
+
+	t.Run("Descending", func(t *testing.T) {
+		entries := collect(t, dsq.Query{Orders: []dsq.Order{dsq.OrderByKeyDescending{}}})
+		require.NotEmpty(t, entries)
+		for i := 1; i < len(entries); i++ {
+			require.Greater(t, entries[i-1].Key, entries[i].Key)
+		}
+	})
+
+	t.Run("Ascending", func(t *testing.T) {
+		entries := collect(t, dsq.Query{Orders: []dsq.Order{dsq.OrderByKey{}}})
+		require.NotEmpty(t, entries)
+		for i := 1; i < len(entries); i++ {
+			require.Less(t, entries[i-1].Key, entries[i].Key)
+		}
+	})
+
+	t.Run("UnsupportedOrderFallsBackToNaive", func(t *testing.T) {
+		entries := collect(t, dsq.Query{Orders: []dsq.Order{dsq.OrderByValue{}}})
+		require.NotEmpty(t, entries)
+	})
+
+	t.Run("OffsetAndLimit", func(t *testing.T) {
+		all := collect(t, dsq.Query{})
+		require.GreaterOrEqual(t, len(all), 4)
+
+		page := collect(t, dsq.Query{Offset: 1, Limit: 2})
+		require.Len(t, page, 2)
+	})
+
+	t.Run("KeysOnly", func(t *testing.T) {
+		entries := collect(t, dsq.Query{KeysOnly: true})
+		require.NotEmpty(t, entries)
+		for _, e := range entries {
+			require.Empty(t, e.Value)
+		}
+	})
+
+	t.Run("ReturnExpirations", func(t *testing.T) {
+		require.NoError(t, repo.PutWithTTL(ctx, datastore.NewKey("/q/ttl"), []byte("v"), time.Hour))
+		entries := collect(t, dsq.Query{Prefix: "/q", ReturnExpirations: true})
+		require.NotEmpty(t, entries)
+	})
+
+	t.Run("Filters", func(t *testing.T) {
+		entries := collect(t, dsq.Query{
+			Filters: []dsq.Filter{dsq.FilterKeyCompare{Op: dsq.Equal, Key: "/q/a"}},
+		})
+		require.Len(t, entries, 1)
+		require.Equal(t, "/q/a", entries[0].Key)
+	})
+
+	t.Run("FiltersWithOffset", func(t *testing.T) {
+		entries := collect(t, dsq.Query{
+			Filters: []dsq.Filter{dsq.FilterKeyCompare{Op: dsq.GreaterThan, Key: "/q/a"}},
+			Offset:  1,
+		})
+		require.NotEmpty(t, entries)
+	})
+
+	t.Run("FiltersKeysOnly", func(t *testing.T) {
+		entries := collect(t, dsq.Query{
+			KeysOnly: true,
+			Filters:  []dsq.Filter{dsq.FilterKeyCompare{Op: dsq.Equal, Key: "/q/a"}},
+		})
+		require.Len(t, entries, 1)
+	})
+
+	t.Run("PrefixMisses", func(t *testing.T) {
+		entries := collect(t, dsq.Query{Prefix: "/nothing-here"})
+		require.Empty(t, entries)
+	})
+}
+
+func TestNodeRepoBlocklistErrorPaths(t *testing.T) {
+	const peer = "12D3KooWBlockedPeer"
+
+	t.Run("EmptyPeerId", func(t *testing.T) {
+		repo := NewNodeRepo(newFaultStore(t))
+		require.Error(t, repo.BlocklistExponential(""))
+		require.Error(t, repo.BlocklistPermanent(""))
+		require.False(t, repo.IsBlocklisted(""))
+		_, err := repo.BlocklistTerm("")
+		require.Error(t, err)
+		require.NoError(t, repo.BlocklistRemove(""))
+	})
+
+	t.Run("ExponentialFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Get"), op("SetWithTTL"), op("Set"), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t).arm(o.method, o.nth)
+				require.ErrorIs(t, NewNodeRepo(s).BlocklistExponential(peer), errFault)
+			})
+		}
+		t.Run("NewTxn", func(t *testing.T) {
+			s := newFaultStore(t).failNewTxn(errFault)
+			require.ErrorIs(t, NewNodeRepo(s).BlocklistExponential(peer), errFault)
+		})
+	})
+
+	t.Run("PermanentFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("SetWithTTL"), op("Set"), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t).arm(o.method, o.nth)
+				require.ErrorIs(t, NewNodeRepo(s).BlocklistPermanent(peer), errFault)
+			})
+		}
+		t.Run("NewTxn", func(t *testing.T) {
+			s := newFaultStore(t).failNewTxn(errFault)
+			require.ErrorIs(t, NewNodeRepo(s).BlocklistPermanent(peer), errFault)
+		})
+	})
+
+	t.Run("RemoveFaults", func(t *testing.T) {
+		for _, o := range []faultOp{op("Set"), op("Commit")} {
+			t.Run(o.String(), func(t *testing.T) {
+				s := newFaultStore(t)
+				require.NoError(t, NewNodeRepo(s).BlocklistPermanent(peer))
+				s.arm(o.method, o.nth)
+				require.ErrorIs(t, NewNodeRepo(s).BlocklistRemove(peer), errFault)
+			})
+		}
+		t.Run("NewTxn", func(t *testing.T) {
+			s := newFaultStore(t).failNewTxn(errFault)
+			require.ErrorIs(t, NewNodeRepo(s).BlocklistRemove(peer), errFault)
+		})
+	})
+
+	t.Run("TermStoreFails", func(t *testing.T) {
+		s := newFaultStore(t)
+		require.NoError(t, NewNodeRepo(s).BlocklistPermanent(peer))
+
+		s.arm("db.Get", 1)
+		_, err := NewNodeRepo(s).BlocklistTerm(peer)
+		require.ErrorIs(t, err, errFault)
+	})
+
+	t.Run("CorruptTermPayload", func(t *testing.T) {
+		s := newFaultStore(t)
+		repo := NewNodeRepo(s)
+		require.NoError(t, repo.BlocklistPermanent(peer))
+
+		termKey := local_store.NewPrefixBuilder(repo.prefix).
+			AddSubPrefix(BlocklistSubNamespace).
+			AddSubPrefix(BlocklistTermSubNamespace).
+			AddRootID(peer).
+			Build()
+		require.NoError(t, s.db.Set(termKey, []byte("{not-json")))
+
+		_, err := repo.BlocklistTerm(peer)
+		require.Error(t, err)
+		require.Error(t, repo.BlocklistExponential(peer))
+	})
+
+	t.Run("TermOfUnknownPeerIsZero", func(t *testing.T) {
+		term, err := NewNodeRepo(newFaultStore(t)).BlocklistTerm("never-blocked")
+		require.NoError(t, err)
+		require.Equal(t, BlockLevel(0), term.Level)
+	})
+}

--- a/security/noise_branches_test.go
+++ b/security/noise_branches_test.go
@@ -1,0 +1,200 @@
+//nolint:all
+package security
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOrCreateNoiseStaticKey(t *testing.T) {
+	t.Run("creates and then reloads the same key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "keys", "noise.key")
+
+		created, err := LoadOrCreateNoiseStaticKey(path)
+		require.NoError(t, err)
+		require.Len(t, created.Private, noiseKeySize)
+		require.NotEmpty(t, created.Public)
+
+		reloaded, err := LoadOrCreateNoiseStaticKey(path)
+		require.NoError(t, err)
+		require.Equal(t, created.Private, reloaded.Private)
+		require.Equal(t, created.Public, reloaded.Public)
+	})
+
+	t.Run("rejects a truncated key file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "noise.key")
+		require.NoError(t, os.WriteFile(path, []byte("too short"), 0o600))
+
+		_, err := LoadOrCreateNoiseStaticKey(path)
+		require.ErrorIs(t, err, ErrNoiseKeyCorrupted)
+	})
+
+	t.Run("reports an unreadable key file", func(t *testing.T) {
+		// a directory in place of the key file is readable as a path but not as a file
+		dir := t.TempDir()
+		_, err := LoadOrCreateNoiseStaticKey(dir)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrNoiseKeyCorrupted)
+	})
+
+	t.Run("reports an unwritable key location", func(t *testing.T) {
+		blocked := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(blocked, nil, 0o600))
+
+		_, err := LoadOrCreateNoiseStaticKey(filepath.Join(blocked, "noise.key"))
+		require.Error(t, err)
+	})
+}
+
+func TestNoiseFingerprintIsStable(t *testing.T) {
+	key, err := GenerateNoiseKey()
+	require.NoError(t, err)
+
+	first := NoiseFingerprint(key.Public)
+	require.Len(t, first, 64)
+	require.Equal(t, first, NoiseFingerprint(key.Public))
+
+	other, err := GenerateNoiseKey()
+	require.NoError(t, err)
+	require.NotEqual(t, first, NoiseFingerprint(other.Public))
+}
+
+// noisePair wires a responder and an initiator over in-memory channels.
+func noisePair(t *testing.T) (responder, initiator *NoiseSession) {
+	t.Helper()
+
+	serverKey, err := GenerateNoiseKey()
+	require.NoError(t, err)
+	clientKey, err := GenerateNoiseKey()
+	require.NoError(t, err)
+
+	toServer := make(chan []byte, 4)
+	toClient := make(chan []byte, 4)
+
+	// each side owns its own error variable: the two run concurrently
+	var responderErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		responder, responderErr = NoiseHandshake(serverKey,
+			func() ([]byte, error) { return <-toServer, nil },
+			func(b []byte) error { toClient <- b; return nil },
+		)
+	}()
+
+	initiator, err = NoiseHandshakeInitiator(clientKey,
+		func() ([]byte, error) { return <-toClient, nil },
+		func(b []byte) error { toServer <- b; return nil },
+	)
+	require.NoError(t, err)
+
+	<-done
+	require.NoError(t, responderErr)
+	return responder, initiator
+}
+
+func TestNoiseHandshakeRoundTrip(t *testing.T) {
+	responder, initiator := noisePair(t)
+
+	sealed, err := initiator.Encrypt([]byte("hello node"))
+	require.NoError(t, err)
+
+	plain, err := responder.Decrypt(sealed)
+	require.NoError(t, err)
+	require.Equal(t, "hello node", string(plain))
+
+	back, err := responder.Encrypt([]byte("hello client"))
+	require.NoError(t, err)
+	plain, err = initiator.Decrypt(back)
+	require.NoError(t, err)
+	require.Equal(t, "hello client", string(plain))
+
+	require.NotEmpty(t, responder.RemoteStatic())
+	require.NotEmpty(t, initiator.RemoteStatic())
+}
+
+func TestNoiseHandshakeTransportFailures(t *testing.T) {
+	key, err := GenerateNoiseKey()
+	require.NoError(t, err)
+	transportErr := errors.New("connection reset")
+
+	failRead := func() ([]byte, error) { return nil, transportErr }
+	okWrite := func([]byte) error { return nil }
+	failWrite := func([]byte) error { return transportErr }
+
+	t.Run("responder cannot read the initiation", func(t *testing.T) {
+		_, err := NoiseHandshake(key, failRead, okWrite)
+		require.ErrorIs(t, err, transportErr)
+	})
+
+	t.Run("responder rejects a malformed initiation", func(t *testing.T) {
+		_, err := NoiseHandshake(key,
+			func() ([]byte, error) { return []byte("not-noise"), nil }, okWrite)
+		require.Error(t, err)
+	})
+
+	t.Run("initiator cannot write the initiation", func(t *testing.T) {
+		_, err := NoiseHandshakeInitiator(key, failRead, failWrite)
+		require.ErrorIs(t, err, transportErr)
+	})
+
+	t.Run("initiator cannot read the response", func(t *testing.T) {
+		_, err := NoiseHandshakeInitiator(key, failRead, okWrite)
+		require.ErrorIs(t, err, transportErr)
+	})
+
+	t.Run("initiator rejects a malformed response", func(t *testing.T) {
+		_, err := NoiseHandshakeInitiator(key,
+			func() ([]byte, error) { return []byte("not-noise"), nil }, okWrite)
+		require.Error(t, err)
+	})
+
+	t.Run("responder cannot write its response", func(t *testing.T) {
+		clientKey, err := GenerateNoiseKey()
+		require.NoError(t, err)
+
+		// produce a genuine first message so the responder gets past ReadMessage
+		toServer := make(chan []byte, 1)
+		go func() {
+			_, _ = NoiseHandshakeInitiator(clientKey,
+				func() ([]byte, error) { return nil, transportErr },
+				func(b []byte) error { toServer <- b; return nil },
+			)
+		}()
+
+		_, err = NoiseHandshake(key,
+			func() ([]byte, error) { return <-toServer, nil }, failWrite)
+		require.ErrorIs(t, err, transportErr)
+	})
+
+	t.Run("responder cannot read the client static", func(t *testing.T) {
+		clientKey, err := GenerateNoiseKey()
+		require.NoError(t, err)
+
+		toServer := make(chan []byte, 2)
+		toClient := make(chan []byte, 2)
+		go func() {
+			_, _ = NoiseHandshakeInitiator(clientKey,
+				func() ([]byte, error) { return <-toClient, nil },
+				func(b []byte) error { toServer <- b; return nil },
+			)
+		}()
+
+		reads := 0
+		_, err = NoiseHandshake(key,
+			func() ([]byte, error) {
+				reads++
+				if reads == 1 {
+					return <-toServer, nil
+				}
+				return nil, transportErr
+			},
+			func(b []byte) error { toClient <- b; return nil },
+		)
+		require.ErrorIs(t, err, transportErr)
+	})
+}


### PR DESCRIPTION
Measured the way CI does: go test -race -coverprofile ./... then go tool cover -func | grep total.

The bulk of it is a fault-injecting store (database/faultstore_test.go) that wraps a real in-memory Badger and fails the Nth call of a chosen transaction method, so every repo's error branches run against otherwise-genuine storage: database 78.2% -> 95.1%.

Packages that had no tests at all are now driven as real nodes rather than constructors — libp2p on the configured port, pubsub, DHT, mDNS and the CRDT stats store come up and shut down again:
cmd/node/member/node 0 -> 85.6%, cmd/node/relay/node 0 -> 90.2%, cmd/node/moderator/node 0 -> 92.6%. The relay and moderator entry points are covered by running main() and delivering the interrupt it waits for; those tests register their own signal handler first, so the signal can never terminate the test binary.

Also 0% -> 100%: core/authorship, core/mastodon, database/datastore, cmd/node/moderator/isolation. And core/mdns 0 -> 92.7%, core/dht 32.8 -> 86.4%, core/notifications 39.5 -> 84.9%, cmd/node/member/deeplink 33.8 -> 88.3%, core/middleware 73.5 -> 96.2%.

Two production fixes, both surfaced by -race on the new node tests: member and relay Start() ran the pubsub service before the discovery service, but the gossip listener feeds DiscoveryHandlerPubSub, which reads the fields discService.Run writes. Discovery now starts first.

Feature branch only: the version and release tag are untouched.