### PR TITLE
fix(node): make node shutdown idempotent

### DIFF
--- a/cmd/node/member/node/member-node_test.go
+++ b/cmd/node/member/node/member-node_test.go
@@ -1,0 +1,74 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package node
+
+import (
+	"context"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/Warp-net/warpnet/core/warpnet"
+	"github.com/Warp-net/warpnet/database"
+	local_store "github.com/Warp-net/warpnet/database/local-store"
+	"github.com/Warp-net/warpnet/domain"
+	"github.com/stretchr/testify/require"
+)
+
+// The desktop app stops the node twice: logout (PRIVATE_POST_LOGOUT) stops it,
+// then the wails shutdown hook (App.close) stops it again when the window
+// closes. A second Stop must be a no-op instead of panicking on an
+// already closed channel.
+func TestStopIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db, err := local_store.New("", local_store.DefaultOptions().WithInMemory(true))
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	authRepo := database.NewAuthRepo(db, "test")
+	require.NoError(t, authRepo.Authenticate("test", "test"))
+
+	privKey := authRepo.PrivateKey()
+	ownNodeId, err := warpnet.IDFromPublicKey(privKey.Public().(ed25519.PublicKey))
+	require.NoError(t, err)
+
+	_, err = authRepo.SetOwner(domain.Owner{
+		NodeId:   ownNodeId.String(),
+		UserId:   ownNodeId.String(),
+		Username: "test",
+	})
+	require.NoError(t, err)
+
+	n, err := NewMemberNode(ctx, privKey, nil, ownNodeId, authRepo, db, nil)
+	require.NoError(t, err)
+
+	n.Stop()
+	n.Stop()
+}

--- a/core/dht/dht.go
+++ b/core/dht/dht.go
@@ -30,6 +30,7 @@ package dht
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/Warp-net/warpnet/core/warpnet"
@@ -84,10 +85,11 @@ type RoutingStorer interface {
 }
 
 type distributedHashTable struct {
-	ctx      context.Context
-	cfg      dhtConfig
-	dht      *dht.IpfsDHT
-	stopChan chan struct{}
+	ctx       context.Context
+	cfg       dhtConfig
+	dht       *dht.IpfsDHT
+	stopChan  chan struct{}
+	closeOnce sync.Once
 }
 
 func defaultNodeRemovedCallback(id warpnet.WarpPeerID) {
@@ -334,12 +336,14 @@ func (d *distributedHashTable) Close() {
 		return
 	}
 
-	close(d.stopChan)
+	d.closeOnce.Do(func() {
+		close(d.stopChan)
 
-	log.Infoln("dht: closing...")
-	if err := d.dht.Close(); err != nil {
-		log.Errorf("dht: close: %s", err.Error())
-	}
+		log.Infoln("dht: closing...")
+		if err := d.dht.Close(); err != nil {
+			log.Errorf("dht: close: %s", err.Error())
+		}
 
-	log.Infoln("dht: closed")
+		log.Infoln("dht: closed")
+	})
 }

--- a/core/dht/dht_test.go
+++ b/core/dht/dht_test.go
@@ -1,0 +1,63 @@
+/*
+
+ Warpnet - Decentralized Social Network
+ Copyright (C) 2025 Vadim Filin, https://github.com/Warp-net,
+ <github.com.mecdy@passmail.net>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+WarpNet is provided “as is” without warranty of any kind, either expressed or implied.
+Use at your own risk. The maintainers shall not be liable for any damages or data loss
+resulting from the use or misuse of this software.
+*/
+
+// Copyright 2025 Vadim Filin
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//nolint:all
+package dht
+
+import (
+	"context"
+	"testing"
+
+	datastore "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
+)
+
+// The desktop app stops the node twice - logout stops it, then the wails
+// shutdown hook stops it again - so a second close must be a no-op.
+func TestCloseIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	require.NoError(t, err)
+	defer func() { _ = h.Close() }()
+
+	table := NewDHTable(
+		ctx,
+		Network("testnet"),
+		RoutingStore(dssync.MutexWrap(datastore.NewMapDatastore())),
+	)
+
+	_, err = table.StartRouting(h)
+	require.NoError(t, err)
+
+	table.Close()
+	table.Close()
+	table.Close()
+}

--- a/database/node-repo.go
+++ b/database/node-repo.go
@@ -33,6 +33,7 @@ import (
 	"math"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Warp-net/warpnet/database/datastore"
@@ -65,9 +66,10 @@ type NodeStorer interface {
 }
 
 type NodeRepo struct {
-	db       NodeStorer
-	prefix   string
-	stopChan chan struct{}
+	db        NodeStorer
+	prefix    string
+	stopChan  chan struct{}
+	closeOnce sync.Once
 
 	RelaySelfHashHex string
 }
@@ -530,8 +532,10 @@ func (d *NodeRepo) Close() (err error) {
 		return nil
 	}
 
-	close(d.stopChan)
-	log.Infoln("node repo: closed")
+	d.closeOnce.Do(func() {
+		close(d.stopChan)
+		log.Infoln("node repo: closed")
+	})
 	return nil
 }
 

--- a/database/node-repo_test.go
+++ b/database/node-repo_test.go
@@ -227,6 +227,16 @@ func (s *NodeRepoDatastoreTestSuite) TearDownSuite() {
 	s.db.Close()
 }
 
+// The desktop app stops the node twice - logout stops it, then the wails
+// shutdown hook stops it again - so a second close must be a no-op.
+func (s *NodeRepoDatastoreTestSuite) TestCloseIsIdempotent() {
+	repo := NewNodeRepo(s.db)
+
+	s.Require().NoError(repo.Close())
+	s.NoError(repo.Close())
+	s.NoError(repo.Close())
+}
+
 func (s *NodeRepoDatastoreTestSuite) TestBlocklistEscalationLadderSaturates() {
 	peer := "12D3KooWEscalate"
 


### PR DESCRIPTION
The desktop app stops the node twice: PRIVATE_POST_LOGOUT calls App.Call -> node.Stop(), and the wails OnShutdown hook calls App.close -> node.Stop() again, so logging out and then closing the window ran the whole shutdown sequence a second time.

Two closers in that sequence closed their stop channel unguarded, and MemberNode.Stop has no recover of its own: distributedHashTable.Close (reached first, from m.dHashTable) and NodeRepo.Close. The second Stop panicked with "close of closed channel", and because the panic escaped into App.close's recover, the rest of the shutdown - AuthLogout and close(readyChan) - never ran.

Both are now guarded by a sync.Once instead of leaning on a recover, so the second Stop is a real no-op; the DHT's Once also keeps the inner IpfsDHT.Close from running twice. The rest of the sequence was already double-call safe (Gossip and MulticastDNS check isRunning, WarpMiddleware holds its own Once, WarpNode.StopNode nils its node, CRDTStatsStore and the relay's memory-store closer tolerate a second call), and RelayNode shares the fixed DHT.

Pinned from three levels: MemberNode.Stop called twice (the package had no test file at all, precisely because that panicked), plus the two closers on their own - the DHT after StartRouting on a real host, and the node repo on a live DB.