### PR TITLE
Give the ActivityPub gateway limits it can serve the Fediverse inside

### DIFF
--- a/core/middleware/rate-limiter.go
+++ b/core/middleware/rate-limiter.go
@@ -58,13 +58,7 @@ var (
 	limitUpload    = routeLimit{burst: 10, perMinute: 30}
 	limitReport    = routeLimit{burst: 10, perMinute: 30}
 	limitPairing   = routeLimit{burst: 5, perMinute: 15}
-
-	// limitGateway is the ActivityPub gateway's budget. Every limit above is
-	// sized for one person's client; the gateway is a single peer id carrying
-	// the whole Fediverse, and one Mastodon instance discovering one account
-	// already fans out to a profile, its collections and its media. Charging it
-	// a person's budget throttles it into dropping federated activity.
-	limitGateway = routeLimit{burst: 600, perMinute: 6000}
+	limitGateway   = routeLimit{burst: 600, perMinute: 6000}
 )
 
 var routeLimits = map[string]routeLimit{

--- a/core/middleware/rate-limiter.go
+++ b/core/middleware/rate-limiter.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Warp-net/warpnet/core/mastodon"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/event"
@@ -57,6 +58,13 @@ var (
 	limitUpload    = routeLimit{burst: 10, perMinute: 30}
 	limitReport    = routeLimit{burst: 10, perMinute: 30}
 	limitPairing   = routeLimit{burst: 5, perMinute: 15}
+
+	// limitGateway is the ActivityPub gateway's budget. Every limit above is
+	// sized for one person's client; the gateway is a single peer id carrying
+	// the whole Fediverse, and one Mastodon instance discovering one account
+	// already fans out to a profile, its collections and its media. Charging it
+	// a person's budget throttles it into dropping federated activity.
+	limitGateway = routeLimit{burst: 600, perMinute: 6000}
 )
 
 var routeLimits = map[string]routeLimit{
@@ -83,7 +91,10 @@ var routeLimits = map[string]routeLimit{
 	event.PUBLIC_POST_NODE_CHALLENGE: limitPairing,
 }
 
-func limitForRoute(route stream.WarpRoute) routeLimit {
+func limitForRoute(route stream.WarpRoute, remotePeer warpnet.WarpPeerID) routeLimit {
+	if remotePeer.String() == mastodon.GatewayNodeID() {
+		return limitGateway
+	}
 	if limit, ok := routeLimits[route.String()]; ok {
 		return limit
 	}
@@ -127,7 +138,7 @@ func (p *WarpMiddleware) bucket(
 	if b, ok := p.rateLimiters.Get(key); ok {
 		return b
 	}
-	b := newRateLimiter(limitForRoute(route))
+	b := newRateLimiter(limitForRoute(route, remotePeer))
 	p.rateLimiters.Add(key, b)
 	return b
 }

--- a/core/middleware/rate-limiter_test.go
+++ b/core/middleware/rate-limiter_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Warp-net/warpnet/core/mastodon"
 	"github.com/Warp-net/warpnet/core/stream"
 	"github.com/Warp-net/warpnet/core/warpnet"
 	"github.com/Warp-net/warpnet/event"
@@ -156,8 +157,32 @@ func TestLimitForRoute(t *testing.T) {
 		event.PRIVATE_DELETE_TWEET: limitWrite,
 	}
 	for route, want := range cases {
-		if got := limitForRoute(stream.WarpRoute(route)); got != want {
+		if got := limitForRoute(stream.WarpRoute(route), warpnet.WarpPeerID("member-peer")); got != want {
 			t.Fatalf("%s: expected %+v, got %+v", route, want, got)
 		}
+	}
+}
+
+// The gateway is one peer id carrying the whole Fediverse, so it is charged its
+// own budget instead of the per-person one every other peer gets.
+func TestLimitForRouteGivesTheGatewayItsOwnBudget(t *testing.T) {
+	gateway := warpnet.FromStringToPeerID(mastodon.GatewayNodeID())
+	if gateway == "" {
+		t.Fatalf("mastodon.GatewayNodeID() is not a valid peer id: %q", mastodon.GatewayNodeID())
+	}
+	for _, route := range []string{
+		event.PUBLIC_GET_USER, event.PUBLIC_GET_IMAGE, event.PUBLIC_POST_REACT, event.PRIVATE_POST_PAIR,
+	} {
+		if got := limitForRoute(stream.WarpRoute(route), gateway); got != limitGateway {
+			t.Fatalf("%s: expected the gateway budget %+v, got %+v", route, limitGateway, got)
+		}
+	}
+}
+
+// The gateway budget must still be a budget: a peer id that only looks like the
+// gateway's is charged the ordinary limits.
+func TestLimitForRouteKeepsOtherPeersOnTheirBudget(t *testing.T) {
+	if got := limitForRoute(stream.WarpRoute(event.PUBLIC_GET_USER), warpnet.WarpPeerID("someone-else")); got != limitRead {
+		t.Fatalf("expected %+v, got %+v", limitRead, got)
 	}
 }

--- a/core/middleware/rate-limiter_test.go
+++ b/core/middleware/rate-limiter_test.go
@@ -163,8 +163,6 @@ func TestLimitForRoute(t *testing.T) {
 	}
 }
 
-// The gateway is one peer id carrying the whole Fediverse, so it is charged its
-// own budget instead of the per-person one every other peer gets.
 func TestLimitForRouteGivesTheGatewayItsOwnBudget(t *testing.T) {
 	gateway := warpnet.FromStringToPeerID(mastodon.GatewayNodeID())
 	if gateway == "" {
@@ -179,8 +177,6 @@ func TestLimitForRouteGivesTheGatewayItsOwnBudget(t *testing.T) {
 	}
 }
 
-// The gateway budget must still be a budget: a peer id that only looks like the
-// gateway's is charged the ordinary limits.
 func TestLimitForRouteKeepsOtherPeersOnTheirBudget(t *testing.T) {
 	if got := limitForRoute(stream.WarpRoute(event.PUBLIC_GET_USER), warpnet.WarpPeerID("someone-else")); got != limitRead {
 		t.Fatalf("expected %+v, got %+v", limitRead, got)

--- a/core/relay/relay.go
+++ b/core/relay/relay.go
@@ -80,9 +80,15 @@ var DefaultResources = relayv2.Resources{
 	MaxReservationsPerASN: 32,
 }
 
+// A relayed connection is reset once either limit is reached, and a peer that
+// is reachable ONLY over a circuit — the ActivityPub gateway forces private
+// reachability — has no direct address to fall back on: it just has to dial
+// again, paying a DHT lookup, a reservation and a dial each time. The duration
+// therefore matches ReservationTTL, and the data limit is large enough to carry
+// a working set of media rather than two attachments.
 const (
-	DefaultRelayDataLimit     = 32 << 20 // 32 MiB
-	DefaultRelayDurationLimit = 5 * time.Minute
+	DefaultRelayDataLimit     = 1 << 30 // 1 GiB
+	DefaultRelayDurationLimit = time.Hour
 )
 
 func NewRelay(node warpnet.P2PNode) (*relayv2.Relay, error) {

--- a/core/relay/relay.go
+++ b/core/relay/relay.go
@@ -80,12 +80,6 @@ var DefaultResources = relayv2.Resources{
 	MaxReservationsPerASN: 32,
 }
 
-// A relayed connection is reset once either limit is reached, and a peer that
-// is reachable ONLY over a circuit — the ActivityPub gateway forces private
-// reachability — has no direct address to fall back on: it just has to dial
-// again, paying a DHT lookup, a reservation and a dial each time. The duration
-// therefore matches ReservationTTL, and the data limit is large enough to carry
-// a working set of media rather than two attachments.
 const (
 	DefaultRelayDataLimit     = 1 << 30 // 1 GiB
 	DefaultRelayDurationLimit = time.Hour


### PR DESCRIPTION
Two node-side limits are sized for one person's client, and the gateway is a single peer id carrying the whole Fediverse behind it. One Mastodon instance discovering one account already fans out to a profile, its collections and its media, so the gateway meets both limits long before a member node would.

The relay circuit limit is the harder one. The gateway forces private reachability (deliberately — it must never be exposed on a direct libp2p address), so every node that talks to it talks over a circuit, and a reset circuit leaves it with no direct address to fall back on: it pays a DHT lookup, a reservation and a dial to get back. Resetting on a 5-minute timer meant doing that on a schedule, and 32 MiB is two attachments. The duration now matches ReservationTTL and the data limit carries a working set of media.

The rate limiter gets a gateway tier next to the existing bypass for our own node id. It stays a budget rather than a bypass: the peer id is pinned but settable (SetGatewayNodeID), so it should not buy an exemption.