### PR TITLE
fix(discovery): stop enqueue panicking on a closed queue after Close

### DIFF
--- a/core/discovery/discovery.go
+++ b/core/discovery/discovery.go
@@ -205,6 +205,9 @@ func (s *discoveryService) enqueue(pi warpnet.WarpAddrInfo, source discoverySour
 		log.Errorf("discovery: handle new peer found: nil discovery service")
 		return
 	}
+	if s.isStopped() { // mdns, gossip, DHT and stream handlers outlive Close
+		return
+	}
 	log.Debugf("discovery: found peer: %s, source: %s", pi.ID.String(), source)
 
 	if pi.ID == "" || pi.ID == s.ownId {
@@ -232,6 +235,16 @@ func (s *discoveryService) enqueue(pi warpnet.WarpAddrInfo, source discoverySour
 		for range dropMessagesNum {
 			<-s.discoveryChan // drop old data
 		}
+	}
+}
+
+// isStopped reports whether Close has already run.
+func (s *discoveryService) isStopped() bool {
+	select {
+	case <-s.stopChan:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -464,7 +477,8 @@ func (s *discoveryService) Close() {
 		return
 	}
 	s.discoveryTicker.Stop()
+	// discoveryChan is left open on purpose: senders outlive Close and a send on
+	// a closed channel panics. The reader exits on stopChan alone.
 	close(s.stopChan)
-	close(s.discoveryChan)
 	log.Infoln("discovery: closed")
 }

--- a/core/discovery/discovery_test.go
+++ b/core/discovery/discovery_test.go
@@ -285,6 +285,53 @@ func TestEnqueue_RateLimiterShedsFloods(t *testing.T) {
 		"the queue must never exceed its capacity")
 }
 
+func TestEnqueue_AfterCloseNeverSendsOnAClosedQueue(t *testing.T) {
+	s, _, _, _ := newService(t)
+	s.limiter = newRateLimiter(1<<20, 1) // the rate limiter must not hide the race
+
+	pi := warpnet.WarpAddrInfo{ID: warpnet.FromStringToPeerID(peerID)}
+	s.Close()
+
+	// mdns, gossip, DHT and stream handlers all keep firing while the node tears
+	// down: a send on a closed queue panics in their goroutine and kills the node,
+	// so this test reports the regression by crashing the whole binary.
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 250 {
+				s.DiscoveryHandlerMDNS(pi)
+				s.DiscoveryHandlerPubSub(pi)
+				s.DiscoveryHandlerDHT(pi.ID)
+				s.DiscoveryHandlerStream(pi)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Empty(t, s.discoveryChan, "a closed service must not queue new discoveries")
+}
+
+func TestClose_KeepsTheQueueOpenForLateSenders(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := newFakeNode()
+	node.info.Type = warpnet.RelayNode
+
+	s := NewDiscoveryService(ctx, newFakeUserRepo(), newFakeNodeRepo())
+	require.NoError(t, s.Run(node))
+
+	s.Close()
+
+	select {
+	case _, ok := <-s.discoveryChan:
+		require.True(t, ok, "the discovery queue must stay open after Close")
+	default:
+	}
+}
+
 func TestEnqueue_NilServiceIsInert(t *testing.T) {
 	var s *discoveryService
 	assert.NotPanics(t, func() {


### PR DESCRIPTION
Close() closed both stopChan and discoveryChan. Go picks uniformly at random among ready select cases, so once both were closed the send case in enqueue could win over the stopChan case and panic with "send on closed channel", taking the whole node down.

The window is real on every teardown: MemberNode.Stop() closes the discovery service first and only then mDNS, pubsub, DHT and the node itself, so all four discovery sources — gossip, mDNS, DHT callbacks and the stream handler — keep calling enqueue against an already closed channel.

discoveryChan is now left open, which is what actually removes the panic; a closed flag alone cannot, since Close can still land between the check and the send. The reader loop already exits on stopChan and ctx.Done(), so nothing keeps it alive, and no code outside this file touches the channel. enqueue also returns early when Close has run, ahead of the rate limiter, so late discoveries are dropped deterministically instead of piling into a buffer nobody drains.

Both regression tests fail without the fix: hammering all four handlers from eight goroutines after Close reproduces the exact panic, and the second pins the invariant with a readable failure if the close is ever put back.